### PR TITLE
Add PlacementLib patch for components popping off chunks

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -56,6 +56,7 @@ public class LoadingConfig {
     public boolean speedupBOPFogHandling;
     public boolean makeBigFirsPlantable;
     public boolean fixHudLightingGlitch;
+    public boolean fixComponentsPoppingOff;
     public boolean thirstyTankContainer;
     public boolean fixWorldServerLeakingUnloadedEntities;
 
@@ -123,6 +124,7 @@ public class LoadingConfig {
         ic2SeedMaxStackSize = config.get("tweaks", "ic2SeedMaxStackSize", 64, "IC2 seed max stack size").getInt();
         addSystemInfo = config.get("tweaks", "addSystemInfo", true, "Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture)").getBoolean();
         fixHudLightingGlitch = config.get("tweaks", "fixHudLightingGlitch", true, "Fix hotbars being dark when Project Red is installed").getBoolean();
+        fixComponentsPoppingOff = config.get("tweaks", "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();
         thirstyTankContainer = config.get("tweaks", "thirstyTankContainer", true, "Implement container for thirsty tank").getBoolean();
         
         speedupChunkCoordinatesHashCode = config.get("speedups", "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -73,7 +73,9 @@ public enum Mixins {
 
     // MrTJPCore (Project Red)
     FIX_HUD_LIGHTING_GLITCH("mrtjpcore.MixinFXEngine", () -> Hodgepodge.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE),
-    
+    FIX_POPPING_OFF("mrtjpcore.MixinPlacementLib", () -> Hodgepodge.config.fixComponentsPoppingOff, TargetedMod.MRTJPCORE),
+
+
     // Automagy
     IMPLEMENTS_CONTAINER_FOR_THIRSTY_TANK("automagy.MixinItemBlockThirstyTank", () -> Hodgepodge.config.thirstyTankContainer, TargetedMod.AUTOMAGY),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/mrtjpcore/MixinPlacementLib.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/mrtjpcore/MixinPlacementLib.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.mrtjpcore;
+
+import mrtjp.core.world.PlacementLib$;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(PlacementLib$.class)
+public class MixinPlacementLib {
+    /**
+     * @reason Allow blocks to stay on unloaded chunks.
+     */
+    @ModifyConstant(method = { "canPlaceWireOnSide", "canPlaceTorchOnBlock" }, constant = @Constant(intValue = 0, ordinal = 1), remap = false)
+    private int allowChunkUnloading1(int oldFalse) {
+        return 1; /* true */
+    }
+
+    @ModifyConstant(method = "canPlaceGateOnSide", constant = @Constant(intValue = 0, ordinal = 2), remap = false)
+    private int allowChunkUnloading2(int oldFalse) {
+        return 1; /* true */
+    }
+}


### PR DESCRIPTION
This is an alternative solution to https://github.com/GTNewHorizons/ProjectRed/pull/17 that patches `PlacementLib` directly. It has the advantage of fixing any other code/mods that might depend on `PlacementLib`.