### PR TITLE
Move animationsMode debug info to the right

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
@@ -43,7 +43,8 @@ public class DebugScreenHandler {
             event.right.add(7, "OS: " + this.osName + " (" + this.osVersion + ", " + this.osArch + ")");
 
             if (Hodgepodge.config.speedupAnimations) {
-                event.left.add("animationsMode: " + HodgePodgeClient.animationsMode);
+                event.right.add(8, null); // Empty Line
+                event.right.add(9, "animationsMode: " + HodgePodgeClient.animationsMode);
             }
         }
     }


### PR DESCRIPTION
Since a lot of mods add custom info to the left side it becomes a mess quickly, and it doesn't look nice at there.

![image](https://user-images.githubusercontent.com/87545780/187512810-e7282a1e-88cd-4f7f-84bc-83748991920d.png)
