### PR TITLE
Fix vanilla potion effects rendering above the NEI tooltips in the inventory

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/asm/HodgePodgeASMLoader.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/HodgePodgeASMLoader.java
@@ -38,7 +38,7 @@ public class HodgePodgeASMLoader implements IFMLLoadingPlugin {
                 () -> Hodgepodge.config.speedupProgressBar,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.SpeedupProgressBarTransformer")),
         FIX_POTION_EFFECT_RENDERING(
-                "Move vanilla potion effect status rendering before everything else",
+                "Fix vanilla potion effects rendering above the NEI tooltips in the inventory",
                 () -> Hodgepodge.config.fixPotionEffectRender,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.InventoryEffectRendererTransformer")),
         THERMOS_SLEDGEHAMMER_FURNACE_FIX(

--- a/src/main/java/com/mitchej123/hodgepodge/asm/InventoryEffectRendererTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/InventoryEffectRendererTransformer.java
@@ -4,8 +4,7 @@ import com.mitchej123.hodgepodge.asm.util.AbstractClassTransformer;
 import com.mitchej123.hodgepodge.asm.util.AbstractMethodTransformer;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.AbstractInsnNode;
-import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.*;
 
 public class InventoryEffectRendererTransformer extends AbstractClassTransformer {
     public InventoryEffectRendererTransformer() {
@@ -15,25 +14,141 @@ public class InventoryEffectRendererTransformer extends AbstractClassTransformer
                 new AbstractMethodTransformer() {
                     @Override
                     public void transform() {
-                        // Cut out super.drawScreen() sequence
-                        AbstractInsnNode start =
-                                findNext(currentMethod.instructions.getFirst(), matchOpcode(Opcodes.ALOAD));
-                        // this cannot be InsnList, because it would prematurely take ownership of the removed
-                        // instructions
-                        AbstractInsnNode[] instToMove = new AbstractInsnNode[5];
-                        for (int i = 0; i < 5; ++i) {
-                            instToMove[i] = start;
-                            start = start.getNext();
-                        }
-                        for (int i = 0; i < 5; ++i) currentMethod.instructions.remove(instToMove[i]);
 
-                        // And paste it 2 instructions below status effect rendering (after the label)
-                        InsnList listMove = new InsnList();
-                        for (AbstractInsnNode n : instToMove) listMove.add(n);
-                        AbstractInsnNode inv =
-                                findNext(currentMethod.instructions.getFirst(), matchOpcode(Opcodes.INVOKESPECIAL));
+                        final String NEIClientConfigClasspath = "codechicken/nei/NEIClientConfig";
+                        try {
+                            if (this.getClass().getClassLoader().getResource(NEIClientConfigClasspath + ".class") == null) {
+                                log.info("Skip reordering InventoryEffectRenderer.drawScreen since NEI is not loaded");
+                                return;
+                            }
+                        } catch (Exception ignored) {
+                        }
+
+                        /*
+                        ============ORIGINAL CODE=========
+
+                         super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
+                         if (this.field_147045_u) {
+                             this.func_147044_g();
+                         }
+
+                         ============TARGET CODE==========
+
+                         boolean bookmarkPanelHidden = NEIClientConfig.isHidden();
+                         if (bookmarkPanelHidden) {
+                             super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
+                         }
+                         if (this.field_147045_u) {
+                             this.func_147044_g();
+                         }
+                         if (bookmarkPanelHidden) {
+                             return;
+                         }
+                         super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
+
+                         ==========TARGET BYTECODE========
+
+                         L0
+                         INVOKESTATIC codechicken/nei/NEIClientConfig.isHidden ()Z
+                         DUP
+                         ISTORE 4
+                         IFEQ L5
+                         LINENUMBER 44 L0
+                         ALOAD 0
+                         ILOAD 1
+                         ILOAD 2
+                         FLOAD 3
+                         INVOKESPECIAL net/minecraft/client/gui/inventory/GuiContainer.drawScreen (IIF)V
+                        L5
+                        L1
+                         LINENUMBER 46 L1
+                         ALOAD 0
+                         GETFIELD net/minecraft/client/renderer/InventoryEffectRenderer.field_147045_u : Z
+                         IFEQ L2
+                        L3
+                         LINENUMBER 48 L3
+                         ALOAD 0
+                         INVOKESPECIAL net/minecraft/client/renderer/InventoryEffectRenderer.func_147044_g ()V
+                        L2
+                         ILOAD 4
+                         IFEQ L6
+                         RETURN
+                        L6
+                         ALOAD 0
+                         ILOAD 1
+                         ILOAD 2
+                         FLOAD 3
+                         INVOKESPECIAL net/minecraft/client/gui/inventory/GuiContainer.drawScreen (IIF)V
+                         LINENUMBER 50 L2
+                        FRAME SAME
+                         RETURN
+                        L4
+                         */
+
+                        AbstractInsnNode startNodeSuperCall = findNext(currentMethod.instructions.getFirst(), matchOpcode(Opcodes.ALOAD));
+                        InsnList superCallInsnList = new InsnList();
+                        for (int i = 0; i < 5; ++i) {
+                            superCallInsnList.add(startNodeSuperCall.clone(null));
+                            startNodeSuperCall = startNodeSuperCall.getNext();
+                        }
+
+                        int ordinal = 0;
+                        AbstractInsnNode drawScreenMethodeInsnNode = null;
+                        AbstractInsnNode drawPotionEffectsNode = null;
+                        for (AbstractInsnNode insnNode : currentMethod.instructions.toArray()) {
+                            if (insnNode instanceof MethodInsnNode && insnNode.getOpcode() == Opcodes.INVOKESPECIAL) {
+                                if (ordinal == 0) {
+                                    drawScreenMethodeInsnNode = insnNode;
+                                    ordinal++;
+                                    continue;
+                                }
+                                if (ordinal == 1) {
+                                    drawPotionEffectsNode = insnNode;
+                                }
+                            }
+                        }
+
+                        if (drawScreenMethodeInsnNode == null || drawPotionEffectsNode == null) {
+                            log.info("Failed reordering InventoryEffectRenderer.drawScreen");
+                            return;
+                        }
+
+                        /*
+                         * Injects before super call :
+                         * boolean bookmarkPanelHidden = NEIClientConfig.isHidden();
+                         * if (bookmarkPanelHidden) {
+                         */
+                        LabelNode skipFirstIfLabel = new LabelNode();
+                        InsnList headInjectionList = new InsnList();
+                        headInjectionList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, NEIClientConfigClasspath, "isHidden", "()Z", false));
+                        headInjectionList.add(new InsnNode(Opcodes.DUP));
+                        headInjectionList.add(new VarInsnNode(Opcodes.ISTORE, 4));
+                        headInjectionList.add(new JumpInsnNode(Opcodes.IFEQ, skipFirstIfLabel));
+                        currentMethod.instructions.insert(currentMethod.instructions.getFirst(), headInjectionList);
+
+                        /*
+                         * Injects end of first if after the drawScreen super call
+                         */
+                        currentMethod.instructions.insert(drawScreenMethodeInsnNode, skipFirstIfLabel);
+
+                        /*
+                         * Injects at the end of the method :
+                         * if(bookmarkPanelHidden){
+                         *      return;
+                         * }
+                         * super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
+                         */
+                        InsnList secondDrawScreenInsnList = new InsnList();
+                        LabelNode skipSecondIfLabel = new LabelNode();
+                        secondDrawScreenInsnList.add(new VarInsnNode(Opcodes.ILOAD, 4));
+                        secondDrawScreenInsnList.add(new JumpInsnNode(Opcodes.IFEQ, skipSecondIfLabel));
+                        secondDrawScreenInsnList.add(new InsnNode(Opcodes.RETURN));
+                        secondDrawScreenInsnList.add(skipSecondIfLabel);
+                        secondDrawScreenInsnList.add(superCallInsnList);
+                        currentMethod.instructions.insert(drawPotionEffectsNode.getNext(), secondDrawScreenInsnList);
+
+                        currentMethod.maxLocals = 5;
                         log.info("Reordering InventoryEffectRenderer.drawScreen");
-                        currentMethod.instructions.insert(inv.getNext(), listMove);
                     }
                 });
     }

--- a/src/main/java/com/mitchej123/hodgepodge/asm/InventoryEffectRendererTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/InventoryEffectRendererTransformer.java
@@ -17,7 +17,8 @@ public class InventoryEffectRendererTransformer extends AbstractClassTransformer
 
                         final String NEIClientConfigClasspath = "codechicken/nei/NEIClientConfig";
                         try {
-                            if (this.getClass().getClassLoader().getResource(NEIClientConfigClasspath + ".class") == null) {
+                            if (this.getClass().getClassLoader().getResource(NEIClientConfigClasspath + ".class")
+                                    == null) {
                                 log.info("Skip reordering InventoryEffectRenderer.drawScreen since NEI is not loaded");
                                 return;
                             }
@@ -85,7 +86,8 @@ public class InventoryEffectRendererTransformer extends AbstractClassTransformer
                         L4
                          */
 
-                        AbstractInsnNode startNodeSuperCall = findNext(currentMethod.instructions.getFirst(), matchOpcode(Opcodes.ALOAD));
+                        AbstractInsnNode startNodeSuperCall =
+                                findNext(currentMethod.instructions.getFirst(), matchOpcode(Opcodes.ALOAD));
                         InsnList superCallInsnList = new InsnList();
                         for (int i = 0; i < 5; ++i) {
                             superCallInsnList.add(startNodeSuperCall.clone(null));
@@ -120,7 +122,8 @@ public class InventoryEffectRendererTransformer extends AbstractClassTransformer
                          */
                         LabelNode skipFirstIfLabel = new LabelNode();
                         InsnList headInjectionList = new InsnList();
-                        headInjectionList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, NEIClientConfigClasspath, "isHidden", "()Z", false));
+                        headInjectionList.add(new MethodInsnNode(
+                                Opcodes.INVOKESTATIC, NEIClientConfigClasspath, "isHidden", "()Z", false));
                         headInjectionList.add(new InsnNode(Opcodes.DUP));
                         headInjectionList.add(new VarInsnNode(Opcodes.ISTORE, 4));
                         headInjectionList.add(new JumpInsnNode(Opcodes.IFEQ, skipFirstIfLabel));

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -222,7 +222,7 @@ public class LoadingConfig {
                         "tweaks",
                         "fixPotionEffectRender",
                         true,
-                        "Move vanilla potion effect status rendering before everything else")
+                        "Fix vanilla potion effects rendering above the NEI tooltips in the inventory")
                 .getBoolean();
         installAnchorAlarm = config.get(
                         "tweaks", "installAnchorAlarm", true, "Wake up passive & personal anchors on player login")


### PR DESCRIPTION
this was already fixed before but it made the potion effect render with a shadow when NEI was hidden, so I changed it to make it render in the foreground when NEI is hidden and in the background if NEI is open

![image](https://user-images.githubusercontent.com/57050655/187790310-19f7ac6b-1769-44e7-8fc0-48992d941ae5.png)
![image](https://user-images.githubusercontent.com/57050655/187790330-520b69c2-1f41-4015-b2ba-8b4df5d717e5.png)
