### PR TITLE
Allow IC2 seeds to stack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNH2:ForgeGradle:FG_1.2-SNAPSHOT'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.4'
     }
 }
 
@@ -43,7 +43,7 @@ repositories {
     }
 }
 
-version = "1.6.12"
+version = "1.6.13"
 group = "com.mitchej123.hodgepodge"
 archivesBaseName = "hodgepodge"
 sourceCompatibility = 1.8

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
-    private static final Logger log = LogManager.getLogger("Hodgepodge");
+    public static final Logger log = LogManager.getLogger("Hodgepodge");
     public static LoadingConfig config;
     public static boolean thermosTainted;
 

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -7,6 +7,8 @@ import net.minecraftforge.common.config.Configuration;
 import java.io.File;
 
 public class LoadingConfig {
+    // Adjustments
+    public int ic2SeedMaxStackSize;
     // Mixins
     public boolean fixNorthWestBias;
     public boolean fixFenceConnections;
@@ -60,6 +62,7 @@ public class LoadingConfig {
         fixHopperHitBox = config.get("fixes", "fixHopperHitBox", true, "Fix vanilla hopper hit box").getBoolean();
         fixGetBlockLightValue = config.get("fixes", "fixGetBlockLightValue", true, "Fix vanilla light calculation sometimes cause NPE on thermos").getBoolean();
         fixFireSpread = config.get("fixes", "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();
+        
         fixPotionEffectRender = config.get("tweaks", "fixPotionEffectRender", true, "Move vanilla potion effect status rendering before everything else").getBoolean();
         installAnchorAlarm = config.get("tweaks", "installAnchorAlarm", true, "Wake up passive & personal anchors on player login").getBoolean();
         preventPickupLoot = config.get("tweaks", "preventPickupLoot", true, "Prevent monsters from picking up loot.").getBoolean();
@@ -68,6 +71,8 @@ public class LoadingConfig {
         enableTileRendererProfiler = config.get("tweaks", "enableTileRendererProfiler", true, "Shows renderer's impact on FPS in vanilla lagometer").getBoolean();
         addCVSupportToWandPedestal = config.get("tweaks", "addCVSupportToWandPedestal", true, "Add CV support to Thaumcraft wand recharge pedestal").getBoolean();
 
+        ic2SeedMaxStackSize = config.get("tweaks", "ic2SeedMaxStackSize", 64, "IC2 seed max stack size").getInt();
+        
         speedupChunkCoordinatesHashCode = config.get("speedups", "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
 
         pollutionAsm = config.get("asm", "pollutionAsm", true, "Enable pollution rendering ASM").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/fixic2directinventoryaccess/item/MixinItemCropSeed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/fixic2directinventoryaccess/item/MixinItemCropSeed.java
@@ -1,39 +1,33 @@
 package com.mitchej123.hodgepodge.mixins.fixic2directinventoryaccess.item;
 
+import com.mitchej123.hodgepodge.core.HodgepodgeMixinPlugin;
+import ic2.core.init.InternalName;
 import ic2.core.item.ItemCropSeed;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = ItemCropSeed.class)
-public class MixinItemCropSeed {
+public class MixinItemCropSeed extends Item {
     @Inject(method = "onItemUse", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;inventory:Lnet/minecraft/entity/player/InventoryPlayer;"), cancellable = true)
     public void onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int x, int y, int z, int side, float a, float b, float c, CallbackInfoReturnable<Boolean> ci) {
-        entityplayer.inventory.setInventorySlotContents(entityplayer.inventory.currentItem, null);
+        ItemStack currentItem = entityplayer.inventory.getCurrentItem();
+        currentItem.stackSize -= 1;
         ci.setReturnValue(true);
         ci.cancel();
     }
+    @Inject(at=@At("RETURN"), method="<init>(Lic2/core/init/InternalName;)V", remap = false)
+    public void AdjustMaxStackSize(InternalName internalName, CallbackInfo ci) {
+        final int maxStackSize = HodgepodgeMixinPlugin.config.ic2SeedMaxStackSize;
+        if(maxStackSize != 1) {
+            HodgepodgeMixinPlugin.log.info("Setting IC2 seed max stack size to " + maxStackSize);
+            setMaxStackSize(maxStackSize);
+        }
+    }
 }
-
-
-// Alternative that doesn't use the remapping
-
-//@Mixin(value = { ItemCropSeed.class}, remap = false)
-//public class MixinItemCropSeed {
-//    @Inject(method = 
-//        "Lic2/core/item/ItemCropSeed;func_77648_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/world/World;IIIIFFF)Z"
-//        , at = @At(value = "FIELD",
-//        target = "Lnet/minecraft/entity/player/EntityPlayer;field_71071_by:Lnet/minecraft/entity/player/InventoryPlayer;"
-//        ), cancellable=true
-//    )
-//    public void onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int x, int y, int z, int side, float a, float b, float c, CallbackInfoReturnable<Boolean> ci) {
-//        System.out.println("Naughty naughty seedbag");
-//        entityplayer.inventory.setInventorySlotContents(entityplayer.inventory.currentItem, null);
-//        ci.setReturnValue(true);
-//        ci.cancel();
-//    }
-//}


### PR DESCRIPTION
Allows adjustment of the max stack size of IC2 seeds from the ic2 default of 1, to hodgepodge's default of 64 (configurable).

Tested with unknown seeds, NEI cheated in seeds, seeds from crops.  Tested using the seeds, as well as the cropnlyzer.