### PR TITLE
Fix Drawer + Hopper voiding items

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -33,6 +33,7 @@ public class LoadingConfig {
     public boolean fixNorthWestBias;
     public boolean fixPotionEffectRender;
     public boolean fixPotionLimit;
+    public boolean fixHopperVoidingItems;
     public boolean fixThaumcraftUnprotectedGetBlock;
     public boolean fixUrlDetection;
     public boolean fixVanillaUnprotectedGetBlock;
@@ -90,6 +91,7 @@ public class LoadingConfig {
         fixUrlDetection = config.get("fixes", "fixUrlDetection", true, "Fix URISyntaxException in forge.").getBoolean();
         fixDimensionChangeHearts = config.get("fixes", "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();
         fixPotionLimit = config.get("fixes", "fixPotionLimit", true, "Fix potions >= 128").getBoolean();
+        fixHopperVoidingItems = config.get("fixes", "fixHopperVoidingItems", true, "Fix Drawer + Hopper voiding items").getBoolean();
 
         increaseParticleLimit = config.get("tweaks", "increaseParticleLimit", true, "Increase particle limit").getBoolean();
         particleLimit = Math.max(Math.min(config.get("tweaks", "particleLimit", 8000, "Particle limit [4000-16000]").getInt(), 16000), 4000);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -26,7 +26,8 @@ public enum Mixins {
     CLONE_PLAYER_HEART_FIX("minecraft.MixinEntityPlayerMP", Side.BOTH, () -> Hodgepodge.config.fixDimensionChangeHearts, TargetedMod.VANILLA),
     INCREASE_PARTICLE_LIMIT("minecraft.MixinEffectRenderer", Side.CLIENT, () -> Hodgepodge.config.increaseParticleLimit, TargetedMod.VANILLA),
     FIX_POTION_LIMIT("minecraft.MixinPotionEffect", Side.BOTH, () -> Hodgepodge.config.fixPotionLimit, TargetedMod.VANILLA),
-    
+    FIX_HOPPER_VOIDING_ITEMS("minecraft.MixinTileEntityHopper", () -> Hodgepodge.config.fixHopperVoidingItems, TargetedMod.VANILLA),
+
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX("minecraft.MixinBlockGrass", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     FIRE_GET_BLOCK_FIX("minecraft.MixinBlockFireGetBlock", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinTileEntityHopper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinTileEntityHopper.java
@@ -24,7 +24,9 @@ public class MixinTileEntityHopper {
                 if (decreased != null && decreased.stackSize != 0) {
                     ItemStack space = hopper.getStackInSlot(spaceSlot);
                     if (space == null) {
-                        hopper.setInventorySlotContents(spaceSlot, oneSizedCopy(is));
+                        space = is.copy();
+                        space.stackSize = 1;
+                        hopper.setInventorySlotContents(spaceSlot, space);
                     } else {
                         space.stackSize += 1;
                     }
@@ -43,16 +45,10 @@ public class MixinTileEntityHopper {
                 return i;
             }
             if (space.stackSize < Math.min(space.getMaxStackSize(), hopper.getInventoryStackLimit()))
-                if (ItemStack.areItemStacksEqual(oneSizedCopy(is), oneSizedCopy(space))) {
+                if (is.isItemEqual(space) && ItemStack.areItemStackTagsEqual(is, space)) {
                     return i;
                 }
         }
         return -1;
-    }
-
-    private static ItemStack oneSizedCopy(ItemStack is) {
-        is = is.copy();
-        is.stackSize = 1;
-        return is;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinTileEntityHopper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinTileEntityHopper.java
@@ -1,0 +1,58 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.IHopper;
+import net.minecraft.tileentity.TileEntityHopper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(TileEntityHopper.class)
+public class MixinTileEntityHopper {
+    /**
+     * @author MuXiu1997
+     * @reason Full hopper voiding items from drawer
+     */
+    @Overwrite
+    private static boolean func_145892_a(IHopper hopper, IInventory inventory, int slot, int side) {
+        ItemStack is = inventory.getStackInSlot(slot);
+        if (is != null && is.stackSize != 0) {
+            int spaceSlot = getSpaceSlot(hopper, is);
+            if (spaceSlot != -1) {
+                ItemStack decreased = inventory.decrStackSize(slot, 1);
+                if (decreased != null && decreased.stackSize != 0) {
+                    ItemStack space = hopper.getStackInSlot(spaceSlot);
+                    if (space == null) {
+                        hopper.setInventorySlotContents(spaceSlot, oneSizedCopy(is));
+                    } else {
+                        space.stackSize += 1;
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    private static int getSpaceSlot(IHopper hopper, ItemStack is) {
+        final int size = hopper.getSizeInventory();
+        for (int i = 0; i < size; i++) {
+            ItemStack space = hopper.getStackInSlot(i);
+            if (space == null) {
+                return i;
+            }
+            if (space.stackSize < Math.min(space.getMaxStackSize(), hopper.getInventoryStackLimit()))
+                if (ItemStack.areItemStacksEqual(oneSizedCopy(is), oneSizedCopy(space))) {
+                    return i;
+                }
+        }
+        return -1;
+    }
+
+    private static ItemStack oneSizedCopy(ItemStack is) {
+        is = is.copy();
+        is.stackSize = 1;
+        return is;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinTileEntityHopper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinTileEntityHopper.java
@@ -5,7 +5,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.IHopper;
 import net.minecraft.tileentity.TileEntityHopper;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(TileEntityHopper.class)
 public class MixinTileEntityHopper {
@@ -13,8 +14,8 @@ public class MixinTileEntityHopper {
      * @author MuXiu1997
      * @reason Full hopper voiding items from drawer
      */
-    @Overwrite
-    private static boolean func_145892_a(IHopper hopper, IInventory inventory, int slot, int side) {
+    @Redirect(method = "func_145891_a(Lnet/minecraft/tileentity/IHopper;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/tileentity/TileEntityHopper;func_145892_a(Lnet/minecraft/tileentity/IHopper;Lnet/minecraft/inventory/IInventory;II)Z"))
+    private static boolean redirect_func_145891_a(IHopper hopper, IInventory inventory, int slot, int side) {
         ItemStack is = inventory.getStackInSlot(slot);
         if (is != null && is.stackSize != 0) {
             int spaceSlot = getSpaceSlot(hopper, is);
@@ -33,7 +34,6 @@ public class MixinTileEntityHopper {
         }
         return false;
     }
-
 
     private static int getSpaceSlot(IHopper hopper, ItemStack is) {
         final int size = hopper.getSizeInventory();


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7778

I think it is reasonable for `Drawer` to sync after each write operation
And `Hopper` needs to use 2 write operations on `Drawers` to finish transferring items, which is not reasonable

So I tried to fix it with `mixin` and it seems to be working




https://user-images.githubusercontent.com/49554020/162173928-439ffd36-7a61-4a21-ae67-c379fc7707e8.mp4


