### PR TITLE
RenderItem mixin

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -40,7 +40,8 @@ public enum Mixins {
             "minecraft.textures.client.MixinChunkCache",
             "minecraft.textures.client.MixinRenderBlocks",
             "minecraft.textures.client.MixinRenderBlockFluid",
-            "minecraft.textures.client.MixinWorldRenderer"),
+            "minecraft.textures.client.MixinWorldRenderer",
+            "minecraft.textures.client.MixinRenderItem"),
     SPEEDUP_VANILLA_ANIMATIONS_FC("minecraft.textures.client.fastcraft.MixinTextureMap", Side.CLIENT, () -> Hodgepodge.config.speedupAnimations, TargetedMod.FASTCRAFT),
     FIX_POTION_ITERATING("minecraft.MixinEntityLivingPotions", Side.BOTH, () -> Hodgepodge.config.fixPotionIterating, TargetedMod.VANILLA),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/textures/client/MixinRenderItem.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/textures/client/MixinRenderItem.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.minecraft.textures.client;
+
+import com.mitchej123.hodgepodge.core.textures.IPatchedTextureAtlasSprite;
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.util.IIcon;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderItem.class)
+public class MixinRenderItem {
+
+    /**
+     * Some mods may call it to render their internally stored icons, so we make sure we mark those for an update
+     */
+    @Inject(method = "renderIcon", at = @At("HEAD"))
+    private void beforeRenderIcon(int p_94149_1_, int p_94149_2_, IIcon icon, int p_94149_4_, int p_94149_5_, CallbackInfo ci) {
+        if (icon instanceof TextureAtlasSprite) {
+            ((IPatchedTextureAtlasSprite) icon).markNeedsAnimationUpdate();
+        }
+    }
+}


### PR DESCRIPTION
Mark any icon that gets rendered for an animation update, this method can be called by other mods to render their internally stored IIcon so we make sure we mark those for an update.