### PR TITLE
Add reactor related fixes

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
@@ -128,6 +128,14 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
                      "fixIc2Nightvision.MixinIc2QuantumSuitNightVision"
                   )
          ),
+        IC2_REACTOR_DUPE("IC2 Reactor Dupe",
+                () -> config.fixIc2ReactorDupe,
+                Collections.singletonList("fixIc2ReactorDupe.MixinTileEntityReactorChamberElectric")
+        ),
+        HIDE_IC2_REACTOR_COOLANT_SLOTS("IC2 Reactor Accessible Slots",
+                () -> config.hideIc2ReactorSlots,
+                Collections.singletonList("hideIc2ReactorCoolantSlots.MixinTileEntityNuclearReactorElectric")
+        ),
         HUNGER_OVERHAUL_FIX("Hunger Overhaul Fix",
                 () -> config.fixHungerOverhaul,
                 "HungerOverhaul",
@@ -178,13 +186,13 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
             this.name = name;
             this.applyIf = applyIf;
             this.mixinClasses = mixinClasses;
-            this.jarName = jarName; 
+            this.jarName = jarName;
         }
 
         public boolean shouldBeLoaded() {
             return applyIf.get();
         }
-        
+
         public boolean loadJar() {
             try {
                 if( jarName == null) return true;
@@ -193,7 +201,7 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
                     log.info("Jar not found: " + jarName);
                     return false;
                 }
-                
+
                 log.info("Attempting to add " + jar.toString() + " to the URL Class Path");
                 if(!jar.exists())
                     throw new FileNotFoundException(jar.toString());

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -11,6 +11,7 @@ public class LoadingConfig {
     public boolean fixNorthWestBias;
     public boolean fixFenceConnections;
     public boolean fixIc2DirectInventoryAccess;
+    public boolean fixIc2ReactorDupe;
     public boolean fixIc2Nightvision;
     public boolean fixVanillaUnprotectedGetBlock;
     public boolean fixIc2UnprotectedGetBlock;
@@ -23,6 +24,7 @@ public class LoadingConfig {
     public boolean preventPickupLoot;
     public boolean dropPickedLootOnDespawn;
     public boolean installAnchorAlarm;
+    public boolean hideIc2ReactorSlots;
     // ASM
     public boolean pollutionAsm;
     public boolean cofhWorldTransformer;
@@ -40,6 +42,7 @@ public class LoadingConfig {
         fixNorthWestBias = config.get("fixes", "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
         fixFenceConnections = config.get("fixes", "fixFenceConnections", true, "Fix fence connections with other types of fence").getBoolean();
         fixIc2DirectInventoryAccess = config.get("fixes", "fixIc2DirectInventoryAccess", true, "Fix IC2's direct inventory access").getBoolean();
+        fixIc2ReactorDupe = config.get("fixes", "fixIc2ReactorDupe", true, "Fix IC2's reactor dupe").getBoolean();
         fixIc2Nightvision = config.get("fixes", "fixIc2Nightvision", true, "Prevent IC2's nightvision from blinding you").getBoolean();
         fixVanillaUnprotectedGetBlock = config.get("fixes", "fixVanillaUnprotectedGetBlock", true, "Fixes various unchecked vanilla getBlock() methods").getBoolean();
         fixIc2UnprotectedGetBlock = config.get("fixes", "fixIc2UnprotectedGetBlock", true, "Fixes various unchecked IC2 getBlock() methods").getBoolean();
@@ -52,12 +55,13 @@ public class LoadingConfig {
         installAnchorAlarm = config.get("tweaks", "installAnchorAlarm", true, "Wake up passive & personal anchors on player login").getBoolean();
         preventPickupLoot = config.get("tweaks", "preventPickupLoot", true, "Prevent monsters from picking up loot.").getBoolean();
         dropPickedLootOnDespawn = config.get("tweaks", "dropPickedLootOnDespawn", true, "Drop picked loot on entity despawn").getBoolean();
+        hideIc2ReactorSlots = config.get("tweaks", "hideIc2ReactorSlots", true, "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor").getBoolean();
 
         speedupChunkCoordinatesHashCode = config.get("speedups", "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
 
         pollutionAsm = config.get("asm", "pollutionAsm", true, "Enable pollution rendering ASM").getBoolean();
         cofhWorldTransformer = config.get("asm", "cofhWorldTransformer", true, "Enable Glease's ASM patch to disable unused CoFH tileentity cache").getBoolean();
-        
+
         if (config.hasChanged())
             config.save();
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/fixIc2ReactorDupe/MixinTileEntityReactorChamberElectric.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/fixIc2ReactorDupe/MixinTileEntityReactorChamberElectric.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.fixIc2ReactorDupe;
+
+import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(TileEntityReactorChamberElectric.class)
+public class MixinTileEntityReactorChamberElectric {
+    @Redirect(
+            method = "getReactor",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;onNeighborBlockChange(Lnet/minecraft/world/World;IIILnet/minecraft/block/Block;)V"
+            )
+    )
+    public void fixGetReactor(Block blk, World w, int x, int y, int z, Block blk2) {
+        w.notifyBlockChange(x, y, z, blk);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hideIc2ReactorCoolantSlots/MixinTileEntityNuclearReactorElectric.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hideIc2ReactorCoolantSlots/MixinTileEntityNuclearReactorElectric.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.hideIc2ReactorCoolantSlots;
+
+import ic2.core.block.TileEntityInventory;
+import ic2.core.block.invslot.InvSlot;
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
+import net.minecraft.inventory.IInventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(TileEntityNuclearReactorElectric.class)
+public abstract class MixinTileEntityNuclearReactorElectric extends TileEntityInventory {
+    @Shadow(remap = false)
+    public abstract boolean isFluidCooled();
+
+    /**
+     * @author glee8e
+     */
+    public int getSizeInventory() {
+        if (isFluidCooled()) {
+            int sum = 0;
+            for (InvSlot invSlot : this.invSlots) {
+                sum += invSlot.size();
+            }
+            return sum;
+        } else {
+            return this.invSlots.get(0).size();
+        }
+    }
+}


### PR DESCRIPTION
Address https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8084 and https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/16

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8084 is fixed by hiding the coolant cell slot from automations when it's not a fluid reactor (i.e. limiting the inventory size).

https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/16 : IC2 is calling the wrong method to notify block updates. Correcting the call fix the problem.