### PR TITLE
Mobs picking stuff no longer protected against despawn logic

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
@@ -139,6 +139,10 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
         PREVENT_PICKUP_LOOT("Prevent monsters from picking up loot",
                  () -> config.preventPickupLoot,
                  Collections.singletonList("preventPickupLoot.MixinEntityLiving")
+        ),
+        DROP_PICKED_LOOT_ON_DESPAWN("Drop picked loot on entity despawn",
+                () -> config.dropPickedLootOnDespawn,
+                Collections.singletonList("dropPickedLootOnDespawn.MixinEntityLiving")
         );
 
 
@@ -152,8 +156,8 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
             this.applyIf = applyIf;
             this.mixinClasses = mixinClasses;
             this.jarName = null;
-        }        
-        
+        }
+
         MixinSets(String name, Supplier<Boolean> applyIf, String jarName, List<String> mixinClasses) {
             this.name = name;
             this.applyIf = applyIf;

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -19,6 +19,7 @@ public class LoadingConfig {
     public boolean fixHungerOverhaul;
     public boolean removeUpdateChecks;
     public boolean preventPickupLoot;
+	public boolean dropPickedLootOnDespawn;
     
     // ASM
     public boolean pollutionAsm;
@@ -45,7 +46,8 @@ public class LoadingConfig {
         removeUpdateChecks = config.get("fixes", "removeUpdateChecks", true, "Remove old/stale/outdated update checks.").getBoolean();
 
         preventPickupLoot = config.get("tweaks", "preventPickupLoot", true, "Prevent monsters from picking up loot.").getBoolean();
-        
+        dropPickedLootOnDespawn = config.get("tweaks", "dropPickedLootOnDespawn", true, "Drop picked loot on entity despawn").getBoolean();
+
         speedupChunkCoordinatesHashCode = config.get("speedups", "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
 
         pollutionAsm = config.get("asm", "pollutionAsm", true, "Enable pollution rendering ASM").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/dropPickedLootOnDespawn/MixinEntityLiving.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/dropPickedLootOnDespawn/MixinEntityLiving.java
@@ -1,0 +1,39 @@
+package com.mitchej123.hodgepodge.mixins.dropPickedLootOnDespawn;
+
+import net.minecraft.entity.EntityLiving;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.Shadow;
+
+import static org.objectweb.asm.Opcodes.*;
+
+@Mixin(EntityLiving.class)
+public class MixinEntityLiving {
+    @Shadow
+    private boolean persistenceRequired;
+
+    @Shadow
+    protected void dropEquipment(boolean wasHitByPlayer, int lootMultiplicatorPct) {
+        throw new AbstractMethodError("Shadow");
+    }
+
+    /**
+     * @author ElNounch
+     * @reason Don't disable despawning for loot picking reasons
+     */
+    @Redirect(method="onLivingUpdate()V", at = @At(value="FIELD", target="Lnet/minecraft/entity/EntityLiving;persistenceRequired:Z", opcode=PUTFIELD))
+    public void dontSetPersistenceRequired(EntityLiving o, boolean newVal) {
+    }
+
+    /**
+     * @author ElNounch
+     * @reason Drop picked up items when despawning
+     */
+    @Inject(method = "despawnEntity()V", at = @At(value="INVOKE", target="Lnet/minecraft/entity/EntityLiving;setDead()V"))
+    public void despawnEntity_dropPickedLoot(CallbackInfo ci) {
+        this.dropEquipment(false, 0);
+    }
+}


### PR DESCRIPTION
Mobs drop the equipment they looted when being despawn.

Alternative to 'preventPickupLoot' tweak (#10).
Only picked up equipment is dropped at despawn, no additionnal drop.
