### PR TITLE
Fix hotbar turning dark in third-person when Project Red is installed

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,6 +3,7 @@ dependencies {
     compile("com.github.GTNewHorizons:StructureLib:1.0.15:dev")
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compile("com.github.GTNewHorizons:AppleCore:3.1.9:dev")
+    compile("mrtjp:MrTJPCore:1.7.10-1.1.0.33:dev")
     
     compileOnly("com.github.GTNewHorizons:Railcraft:9.13.6:dev") {
         // RC Depends on BuildCraft & Baubles and a few others, use transitive to pull those in for `runClient`

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -32,4 +32,12 @@ repositories {
         name = "jitpack"
         url("https://jitpack.io")
     }
+    maven {
+        name "mvnmrtjp"
+        url "http://files.projectredwiki.com/maven"
+        metadataSources {
+            mavenPom()
+            artifact()
+        }
+    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -51,6 +51,7 @@ public class LoadingConfig {
     public boolean deduplicateForestryCompatInBOP;
     public boolean speedupBOPFogHandling;
     public boolean makeBigFirsPlantable;
+    public boolean fixHudLightingGlitch;
     
     // ASM
     public boolean pollutionAsm;
@@ -110,6 +111,7 @@ public class LoadingConfig {
         addCVSupportToWandPedestal = config.get("tweaks", "addCVSupportToWandPedestal", true, "Add CV support to Thaumcraft wand recharge pedestal").getBoolean();
         makeBigFirsPlantable = config.get("tweaks", "makeBigFirsPlantable", true, "Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree").getBoolean();
         ic2SeedMaxStackSize = config.get("tweaks", "ic2SeedMaxStackSize", 64, "IC2 seed max stack size").getInt();
+        fixHudLightingGlitch = config.get("tweaks", "fixHudLightingGlitch", true, "Fix hotbars being dark when Project Red is installed").getBoolean();
         
         speedupChunkCoordinatesHashCode = config.get("speedups", "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
         speedupVanillaFurnace = config.get("speedups", "speedupVanillaFurnace", true, "Speedup Vanilla Furnace recipe lookup").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -66,7 +66,10 @@ public enum Mixins {
     // BOP
     DEDUPLICATE_FORESTRY_COMPAT_IN_BOP("biomesoplenty.MixinForestryIntegration", () -> Hodgepodge.config.deduplicateForestryCompatInBOP, TargetedMod.BOP),
     SPEEDUP_BOP_BIOME_FOG("biomesoplenty.MixinFogHandler", Side.CLIENT, () -> Hodgepodge.config.speedupBOPFogHandling, TargetedMod.BOP),
-    BIG_FIR_TREES("biomesoplenty.MixinBlockBOPSapling", () -> Hodgepodge.config.makeBigFirsPlantable, TargetedMod.BOP)
+    BIG_FIR_TREES("biomesoplenty.MixinBlockBOPSapling", () -> Hodgepodge.config.makeBigFirsPlantable, TargetedMod.BOP),
+
+    // MrTJPCore (Project Red)
+    FIX_HUD_LIGHTING_GLITCH("mrtjpcore.MixinFXEngine", () -> Hodgepodge.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE)
     ;
     
     public final String mixinClass;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -8,7 +8,8 @@ public enum TargetedMod {
     RAILCRAFT("Railcraft", "Railcraft"),
     THAUMCRAFT("Thaumcraft", "Thaumcraft-1.7.10"),
     COFH_CORE("CoFHCore", "CoFHCore", "cofh-core"),
-    BOP("BiomesOPlenty", "BiomesOPlenty-1.7.10")
+    BOP("BiomesOPlenty", "BiomesOPlenty-1.7.10"),
+    MRTJPCORE("MrTJPCore", "MrTJPCore")
     ;
 
     public final String modName;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/mrtjpcore/MixinFXEngine.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/mrtjpcore/MixinFXEngine.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.mrtjpcore;
+
+import mrtjp.core.fx.FXEngine$;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(FXEngine$.class)
+public class MixinFXEngine {
+    /**
+     * @reason Lighting should be kept disabled at the end of RenderWorldLastEvent in 1.7.
+     */
+    @Inject(method = "renderParticles", at = @At("TAIL"), remap = false)
+    private void keepLightingDisabled(int dim, float frame, CallbackInfo ci) {
+        GL11.glDisable(GL11.GL_LIGHTING);
+    }
+}


### PR DESCRIPTION
This fixes an annoying issue which causes the hotbar to darken when the player switches to third person mode. I believe the root cause is that lighting is re-enabled in RenderWorldLastEvent by MrTJPCore, when the HUD renderer expects it to be disabled. The workaround is to keep lighting disabled, which is what is done here.

Can someone confirm that they see the issue without the fix applied?

Before:

![before](https://user-images.githubusercontent.com/42941056/163691163-a05e6f18-7d0a-4137-b49c-5b71b5e43802.gif)

After:

![after](https://user-images.githubusercontent.com/42941056/163691165-12243cb1-a8b6-4afb-ba39-0786c9c18474.gif)

Offending code in MrTJPCore: https://github.com/MrTJP/MrTJPCore/blob/adbfa1fe6eff596250949ff13ee3195218db3292/src/mrtjp/core/fx/FXEngine.scala#L140-L144