### PR TITLE
Add more Hardware Info to F3 Overlay

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/ClientTicker.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/ClientTicker.java
@@ -1,6 +1,5 @@
 package com.mitchej123.hodgepodge.client;
 
-import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 

--- a/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
@@ -32,7 +32,7 @@ public class DebugScreenHandler {
     
     @SubscribeEvent
     public void onRenderGameOverlayTextEvent(RenderGameOverlayEvent.Text event) {
-        if(Minecraft.getMinecraft().gameSettings.showDebugInfo) {
+        if (Minecraft.getMinecraft().gameSettings.showDebugInfo) {
             event.right.add(2, null); //Empty Line
             event.right.add(3, "Java: " + this.javaVersion + (this.is64bit ? " 64bit (" : " 32bit (") + this.javaVendor + ")");
             event.right.add(4, "GPU: " + this.gpuName);
@@ -44,9 +44,9 @@ public class DebugScreenHandler {
     
     private static boolean check64bit() {
         String[] keys = {"sun.arch.data.model", "com.ibm.vm.bitmode", "os.arch"};
-        for(String key : keys) {
+        for (String key : keys) {
             String value = System.getProperty(key);
-            if(value != null && value.contains("64")) {
+            if (value != null && value.contains("64")) {
                 return true;
             }
         }

--- a/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
@@ -1,0 +1,56 @@
+package com.mitchej123.hodgepodge.client;
+
+import org.lwjgl.opengl.GL11;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+
+public class DebugScreenHandler {
+    
+    public static final DebugScreenHandler INSTANCE = new DebugScreenHandler();
+    
+    private boolean is64bit;
+    private String javaVersion;
+    private String javaVendor;
+    private String gpuName;
+    private String glVersion;
+    private String osArch;
+    private String osName;
+    private String osVersion;
+    
+    private DebugScreenHandler() {
+        this.is64bit = check64bit();
+        this.javaVersion = System.getProperty("java.version");
+        this.javaVendor = System.getProperty("java.vendor");
+        this.gpuName = GL11.glGetString(GL11.GL_RENDERER);
+        this.glVersion = GL11.glGetString(GL11.GL_VERSION);
+        this.osArch = System.getProperty("os.arch");
+        this.osName = System.getProperty("os.name");
+        this.osVersion = System.getProperty("os.version");
+    }
+    
+    @SubscribeEvent
+    public void onRenderGameOverlayTextEvent(RenderGameOverlayEvent.Text event) {
+        if(Minecraft.getMinecraft().gameSettings.showDebugInfo) {
+            event.right.add(2, null); //Empty Line
+            event.right.add(3, "Java: " + this.javaVersion + (this.is64bit ? " 64bit (" : " 32bit (") + this.javaVendor + ")");
+            event.right.add(4, "GPU: " + this.gpuName);
+            event.right.add(5, "OpenGL: " + this.glVersion);
+            event.right.add(6, "CPU Cores: " + Runtime.getRuntime().availableProcessors());
+            event.right.add(7, "OS: " + this.osName + " (" + this.osVersion + ", " + this.osArch + ")");
+        }
+    }
+    
+    private static boolean check64bit() {
+        String[] keys = {"sun.arch.data.model", "com.ibm.vm.bitmode", "os.arch"};
+        for(String key : keys) {
+            String value = System.getProperty(key);
+            if(value != null && value.contains("64")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
@@ -1,6 +1,7 @@
 package com.mitchej123.hodgepodge.core;
 
 import com.mitchej123.hodgepodge.client.ClientTicker;
+import com.mitchej123.hodgepodge.client.DebugScreenHandler;
 import com.mitchej123.hodgepodge.core.util.ColorOverrideType;
 import com.mitchej123.hodgepodge.asm.References;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -28,6 +29,7 @@ public class HodgePodgeClient {
         }
 
         FMLCommonHandler.instance().bus().register(ClientTicker.INSTANCE);
+        MinecraftForge.EVENT_BUS.register(DebugScreenHandler.INSTANCE);
     }
 
     // ASM hookers

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.core;
 import com.mitchej123.hodgepodge.client.ClientTicker;
 import com.mitchej123.hodgepodge.client.DebugScreenHandler;
 import com.mitchej123.hodgepodge.core.util.ColorOverrideType;
+import com.mitchej123.hodgepodge.Hodgepodge;
 import com.mitchej123.hodgepodge.asm.References;
 import cpw.mods.fml.common.FMLCommonHandler;
 import net.minecraft.block.Block;
@@ -29,7 +30,10 @@ public class HodgePodgeClient {
         }
 
         FMLCommonHandler.instance().bus().register(ClientTicker.INSTANCE);
-        MinecraftForge.EVENT_BUS.register(DebugScreenHandler.INSTANCE);
+        
+        if (Hodgepodge.config.addSystemInfo) {
+            MinecraftForge.EVENT_BUS.register(DebugScreenHandler.INSTANCE);
+        }
     }
 
     // ASM hookers

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -15,6 +15,7 @@ public class LoadingConfig {
     // Adjustments
     public int ic2SeedMaxStackSize;
     public int particleLimit;
+    public boolean addSystemInfo;
     
     // Mixins
     public boolean addCVSupportToWandPedestal;
@@ -59,7 +60,7 @@ public class LoadingConfig {
     public boolean biblocraftRecipes;
     
     public String thermosCraftServerClass;
-        
+    
     
     public static Configuration config;
 
@@ -110,6 +111,7 @@ public class LoadingConfig {
         addCVSupportToWandPedestal = config.get("tweaks", "addCVSupportToWandPedestal", true, "Add CV support to Thaumcraft wand recharge pedestal").getBoolean();
         makeBigFirsPlantable = config.get("tweaks", "makeBigFirsPlantable", true, "Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree").getBoolean();
         ic2SeedMaxStackSize = config.get("tweaks", "ic2SeedMaxStackSize", 64, "IC2 seed max stack size").getInt();
+        addSystemInfo = config.get("tweaks", "addSystemInfo", true, "Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture)").getBoolean();
         
         speedupChunkCoordinatesHashCode = config.get("speedups", "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
         speedupVanillaFurnace = config.get("speedups", "speedupVanillaFurnace", true, "Speedup Vanilla Furnace recipe lookup").getBoolean();


### PR DESCRIPTION
- Java version, vendor and 32bit/64bit
- GPU name
- OpenGL version
- CPU cores
- OS name, version and architecture

CPU name/vendor info is very difficult to get. MC uses the `oshi-core` library in the newest version(s?). If someone knows if one of the libraries included in 1.7.10 is able to do this (or something similar) too, please let me know and I'll add it too.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10241