### PR TITLE
Fix world entity leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1646409286
+//version: 1650343995
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -568,7 +568,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -53,6 +53,7 @@ public class LoadingConfig {
     public boolean makeBigFirsPlantable;
     public boolean fixHudLightingGlitch;
     public boolean thirstyTankContainer;
+    public boolean fixWorldServerLeakingUnloadedEntities;
     
     // ASM
     public boolean pollutionAsm;
@@ -99,6 +100,7 @@ public class LoadingConfig {
         fixPotionLimit = config.get("fixes", "fixPotionLimit", true, "Fix potions >= 128").getBoolean();
         deduplicateForestryCompatInBOP = config.get("fixes", "deduplicateForestryCompatInBOP", true, "Removes duplicate Fermenter and Squeezer recipes and flower registration").getBoolean();
         fixHopperVoidingItems = config.get("fixes", "fixHopperVoidingItems", true, "Fix Drawer + Hopper voiding items").getBoolean();
+        fixWorldServerLeakingUnloadedEntities = config.get("fixes", "fixWorldServerLeakingUnloadedEntities", true, "Fix WorldServer leaking entities when no players are present in a dimension").getBoolean();
 
         increaseParticleLimit = config.get("tweaks", "increaseParticleLimit", true, "Increase particle limit").getBoolean();
         particleLimit = Math.max(Math.min(config.get("tweaks", "particleLimit", 8000, "Particle limit [4000-16000]").getInt(), 16000), 4000);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -27,6 +27,7 @@ public enum Mixins {
     INCREASE_PARTICLE_LIMIT("minecraft.MixinEffectRenderer", Side.CLIENT, () -> Hodgepodge.config.increaseParticleLimit, TargetedMod.VANILLA),
     FIX_POTION_LIMIT("minecraft.MixinPotionEffect", Side.BOTH, () -> Hodgepodge.config.fixPotionLimit, TargetedMod.VANILLA),
     FIX_HOPPER_VOIDING_ITEMS("minecraft.MixinTileEntityHopper", () -> Hodgepodge.config.fixHopperVoidingItems, TargetedMod.VANILLA),
+    FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES("minecraft.MixinWorldServerUpdateEntities", () -> Hodgepodge.config.fixWorldServerLeakingUnloadedEntities, TargetedMod.VANILLA),
 
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX("minecraft.MixinBlockGrass", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinWorldServerUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinWorldServerUpdateEntities.java
@@ -1,0 +1,50 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import net.minecraft.profiler.Profiler;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldSettings;
+import net.minecraft.world.storage.ISaveHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+
+@Mixin(WorldServer.class)
+public abstract class MixinWorldServerUpdateEntities extends World {
+
+    @Shadow
+    private int updateEntityTick;
+
+    /**
+     * @author kubasz
+     * @reason Vanilla skipping the update when no players are in the dimension causes memory leaks
+     */
+    @Overwrite
+    public void updateEntities() {
+        if (this.playerEntities.isEmpty() && getPersistentChunks().isEmpty())
+        {
+            if (this.updateEntityTick++ >= 1200)
+            {
+                // Make sure to run cleanup code every 10s
+                if (this.updateEntityTick % 200 == 0)
+                {
+                    super.updateEntities();
+                }
+                return;
+            }
+        }
+        else
+        {
+            this.updateEntityTick = 0;
+        }
+
+        super.updateEntities();
+    }
+
+    public MixinWorldServerUpdateEntities(ISaveHandler p_i45368_1_, String p_i45368_2_, WorldProvider p_i45368_3_, WorldSettings p_i45368_4_, Profiler p_i45368_5_) {
+        // Needed because we're extending from World
+        super(p_i45368_1_, p_i45368_2_, p_i45368_3_, p_i45368_4_, p_i45368_5_);
+    }
+}


### PR DESCRIPTION
Attempts to fix <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6976>

To avoid causing too much lag (I doubt that would actually be the case, but vanilla probably doesn't call updateEntities for this reason), the updates in worlds without players are throttled to run only every 200t (10s)