### PR TITLE
Mixins for IC2 Hazmat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ repositories {
         name = "ic2"
         url = "http://maven.ic2.player.to/"
     }
+    maven {
+        name = "jitpack"
+        url("https://jitpack.io")
+    }
 }
 
 version = "1.6.8"
@@ -61,6 +65,9 @@ dependencies {
     compileOnly files("libs/Thaumcraft-1.7.10-4.2.3.5-dev.jar")
     compileOnly files("libs/CoFHCore-[1.7.10]3.1.4-329-dev.jar")
     compileOnly files("libs/railcraft-1.7.10-9.12.2.0-dev.jar")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:experimental-SNAPSHOT:dev") {
+        transitive = false
+    }
 }
 
 

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
@@ -132,6 +132,10 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
                 () -> config.fixIc2ReactorDupe,
                 Collections.singletonList("fixIc2ReactorDupe.MixinTileEntityReactorChamberElectric")
         ),
+        IC2_HAZMAT("IC2 Hazmat",
+                () -> config.fixIc2Hazmat,
+                Collections.singletonList("fixIc2Hazmat.MixinIc2Hazmat")
+        ),
         HIDE_IC2_REACTOR_COOLANT_SLOTS("IC2 Reactor Accessible Slots",
                 () -> config.hideIc2ReactorSlots,
                 Collections.singletonList("hideIc2ReactorCoolantSlots.MixinTileEntityNuclearReactorElectric")

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -13,6 +13,7 @@ public class LoadingConfig {
     public boolean fixIc2DirectInventoryAccess;
     public boolean fixIc2ReactorDupe;
     public boolean fixIc2Nightvision;
+    public boolean fixIc2Hazmat;
     public boolean fixVanillaUnprotectedGetBlock;
     public boolean fixIc2UnprotectedGetBlock;
     public boolean fixThaumcraftUnprotectedGetBlock;
@@ -46,6 +47,7 @@ public class LoadingConfig {
         fixIc2DirectInventoryAccess = config.get("fixes", "fixIc2DirectInventoryAccess", true, "Fix IC2's direct inventory access").getBoolean();
         fixIc2ReactorDupe = config.get("fixes", "fixIc2ReactorDupe", true, "Fix IC2's reactor dupe").getBoolean();
         fixIc2Nightvision = config.get("fixes", "fixIc2Nightvision", true, "Prevent IC2's nightvision from blinding you").getBoolean();
+        fixIc2Hazmat = config.get("fixes", "fixIc2Hazmat", true,"Fix IC2 armors to avoid giving poison").getBoolean();
         fixVanillaUnprotectedGetBlock = config.get("fixes", "fixVanillaUnprotectedGetBlock", true, "Fixes various unchecked vanilla getBlock() methods").getBoolean();
         fixIc2UnprotectedGetBlock = config.get("fixes", "fixIc2UnprotectedGetBlock", true, "Fixes various unchecked IC2 getBlock() methods").getBoolean();
         fixThaumcraftUnprotectedGetBlock = config.get("fixes", "fixThaumcraftUnprotectedGetBlock", true, "Various Thaumcraft unchecked getBlock() patches").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/fixIc2Hazmat/MixinIc2Hazmat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/fixIc2Hazmat/MixinIc2Hazmat.java
@@ -7,8 +7,10 @@ import org.spongepowered.asm.mixin.Overwrite;
 import gregtech.api.util.GT_Utility;
 
 @Mixin(value = ItemArmorHazmat.class, remap = false)
+
 public class MixinIc2Hazmat {
     @Overwrite()
+    //IC2 logic superseeded by GT check
     public static boolean hasCompleteHazmat(EntityLivingBase entity) {
         if(GT_Utility.isWearingFullRadioHazmat(entity)) {
             return true;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/fixIc2Hazmat/MixinIc2Hazmat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/fixIc2Hazmat/MixinIc2Hazmat.java
@@ -1,0 +1,18 @@
+package com.mitchej123.hodgepodge.mixins.fixIc2Hazmat;
+
+import ic2.core.item.armor.ItemArmorHazmat;
+import net.minecraft.entity.EntityLivingBase;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import gregtech.api.util.GT_Utility;
+
+@Mixin(value = ItemArmorHazmat.class, remap = false)
+public class MixinIc2Hazmat {
+    @Overwrite()
+    public static boolean hasCompleteHazmat(EntityLivingBase entity) {
+        if(GT_Utility.isWearingFullRadioHazmat(entity)) {
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Changes IC2 hazmat check to work with gt5u radiation hazmat check
Fixes the IC2 items (like plutonium, ic2 rods) giving poison when using gt5u hazmat protection