### PR TITLE
Village getBlock fix

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
@@ -92,6 +92,7 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
                     "fixUnprotectedGetBlock.vanilla.MixinBlockGrass",
                     "fixUnprotectedGetBlock.vanilla.MixinBlockFire",
                     "fixUnprotectedGetBlock.vanilla.MixinVillageCollection",
+                    "fixUnprotectedGetBlock.vanilla.MixinVillage",
                     "fixUnprotectedGetBlock.vanilla.MixinBlockFluidClassic"
                 )
         ),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/fixUnprotectedGetBlock/vanilla/MixinVillage.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/fixUnprotectedGetBlock/vanilla/MixinVillage.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.fixUnprotectedGetBlock.vanilla;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.village.Village;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Village.class)
+public class MixinVillage {
+
+    @Redirect(
+        method = "isBlockDoor(III)Z",
+        at = @At(
+            value = "INVOKE",
+            target="Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"
+        )
+    )
+    protected Block getBlock(World world, int x, int y, int z) {
+        if (!world.blockExists(x, y, z))
+            return Blocks.air;
+
+        return world.getBlock(x, y, z);
+    }
+}


### PR DESCRIPTION
Patching VillageCollection is not enough, a ghost chunkload can happen in Village too.
There's a [few more ghost chunkload fixes pulled into later versions of forge, if anyone wants to pull those in](https://github.com/MinecraftForge/MinecraftForge/pull/4689/commits), however this is just the one that I have had major issues with.