### PR TITLE
Miscellaneous fixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,6 +14,7 @@ dependencies {
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compile("curse.maven:cofh-core-69162:2388751")
     compile("curse.maven:biomes-o-plenty-220318:2499612")
+    compile("curse.maven:projecte-226410:2340786")
     
    
     // Thermos Compat, compile only not run in dev by default

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compile("com.github.GTNewHorizons:AppleCore:3.1.9:dev")
     compile("mrtjp:MrTJPCore:1.7.10-1.1.0.33:dev")
-    compile("curse.maven:automagy-222153:2285272")
+    compileOnly("curse.maven:automagy-222153:2285272")
     
     compileOnly("com.github.GTNewHorizons:Railcraft:9.13.6:dev") {
         // RC Depends on BuildCraft & Baubles and a few others, use transitive to pull those in for `runClient`

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -43,6 +43,7 @@ public class LoadingConfig {
     public boolean fixWorldGetBlock;
     public boolean fixDimensionChangeHearts;
     public boolean increaseParticleLimit;
+    public boolean fixGlStateBugs;
     public boolean hideIc2ReactorSlots;
     public boolean displayIc2FluidLocalizedName;
     public boolean installAnchorAlarm;
@@ -101,6 +102,7 @@ public class LoadingConfig {
         fixUrlDetection = config.get("fixes", "fixUrlDetection", true, "Fix URISyntaxException in forge.").getBoolean();
         fixDimensionChangeHearts = config.get("fixes", "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();
         fixPotionLimit = config.get("fixes", "fixPotionLimit", true, "Fix potions >= 128").getBoolean();
+        fixGlStateBugs = config.get("fixes", "fixGlStateBugs", true, "Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).").getBoolean();
         deduplicateForestryCompatInBOP = config.get("fixes", "deduplicateForestryCompatInBOP", true, "Removes duplicate Fermenter and Squeezer recipes and flower registration").getBoolean();
         fixHopperVoidingItems = config.get("fixes", "fixHopperVoidingItems", true, "Fix Drawer + Hopper voiding items").getBoolean();
         fixHugeChatKick = config.get("fixes", "fixHugeChatKick", true, "Fix oversized chat message kicking player.").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -75,7 +75,10 @@ public enum Mixins {
     FIX_HUD_LIGHTING_GLITCH("mrtjpcore.MixinFXEngine", () -> Hodgepodge.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE),
     
     // Automagy
-    IMPLEMENTS_CONTAINER_FOR_THIRSTY_TANK("automagy.MixinItemBlockThirstyTank", () -> Hodgepodge.config.thirstyTankContainer, TargetedMod.AUTOMAGY)
+    IMPLEMENTS_CONTAINER_FOR_THIRSTY_TANK("automagy.MixinItemBlockThirstyTank", () -> Hodgepodge.config.thirstyTankContainer, TargetedMod.AUTOMAGY),
+
+    // ProjectE
+    FIX_FURNACE_ITERATION("projecte.MixinObjHandler", () -> Hodgepodge.config.speedupVanillaFurnace, TargetedMod.PROJECTE),
     ;
     
     public final String mixinClass;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -29,6 +29,7 @@ public enum Mixins {
     FIX_HOPPER_VOIDING_ITEMS("minecraft.MixinTileEntityHopper", () -> Hodgepodge.config.fixHopperVoidingItems, TargetedMod.VANILLA),
     FIX_HUGE_CHAT_KICK("minecraft.MixinS02PacketChat", () -> Hodgepodge.config.fixHugeChatKick, TargetedMod.VANILLA),
     FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES("minecraft.MixinWorldServerUpdateEntities", () -> Hodgepodge.config.fixWorldServerLeakingUnloadedEntities, TargetedMod.VANILLA),
+    FIX_ARROW_WRONG_LIGHTING("minecraft.MixinRendererLivingEntity", Side.CLIENT, () -> Hodgepodge.config.fixGlStateBugs, TargetedMod.VANILLA),
 
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX("minecraft.MixinBlockGrass", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -10,7 +10,8 @@ public enum TargetedMod {
     COFH_CORE("CoFHCore", "CoFHCore", "cofh-core"),
     BOP("BiomesOPlenty", "BiomesOPlenty-1.7.10"),
     MRTJPCORE("MrTJPCore", "MrTJPCore"),
-    AUTOMAGY("Automagy", "Automagy-1.7.10")
+    AUTOMAGY("Automagy", "Automagy-1.7.10"),
+    PROJECTE("ProjectE", "ProjectE-1.7.10", "projecte")
     ;
 
     public final String modName;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRendererLivingEntity.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRendererLivingEntity.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Use regular lighting for arrows stuck in entities instead of item lighting.
+ */
+@Mixin(RendererLivingEntity.class)
+public class MixinRendererLivingEntity {
+    @Redirect(method = "renderArrowsStuckInEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderHelper;disableStandardItemLighting()V"))
+    private void disableCorrectLighting() {
+        GL11.glDisable(GL11.GL_LIGHTING);
+    }
+
+    @Redirect(method = "renderArrowsStuckInEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderHelper;enableStandardItemLighting()V"))
+    private void enableCorrectLighting() {
+        GL11.glEnable(GL11.GL_LIGHTING);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/projecte/MixinObjHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/projecte/MixinObjHandler.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.projecte;
+
+import moze_intel.projecte.gameObjs.ObjHandler;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Mixin(ObjHandler.class)
+public class MixinObjHandler {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Redirect(method = "registerPhiloStoneSmelting", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/crafting/FurnaceRecipes;func_77599_b()Ljava/util/Map;"), remap = false)
+    private static Map getFakeRecipeMap(FurnaceRecipes instance) {
+        return new HashMap(instance.getSmeltingList());
+    }
+}


### PR DESCRIPTION
This adds two fixes.

MC-10135 causes the world to render with incorrect lighting in third person after you get shot by a skeleton and has a fairly straightforward fix. I've used a simple fix I made for this in 1.12 without problems, so I'm backporting it to 1.7 here. I deliberately left the config name generic as I have a few more 1.12 fixes for similar issues that could potentially be applied here later.

ProjectE is currently incompatible with the smelting list replacement since it assumes the returned map is a HashMap.

```
[08:51:20] [Client thread/ERROR] [FML]: Caught exception from ProjectE
java.lang.ClassCastException: com.mitchej123.hodgepodge.core.util.ItemStackMap cannot be cast to java.util.HashMap
	at moze_intel.projecte.gameObjs.ObjHandler.registerPhiloStoneSmelting(ObjHandler.java:613) ~[ObjHandler.class:?]
	at moze_intel.projecte.PECore.postInit(PECore.java:115) ~[PECore.class:?]
```

I am aware that ProjectE is not part of GTNH so it might not be officially supported at all, but the fix seemed quite simple. I don't see a way of removing the cast with a mixin so I opted to just return a HashMap instance with all the entries from the regular map instead. This is just a temporary object for that function so it shouldn't cause any additional heap usage post-startup.

Lastly, #64 broke dev by making Automagy a `compile` dependency instead of `compileOnly`, thus causing startup to fail since Thaumcraft is `compileOnly`. I've just changed Automagy to also be that way.