### PR TITLE
Add a mixin that increases the potion id limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Requires SpongeMixins mod (https://github.com/GTNewHorizons/SpongeMixins) to wor
 * FixThaumcraftUnprotectedGetBlock - Fixes various unprotected Thaumcraft getBlock() calls, making sure the chunk is loaded first.
 * FixIc2Nightvision - Prevents IC2 night vision from blinding you when it's bright out, making it on par with other nightvision available
 * FixHungerOverhaul - Patches unintended mod interaction with Spice Of Life - Carrot Edition
+* FixPotionLimit - Support all 256 potion slots by fixing the incorrect signed byte conversions.
 * RemoveUpdateChecks - Removes outdated update checks
 ## Speedups
 * SpeedupChunkCoordinatesHashCode - Swaps out the HashCode function for ChunkCoordinates with one that provides better performance with HashSet

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -32,6 +32,7 @@ public class LoadingConfig {
     public boolean fixIc2UnprotectedGetBlock;
     public boolean fixNorthWestBias;
     public boolean fixPotionEffectRender;
+    public boolean fixPotionLimit;
     public boolean fixThaumcraftUnprotectedGetBlock;
     public boolean fixUrlDetection;
     public boolean fixVanillaUnprotectedGetBlock;
@@ -88,7 +89,8 @@ public class LoadingConfig {
         fixFireSpread = config.get("fixes", "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();
         fixUrlDetection = config.get("fixes", "fixUrlDetection", true, "Fix URISyntaxException in forge.").getBoolean();
         fixDimensionChangeHearts = config.get("fixes", "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();
-        
+        fixPotionLimit = config.get("fixes", "fixPotionLimit", true, "Fix potions >= 128").getBoolean();
+
         increaseParticleLimit = config.get("tweaks", "increaseParticleLimit", true, "Increase particle limit").getBoolean();
         particleLimit = Math.max(Math.min(config.get("tweaks", "particleLimit", 8000, "Particle limit [4000-16000]").getInt(), 16000), 4000);
         fixPotionEffectRender = config.get("tweaks", "fixPotionEffectRender", true, "Move vanilla potion effect status rendering before everything else").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -25,6 +25,7 @@ public enum Mixins {
     DIMENSION_CHANGE_FIX("minecraft.MixinServerConfigurationManager", Side.BOTH, () -> Hodgepodge.config.fixDimensionChangeHearts, TargetedMod.VANILLA),
     CLONE_PLAYER_HEART_FIX("minecraft.MixinEntityPlayerMP", Side.BOTH, () -> Hodgepodge.config.fixDimensionChangeHearts, TargetedMod.VANILLA),
     INCREASE_PARTICLE_LIMIT("minecraft.MixinEffectRenderer", Side.CLIENT, () -> Hodgepodge.config.increaseParticleLimit, TargetedMod.VANILLA),
+    FIX_POTION_LIMIT("minecraft.MixinPotionEffect", Side.BOTH, () -> Hodgepodge.config.fixPotionLimit, TargetedMod.VANILLA),
     
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX("minecraft.MixinBlockGrass", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinPotionEffect.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinPotionEffect.java
@@ -1,0 +1,48 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(PotionEffect.class)
+public class MixinPotionEffect {
+
+    @Shadow
+    int potionID;
+
+    /**
+     * @author [com]buster
+     * @reason Fix any incoming potion IDs that have negative values (and were probably incorrectly parsed earlier).
+     */
+    @Inject(
+            method = "<init>(IIIZ)V",
+            at = @At("RETURN")
+    )
+    public void primaryConstructor(int p_i1576_1_, int p_i1576_2_, int p_i1576_3_, boolean p_i1576_4_, CallbackInfo ci) {
+        this.potionID = p_i1576_1_ & 0xff;
+    }
+
+    /**
+     * @author [com]buster
+     * @reason Force treat the potion id as an unsigned byte (to allow IDs 128-255)
+     */
+    @Overwrite()
+    public static PotionEffect readCustomPotionEffectFromNBT(NBTTagCompound tag) {
+        int potion = ((int)tag.getByte("Id")) & 0xff;
+        if (potion >= 0 && potion < Potion.potionTypes.length && Potion.potionTypes[potion] != null) {
+            byte amplifier = tag.getByte("Amplifier");
+            int duration = tag.getInteger("Duration");
+            boolean ambient = tag.getBoolean("Ambient");
+            return new PotionEffect(potion, duration, amplifier, ambient);
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Botania potions fix part 1/3

The vanilla minecraft bug addressed here is that the storage and network protocols use signed bytes for storage efficiency, rather than unsigned ones. This mixin hooks PotionEffect and trims the sign-extended bits off the potion ID, effectively flipping them back to positive. 

In contrast to some other coremods that address this problem (e.g. DragonAPI) this keeps the byte-sized storage unit so that savegames and network protocols stay compatible with and without the mixin applied, of course assuming the higher potion ID's aren't used. If the new limit of 256 potions are not enough, then more complicated options are needed to convert the potion id to an integer proper - with the associated complexity and compatibility risks.