### PR TITLE
Do not use COMPUTE_FRAMES literally everywhere

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/asm/InventoryEffectRendererTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/InventoryEffectRendererTransformer.java
@@ -2,6 +2,7 @@ package com.mitchej123.hodgepodge.asm;
 
 import com.mitchej123.hodgepodge.asm.util.AbstractClassTransformer;
 import com.mitchej123.hodgepodge.asm.util.AbstractMethodTransformer;
+import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
@@ -9,7 +10,7 @@ import org.objectweb.asm.tree.InsnList;
 public class InventoryEffectRendererTransformer extends AbstractClassTransformer {
     public InventoryEffectRendererTransformer()
     {
-        addMethodTransformer(References.cEffectRenderer.getMethod("drawScreen"), new AbstractMethodTransformer() {
+        addMethodTransformer(References.cEffectRenderer.getMethod("drawScreen"), ClassWriter.COMPUTE_FRAMES, new AbstractMethodTransformer() {
             @Override
             public void transform() {
                 // Cut out super.drawScreen() sequence

--- a/src/main/java/com/mitchej123/hodgepodge/asm/PollutionClassTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/PollutionClassTransformer.java
@@ -17,7 +17,7 @@ public class PollutionClassTransformer extends AbstractClassTransformer {
             /*
              * Grabs various methods in RenderBlocks when they query for colorMultiplier and overrides the value.
              */
-            addMethodTransformer(References.cRenderBlocks.getMethod("renderStandardBlock"), new AbstractMethodTransformer() {
+            addMethodTransformer(References.cRenderBlocks.getMethod("renderStandardBlock"), 0, new AbstractMethodTransformer() {
                 @Override
                 public void transform() {
                     log.info("Injecting RenderBlocks.renderStandardBlock");
@@ -28,7 +28,7 @@ public class PollutionClassTransformer extends AbstractClassTransformer {
                             createInvokeStatic(References.cHogClient.getMethod("renderStandardBlock_colorMultiplier")));
                 }
             });
-            addMethodTransformer(References.cRenderBlocks.getMethod("renderBlockLiquid"), new AbstractMethodTransformer() {
+            addMethodTransformer(References.cRenderBlocks.getMethod("renderBlockLiquid"), 0, new AbstractMethodTransformer() {
                 @Override
                 public void transform() {
                     log.info("Injecting RenderBlocks.renderBlockLiquid");
@@ -39,7 +39,7 @@ public class PollutionClassTransformer extends AbstractClassTransformer {
                             createInvokeStatic(References.cHogClient.getMethod("renderBlockLiquid_colorMultiplier")));
                 }
             });
-            addMethodTransformer(References.cRenderBlocks.getMethod("renderBlockDoublePlant"), new AbstractMethodTransformer() {
+            addMethodTransformer(References.cRenderBlocks.getMethod("renderBlockDoublePlant"), 0, new AbstractMethodTransformer() {
                 @Override
                 public void transform() {
                     log.info("Injecting RenderBlocks.renderBlockDoublePlant");
@@ -51,7 +51,7 @@ public class PollutionClassTransformer extends AbstractClassTransformer {
                             createInvokeStatic(References.cHogClient.getMethod("renderBlockDoublePlant_colorMultiplier")));
                 }
             });
-            addMethodTransformer(References.cRenderBlocks.getMethod("renderCrossedSquares"), new AbstractMethodTransformer() {
+            addMethodTransformer(References.cRenderBlocks.getMethod("renderCrossedSquares"), 0, new AbstractMethodTransformer() {
                 @Override
                 public void transform() {
                     log.info("Injecting RenderBlocks.renderCrossedSquares");
@@ -62,7 +62,7 @@ public class PollutionClassTransformer extends AbstractClassTransformer {
                             createInvokeStatic(References.cHogClient.getMethod("renderCrossedSquares_colorMultiplier")));
                 }
             });
-            addMethodTransformer(References.cRenderBlocks.getMethod("renderBlockVine"), new AbstractMethodTransformer() {
+            addMethodTransformer(References.cRenderBlocks.getMethod("renderBlockVine"), 0, new AbstractMethodTransformer() {
                 @Override
                 public void transform() {
                     log.info("Injecting RenderBlocks.renderBlockVine");
@@ -86,7 +86,7 @@ public class PollutionClassTransformer extends AbstractClassTransformer {
             /*
              * Grabs various methods in biomesoplenty.client.render.blocks.FoliageRenderer when they query for colorMultiplier and overrides the value.
              */
-            addMethodTransformer(References.bopFoliageRenderer.getMethod("renderCrossedSquares"), new AbstractMethodTransformer() {
+            addMethodTransformer(References.bopFoliageRenderer.getMethod("renderCrossedSquares"), 0, new AbstractMethodTransformer() {
                 @Override
                 public void transform() {
                     log.info("Injecting biomesoplenty.client.render.blocks.FoliageRenderer.");

--- a/src/main/java/com/mitchej123/hodgepodge/asm/util/AbstractClassTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/util/AbstractClassTransformer.java
@@ -22,9 +22,11 @@ public abstract class AbstractClassTransformer implements IClassTransformer {
     protected Namespace environment = Namespace.MCP;
 
     private final Map<String, Map<MethodRef, AbstractMethodTransformer>> methodTransformers = Maps.newHashMap();
+    private final Map<String, Integer> classWriterFlags = Maps.newHashMap();
 
-    protected void addMethodTransformer(MethodRef ref, AbstractMethodTransformer methodTransformer) {
+    protected void addMethodTransformer(MethodRef ref, int classWriterFlag, AbstractMethodTransformer methodTransformer) {
         methodTransformers.computeIfAbsent(ref.parent.getName(Namespace.MCP), n -> Maps.newHashMap()).put(ref, methodTransformer);
+        classWriterFlags.merge(ref.parent.getName(Namespace.MCP), classWriterFlag, Integer::max);
     }
 
     @Override
@@ -80,7 +82,7 @@ public abstract class AbstractClassTransformer implements IClassTransformer {
         }
 
         // return result
-        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter writer = new ClassWriter(classWriterFlags.getOrDefault(transformedName, ClassWriter.COMPUTE_FRAMES));
         if (hasTransformed) classNode.accept(writer);
         return !hasTransformed ? basicClass : writer.toByteArray();
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft.java
@@ -18,7 +18,7 @@ public class MixinMinecraft {
     /*
      *  LWJGL bug https://bugs.mojang.com/browse/MC-68754?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=true
      */
-    @Inject(method = "toggleFullscreen", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;setVSyncEnabled(Z)V"))
+    @Inject(method = "toggleFullscreen", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;setVSyncEnabled(Z)V", remap = false))
     private void toggleResizable(CallbackInfo ci) {
         if (!this.fullscreen && (Util.getOSType() == Util.EnumOS.WINDOWS)) {
             Display.setResizable(false);


### PR DESCRIPTION
Mere injection of hooks usually does not require COMPUTE_FRAMES. This makes the pollution class a little bit more mixin/asm friendly.