### PR TITLE
implement an opt-in render debug mode

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
@@ -42,9 +42,11 @@ public class DebugScreenHandler {
             event.right.add(6, "CPU Cores: " + Runtime.getRuntime().availableProcessors());
             event.right.add(7, "OS: " + this.osName + " (" + this.osVersion + ", " + this.osArch + ")");
 
-            if (Hodgepodge.config.speedupAnimations) {
+            if (Hodgepodge.config.speedupAnimations || Hodgepodge.config.renderDebug) {
                 event.right.add(8, null); // Empty Line
                 event.right.add(9, "animationsMode: " + HodgePodgeClient.animationsMode);
+                if (Hodgepodge.config.renderDebug)
+                    event.right.add(9, "renderDebugMode: " + HodgePodgeClient.renderDebugMode);
             }
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
@@ -44,7 +44,8 @@ public class DebugScreenHandler {
 
             if (Hodgepodge.config.speedupAnimations || Hodgepodge.config.renderDebug) {
                 event.right.add(8, null); // Empty Line
-                event.right.add(9, "animationsMode: " + HodgePodgeClient.animationsMode);
+                if (Hodgepodge.config.speedupAnimations)
+                    event.right.add(9, "animationsMode: " + HodgePodgeClient.animationsMode);
                 if (Hodgepodge.config.renderDebug)
                     event.right.add(9, "renderDebugMode: " + HodgePodgeClient.renderDebugMode);
             }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
@@ -15,8 +15,8 @@ import net.minecraftforge.common.MinecraftForge;
 
 public class HodgePodgeClient {
     public static Method colorGrass, colorLiquid, colorLeaves, colorFoliage;
-    public static final ManagedEnum<AnimationMode> animationsMode = new ManagedEnum<>(AnimationMode.AnimateVisible);
-    public static final ManagedEnum<RenderDebugMode> renderDebugMode = new ManagedEnum<>(RenderDebugMode.Reduced);
+    public static final ManagedEnum<AnimationMode> animationsMode = new ManagedEnum<>(AnimationMode.VISIBLE_ONLY);
+    public static final ManagedEnum<RenderDebugMode> renderDebugMode = new ManagedEnum<>(RenderDebugMode.REDUCED);
 
     public static void postInit() {
         colorGrass = References.gt_PollutionRenderer.getMethod("colorGrass").resolve();
@@ -27,7 +27,7 @@ public class HodgePodgeClient {
         if (Hodgepodge.config.renderDebug) {
             renderDebugMode.set(Hodgepodge.config.renderDebugMode);
         } else {
-            renderDebugMode.set(RenderDebugMode.Off);
+            renderDebugMode.set(RenderDebugMode.OFF);
         }
 
         if (colorGrass != null) {
@@ -84,14 +84,14 @@ public class HodgePodgeClient {
     }
 
     public enum AnimationMode {
-        NoAnimation,
-        AnimateVisible,
-        AnimateAll;
+        NONE,
+        VISIBLE_ONLY,
+        ALL;
     }
 
     public enum RenderDebugMode {
-        Off,
-        Reduced,
-        Full;
+        OFF,
+        REDUCED,
+        FULL;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
@@ -6,6 +6,7 @@ import com.mitchej123.hodgepodge.client.ClientTicker;
 import com.mitchej123.hodgepodge.client.DebugScreenHandler;
 import com.mitchej123.hodgepodge.core.handlers.ClientKeyListener;
 import com.mitchej123.hodgepodge.core.util.ColorOverrideType;
+import com.mitchej123.hodgepodge.core.util.ManagedEnum;
 import cpw.mods.fml.common.FMLCommonHandler;
 import java.lang.reflect.Method;
 import net.minecraft.block.Block;
@@ -14,10 +15,8 @@ import net.minecraftforge.common.MinecraftForge;
 
 public class HodgePodgeClient {
     public static Method colorGrass, colorLiquid, colorLeaves, colorFoliage;
-    // 0 - render no animations 1 - render visible animations 2 - render all animations
-    public static int animationsMode = 1;
-    // 0 - no debug 1 - reduced 2 - full
-    public static int renderDebugMode = 0;
+    public static final ManagedEnum<AnimationMode> animationsMode = new ManagedEnum<>(AnimationMode.AnimateVisible);
+    public static final ManagedEnum<RenderDebugMode> renderDebugMode = new ManagedEnum<>(RenderDebugMode.Reduced);
 
     public static void postInit() {
         colorGrass = References.gt_PollutionRenderer.getMethod("colorGrass").resolve();
@@ -25,7 +24,11 @@ public class HodgePodgeClient {
         colorLeaves = References.gt_PollutionRenderer.getMethod("colorLeaves").resolve();
         colorFoliage = References.gt_PollutionRenderer.getMethod("colorFoliage").resolve();
 
-        renderDebugMode = Hodgepodge.config.renderDebug ? Hodgepodge.config.renderDebugMode : 0;
+        if (Hodgepodge.config.renderDebug) {
+            renderDebugMode.set(Hodgepodge.config.renderDebugMode);
+        } else {
+            renderDebugMode.set(RenderDebugMode.Off);
+        }
 
         if (colorGrass != null) {
             LoadingConfig.postInitClient();
@@ -78,5 +81,17 @@ public class HodgePodgeClient {
         ColorOverrideType type = LoadingConfig.blockVine.matchesID(block);
         if (type == null) return oColor;
         return type.getColor(oColor, x, z);
+    }
+
+    public enum AnimationMode {
+        NoAnimation,
+        AnimateVisible,
+        AnimateAll;
+    }
+
+    public enum RenderDebugMode {
+        Off,
+        Reduced,
+        Full;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
@@ -16,12 +16,17 @@ public class HodgePodgeClient {
     public static Method colorGrass, colorLiquid, colorLeaves, colorFoliage;
     // 0 - render no animations 1 - render visible animations 2 - render all animations
     public static int animationsMode = 1;
+    // 0 - no debug 1 - reduced 2 - full
+    public static int renderDebugMode = 0;
 
     public static void postInit() {
         colorGrass = References.gt_PollutionRenderer.getMethod("colorGrass").resolve();
         colorLiquid = References.gt_PollutionRenderer.getMethod("colorLiquid").resolve();
         colorLeaves = References.gt_PollutionRenderer.getMethod("colorLeaves").resolve();
         colorFoliage = References.gt_PollutionRenderer.getMethod("colorFoliage").resolve();
+
+        renderDebugMode = Hodgepodge.config.renderDebug ? Hodgepodge.config.renderDebugMode : 0;
+
         if (colorGrass != null) {
             LoadingConfig.postInitClient();
             MinecraftForge.EVENT_BUS.register(LoadingConfig.standardBlocks);

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -333,6 +333,8 @@ public class LoadingConfig {
                 .getBoolean();
         renderDebugMode = config.get(
                         "debug", "renderDebugMode", 0, "Default GL state debug mode. 0 - off, 1 - reduced, 2 - full")
+                .setMinValue(0)
+                .setMaxValue(2)
                 .getInt();
         if (config.hasChanged()) config.save();
     }

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -66,6 +66,10 @@ public class LoadingConfig {
     public boolean fixNetherLeavesFaceRendering;
     public boolean optimizeASMDataTable;
 
+    // render debug
+    public boolean renderDebug;
+    public int renderDebugMode;
+
     // ASM
     public boolean pollutionAsm;
     public boolean cofhWorldTransformer;
@@ -211,7 +215,7 @@ public class LoadingConfig {
                         "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too")
                 .getBoolean();
         optimizeASMDataTable = config.get(
-                        "fixes",
+                        "speedups",
                         "optimizeASMDataTable",
                         true,
                         "Optimize ASMDataTable getAnnotationsFor for faster startup")
@@ -321,6 +325,15 @@ public class LoadingConfig {
                         "If using Bukkit/Thermos, the CraftServer package.")
                 .getString();
 
+        renderDebug = config.get(
+                        "debug",
+                        "renderDebug",
+                        true,
+                        "Enable GL state debug hooks. Will not do anything useful unless mode is changed to nonzero.")
+                .getBoolean();
+        renderDebugMode = config.get(
+                        "debug", "renderDebugMode", 0, "Default GL state debug mode. 0 - off, 1 - reduced, 2 - full")
+                .getInt();
         if (config.hasChanged()) config.save();
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/core/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/handlers/ClientKeyListener.java
@@ -19,11 +19,9 @@ public class ClientKeyListener {
         boolean released = !Keyboard.getEventKeyState();
         if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown() && released) {
             if (key == Keyboard.KEY_N) {
-                HodgePodgeClient.animationsMode =
-                        HodgePodgeClient.animationsMode == 2 ? 0 : ++HodgePodgeClient.animationsMode;
+                HodgePodgeClient.animationsMode.next();
             } else if (key == Keyboard.KEY_D && Hodgepodge.config.renderDebug) {
-                HodgePodgeClient.renderDebugMode =
-                        HodgePodgeClient.renderDebugMode == 2 ? 0 : ++HodgePodgeClient.renderDebugMode;
+                HodgePodgeClient.renderDebugMode.next();
             }
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/core/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/handlers/ClientKeyListener.java
@@ -1,5 +1,6 @@
 package com.mitchej123.hodgepodge.core.handlers;
 
+import com.mitchej123.hodgepodge.Hodgepodge;
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
@@ -16,12 +17,14 @@ public class ClientKeyListener {
     public void keyUp(InputEvent.KeyInputEvent event) {
         int key = Keyboard.getEventKey();
         boolean released = !Keyboard.getEventKeyState();
-        if (Minecraft.getMinecraft().gameSettings.showDebugInfo
-                && GuiScreen.isShiftKeyDown()
-                && key == Keyboard.KEY_N
-                && released) {
-            HodgePodgeClient.animationsMode =
-                    HodgePodgeClient.animationsMode == 2 ? 0 : ++HodgePodgeClient.animationsMode;
+        if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown() && released) {
+            if (key == Keyboard.KEY_N) {
+                HodgePodgeClient.animationsMode =
+                        HodgePodgeClient.animationsMode == 2 ? 0 : ++HodgePodgeClient.animationsMode;
+            } else if (key == Keyboard.KEY_D && Hodgepodge.config.renderDebug) {
+                HodgePodgeClient.renderDebugMode =
+                        HodgePodgeClient.renderDebugMode == 2 ? 0 : ++HodgePodgeClient.renderDebugMode;
+            }
         }
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/util/ManagedEnum.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/util/ManagedEnum.java
@@ -1,0 +1,51 @@
+package com.mitchej123.hodgepodge.core.util;
+
+public class ManagedEnum<T extends Enum<?>> {
+    private final T[] allValues;
+    private T value;
+
+    public ManagedEnum(T initialValue) {
+        if (initialValue == null) throw new IllegalArgumentException();
+        value = initialValue;
+        @SuppressWarnings("unchecked")
+        T[] allValues = (T[]) value.getClass().getEnumConstants();
+        this.allValues = allValues;
+    }
+
+    public boolean is(T value) {
+        return this.value == value;
+    }
+
+    public T next() {
+        value = allValues[(value.ordinal() + 1) % allValues.length];
+        return value;
+    }
+
+    public void set(T value) {
+        this.value = value;
+    }
+
+    public void set(int ordinal) {
+        this.value = allValues[Math.min(Math.max(0, ordinal), allValues.length - 1)];
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ManagedEnum<?> that = (ManagedEnum<?>) o;
+
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/core/util/RenderDebugHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/util/RenderDebugHelper.java
@@ -19,6 +19,7 @@ import static org.lwjgl.opengl.GL20.GL_VERTEX_PROGRAM_TWO_SIDE;
 
 import com.google.common.collect.ImmutableMap;
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
+import com.mitchej123.hodgepodge.core.HodgePodgeClient.RenderDebugMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -154,7 +155,7 @@ public class RenderDebugHelper {
     private static final List<String> errorBuffer = new ArrayList<>(32);
 
     public static void recordGLStates() {
-        if (HodgePodgeClient.renderDebugMode == 1) {
+        if (HodgePodgeClient.renderDebugMode.is(RenderDebugMode.Reduced)) {
             saved_GL_BLEND = GL11.glGetBoolean(GL_BLEND);
             saved_GL_ALPHA_TEST = GL11.glGetBoolean(GL_ALPHA_TEST);
             saved_GL_CULL_FACE = GL11.glGetBoolean(GL_CULL_FACE);
@@ -246,7 +247,7 @@ public class RenderDebugHelper {
 
     public static boolean checkGLStates() {
         errorBuffer.clear();
-        if (HodgePodgeClient.renderDebugMode == 1) {
+        if (HodgePodgeClient.renderDebugMode.is(RenderDebugMode.Reduced)) {
             if (GL11.glGetBoolean(GL_BLEND) != saved_GL_BLEND) errorBuffer.add("GL_BLEND");
             if (GL11.glGetBoolean(GL_ALPHA_TEST) != saved_GL_ALPHA_TEST) errorBuffer.add("GL_ALPHA_TEST");
             if (GL11.glGetBoolean(GL_CULL_FACE) != saved_GL_CULL_FACE) errorBuffer.add("GL_CULL_FACE");

--- a/src/main/java/com/mitchej123/hodgepodge/core/util/RenderDebugHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/util/RenderDebugHelper.java
@@ -155,7 +155,7 @@ public class RenderDebugHelper {
     private static final List<String> errorBuffer = new ArrayList<>(32);
 
     public static void recordGLStates() {
-        if (HodgePodgeClient.renderDebugMode.is(RenderDebugMode.Reduced)) {
+        if (HodgePodgeClient.renderDebugMode.is(RenderDebugMode.REDUCED)) {
             saved_GL_BLEND = GL11.glGetBoolean(GL_BLEND);
             saved_GL_ALPHA_TEST = GL11.glGetBoolean(GL_ALPHA_TEST);
             saved_GL_CULL_FACE = GL11.glGetBoolean(GL_CULL_FACE);
@@ -247,7 +247,7 @@ public class RenderDebugHelper {
 
     public static boolean checkGLStates() {
         errorBuffer.clear();
-        if (HodgePodgeClient.renderDebugMode.is(RenderDebugMode.Reduced)) {
+        if (HodgePodgeClient.renderDebugMode.is(RenderDebugMode.REDUCED)) {
             if (GL11.glGetBoolean(GL_BLEND) != saved_GL_BLEND) errorBuffer.add("GL_BLEND");
             if (GL11.glGetBoolean(GL_ALPHA_TEST) != saved_GL_ALPHA_TEST) errorBuffer.add("GL_ALPHA_TEST");
             if (GL11.glGetBoolean(GL_CULL_FACE) != saved_GL_CULL_FACE) errorBuffer.add("GL_CULL_FACE");

--- a/src/main/java/com/mitchej123/hodgepodge/core/util/RenderDebugHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/util/RenderDebugHelper.java
@@ -1,0 +1,359 @@
+package com.mitchej123.hodgepodge.core.util;
+
+import static org.lwjgl.opengl.ARBImaging.*;
+import static org.lwjgl.opengl.ARBImaging.GL_POST_COLOR_MATRIX_COLOR_TABLE;
+import static org.lwjgl.opengl.ARBImaging.GL_POST_CONVOLUTION_COLOR_TABLE;
+import static org.lwjgl.opengl.ARBImaging.GL_SEPARABLE_2D;
+import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_FUNC;
+import static org.lwjgl.opengl.GL11.GL_VERTEX_ARRAY;
+import static org.lwjgl.opengl.GL12.GL_RESCALE_NORMAL;
+import static org.lwjgl.opengl.GL12.GL_TEXTURE_3D;
+import static org.lwjgl.opengl.GL13.*;
+import static org.lwjgl.opengl.GL14.*;
+import static org.lwjgl.opengl.GL14.GL_BLEND_SRC_RGB;
+import static org.lwjgl.opengl.GL15.GL_FOG_COORD_ARRAY;
+import static org.lwjgl.opengl.GL20.GL_POINT_SPRITE;
+import static org.lwjgl.opengl.GL20.GL_VERTEX_PROGRAM_POINT_SIZE;
+import static org.lwjgl.opengl.GL20.GL_VERTEX_PROGRAM_TWO_SIDE;
+
+import com.google.common.collect.ImmutableMap;
+import com.mitchej123.hodgepodge.core.HodgePodgeClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.lwjgl.opengl.GL11;
+// spotless:off
+// @formatter:off
+// this file is formatted in such a way that makes block/sed/other line based editing easy.
+// formatter will usually screw this up by introducing line breaks when it uses some very long GL constants, or I placed
+// too much content (maybe even multiple statements), so we will turn them off here.
+
+public class RenderDebugHelper {
+    public static final Logger log = LogManager.getLogger("RenderDebug");
+    /*
+    Reduced states considers only these states
+
+    GL_BLEND
+    GL_ALPHA_TEST
+    GL_CULL_FACE
+    GL_DEPTH_TEST
+    GL_RESCALE_NORMAL
+    GL_DEPTH_FUNC
+    */
+    // boolean states
+    private static boolean saved_GL_ALPHA_TEST;
+    private static boolean saved_GL_AUTO_NORMAL;
+    private static boolean saved_GL_BLEND;
+    private static boolean saved_GL_COLOR_ARRAY;
+    private static boolean saved_GL_COLOR_LOGIC_OP;
+    private static boolean saved_GL_COLOR_MATERIAL;
+    private static boolean saved_GL_COLOR_SUM;
+    private static boolean saved_GL_COLOR_TABLE;
+    private static boolean saved_GL_CONVOLUTION_1D;
+    private static boolean saved_GL_CONVOLUTION_2D;
+    private static boolean saved_GL_CULL_FACE;
+    private static boolean saved_GL_DEPTH_TEST;
+    private static boolean saved_GL_DITHER;
+    private static boolean saved_GL_EDGE_FLAG_ARRAY;
+    private static boolean saved_GL_FOG;
+    private static boolean saved_GL_FOG_COORD_ARRAY;
+    private static boolean saved_GL_HISTOGRAM;
+    private static boolean saved_GL_INDEX_ARRAY;
+    private static boolean saved_GL_INDEX_LOGIC_OP;
+    private static boolean saved_GL_LIGHTING;
+    private static boolean saved_GL_LINE_SMOOTH;
+    private static boolean saved_GL_LINE_STIPPLE;
+    private static boolean saved_GL_MAP1_COLOR_4;
+    private static boolean saved_GL_MAP1_INDEX;
+    private static boolean saved_GL_MAP1_NORMAL;
+    private static boolean saved_GL_MAP1_TEXTURE_COORD_1;
+    private static boolean saved_GL_MAP1_TEXTURE_COORD_2;
+    private static boolean saved_GL_MAP1_TEXTURE_COORD_3;
+    private static boolean saved_GL_MAP1_TEXTURE_COORD_4;
+    private static boolean saved_GL_MAP2_COLOR_4;
+    private static boolean saved_GL_MAP2_INDEX;
+    private static boolean saved_GL_MAP2_NORMAL;
+    private static boolean saved_GL_MAP2_TEXTURE_COORD_1;
+    private static boolean saved_GL_MAP2_TEXTURE_COORD_2;
+    private static boolean saved_GL_MAP2_TEXTURE_COORD_3;
+    private static boolean saved_GL_MAP2_TEXTURE_COORD_4;
+    private static boolean saved_GL_MAP2_VERTEX_3;
+    private static boolean saved_GL_MAP2_VERTEX_4;
+    private static boolean saved_GL_MINMAX;
+    private static boolean saved_GL_MULTISAMPLE;
+    private static boolean saved_GL_NORMAL_ARRAY;
+    private static boolean saved_GL_NORMALIZE;
+    private static boolean saved_GL_POINT_SMOOTH;
+    private static boolean saved_GL_POINT_SPRITE;
+    private static boolean saved_GL_POLYGON_SMOOTH;
+    private static boolean saved_GL_POLYGON_OFFSET_FILL;
+    private static boolean saved_GL_POLYGON_OFFSET_LINE;
+    private static boolean saved_GL_POLYGON_OFFSET_POINT;
+    private static boolean saved_GL_POLYGON_STIPPLE;
+    private static boolean saved_GL_POST_COLOR_MATRIX_COLOR_TABLE;
+    private static boolean saved_GL_POST_CONVOLUTION_COLOR_TABLE;
+    private static boolean saved_GL_RESCALE_NORMAL;
+    private static boolean saved_GL_SAMPLE_ALPHA_TO_COVERAGE;
+    private static boolean saved_GL_SAMPLE_ALPHA_TO_ONE;
+    private static boolean saved_GL_SAMPLE_COVERAGE;
+    private static boolean saved_GL_SCISSOR_TEST;
+    private static boolean saved_GL_SECONDARY_COLOR_ARRAY;
+    private static boolean saved_GL_SEPARABLE_2D;
+    private static boolean saved_GL_STENCIL_TEST;
+    private static boolean saved_GL_TEXTURE_1D;
+    private static boolean saved_GL_TEXTURE_2D;
+    private static boolean saved_GL_TEXTURE_3D;
+    private static boolean saved_GL_TEXTURE_COORD_ARRAY;
+    private static boolean saved_GL_TEXTURE_CUBE_MAP;
+    private static boolean saved_GL_TEXTURE_GEN_Q;
+    private static boolean saved_GL_TEXTURE_GEN_R;
+    private static boolean saved_GL_TEXTURE_GEN_S;
+    private static boolean saved_GL_TEXTURE_GEN_T;
+    private static boolean saved_GL_VERTEX_ARRAY;
+    private static boolean saved_GL_VERTEX_PROGRAM_POINT_SIZE;
+    private static boolean saved_GL_VERTEX_PROGRAM_TWO_SIDE;
+    // int states
+    private static int saved_GL_ALPHA_TEST_FUNC;
+    private static int saved_GL_DEPTH_FUNC;
+    private static int saved_GL_BLEND_DST_ALPHA;
+    private static int saved_GL_BLEND_DST_RGB;
+    private static int saved_GL_BLEND_SRC_ALPHA;
+    private static int saved_GL_BLEND_SRC_RGB;
+    // double states
+    private static float saved_GL_ALPHA_TEST_REF;
+
+    private static final Map<Integer, String> functions = ImmutableMap.<Integer, String>builder()
+            .put(GL11.GL_NEVER, "GL_NEVER")
+            .put(GL11.GL_LESS, "GL_LESS")
+            .put(GL11.GL_EQUAL, "GL_EQUAL")
+            .put(GL11.GL_LEQUAL, "GL_LEQUAL")
+            .put(GL11.GL_GREATER, "GL_GREATER")
+            .put(GL11.GL_NOTEQUAL, "GL_NOTEQUAL")
+            .put(GL11.GL_GEQUAL, "GL_GEQUAL")
+            .put(GL11.GL_ALWAYS, "GL_ALWAYS")
+            .put(GL11.GL_ZERO, "GL_ZERO")
+            .put(GL11.GL_ONE, "GL_ONE")
+            .put(GL11.GL_SRC_COLOR, "GL_SRC_COLOR")
+            .put(GL11.GL_ONE_MINUS_SRC_COLOR, "GL_ONE_MINUS_SRC_COLOR")
+            .put(GL11.GL_DST_COLOR, "GL_DST_COLOR")
+            .put(GL11.GL_ONE_MINUS_DST_COLOR, "GL_ONE_MINUS_DST_COLOR")
+            .put(GL11.GL_SRC_ALPHA, "GL_SRC_ALPHA")
+            .put(GL11.GL_ONE_MINUS_SRC_ALPHA, "GL_ONE_MINUS_SRC_ALPHA")
+            .put(GL11.GL_DST_ALPHA, "GL_DST_ALPHA")
+            .put(GL11.GL_ONE_MINUS_DST_ALPHA, "GL_ONE_MINUS_DST_ALPHA")
+            .put(GL11.GL_CONSTANT_COLOR, "GL_CONSTANT_COLOR")
+            .put(GL11.GL_ONE_MINUS_CONSTANT_COLOR, "GL_ONE_MINUS_CONSTANT_COLOR")
+            .put(GL11.GL_CONSTANT_ALPHA, "GL_CONSTANT_ALPHA")
+            .put(GL11.GL_ONE_MINUS_CONSTANT_ALPHA, "GL_ONE_MINUS_CONSTANT_ALPHA")
+            .put(GL11.GL_SRC_ALPHA_SATURATE, "GL_SRC_ALPHA_SATURATE")
+            .build();
+
+    private static final List<String> errorBuffer = new ArrayList<>(32);
+
+    public static void recordGLStates() {
+        if (HodgePodgeClient.renderDebugMode == 1) {
+            saved_GL_BLEND = GL11.glGetBoolean(GL_BLEND);
+            saved_GL_ALPHA_TEST = GL11.glGetBoolean(GL_ALPHA_TEST);
+            saved_GL_CULL_FACE = GL11.glGetBoolean(GL_CULL_FACE);
+            saved_GL_DEPTH_TEST = GL11.glGetBoolean(GL_DEPTH_TEST);
+            saved_GL_RESCALE_NORMAL = GL11.glGetBoolean(GL_RESCALE_NORMAL);
+            saved_GL_DEPTH_FUNC = GL11.glGetInteger(GL_DEPTH_FUNC);
+            return;
+        }
+
+        saved_GL_ALPHA_TEST = GL11.glIsEnabled(GL_ALPHA_TEST);
+        saved_GL_AUTO_NORMAL = GL11.glIsEnabled(GL_AUTO_NORMAL);
+        saved_GL_BLEND = GL11.glIsEnabled(GL_BLEND);
+        saved_GL_COLOR_ARRAY = GL11.glIsEnabled(GL_COLOR_ARRAY);
+        saved_GL_COLOR_LOGIC_OP = GL11.glIsEnabled(GL_COLOR_LOGIC_OP);
+        saved_GL_COLOR_MATERIAL = GL11.glIsEnabled(GL_COLOR_MATERIAL);
+        saved_GL_COLOR_SUM = GL11.glIsEnabled(GL_COLOR_SUM);
+        saved_GL_COLOR_TABLE = GL11.glIsEnabled(GL_COLOR_TABLE);
+        saved_GL_CONVOLUTION_1D = GL11.glIsEnabled(GL_CONVOLUTION_1D);
+        saved_GL_CONVOLUTION_2D = GL11.glIsEnabled(GL_CONVOLUTION_2D);
+        saved_GL_CULL_FACE = GL11.glIsEnabled(GL_CULL_FACE);
+        saved_GL_DEPTH_TEST = GL11.glIsEnabled(GL_DEPTH_TEST);
+        saved_GL_DITHER = GL11.glIsEnabled(GL_DITHER);
+        saved_GL_EDGE_FLAG_ARRAY = GL11.glIsEnabled(GL_EDGE_FLAG_ARRAY);
+        saved_GL_FOG = GL11.glIsEnabled(GL_FOG);
+        saved_GL_FOG_COORD_ARRAY = GL11.glIsEnabled(GL_FOG_COORD_ARRAY);
+        saved_GL_HISTOGRAM = GL11.glIsEnabled(GL_HISTOGRAM);
+        saved_GL_INDEX_ARRAY = GL11.glIsEnabled(GL_INDEX_ARRAY);
+        saved_GL_INDEX_LOGIC_OP = GL11.glIsEnabled(GL_INDEX_LOGIC_OP);
+        saved_GL_LIGHTING = GL11.glIsEnabled(GL_LIGHTING);
+        saved_GL_LINE_SMOOTH = GL11.glIsEnabled(GL_LINE_SMOOTH);
+        saved_GL_LINE_STIPPLE = GL11.glIsEnabled(GL_LINE_STIPPLE);
+        saved_GL_MAP1_COLOR_4 = GL11.glIsEnabled(GL_MAP1_COLOR_4);
+        saved_GL_MAP1_INDEX = GL11.glIsEnabled(GL_MAP1_INDEX);
+        saved_GL_MAP1_NORMAL = GL11.glIsEnabled(GL_MAP1_NORMAL);
+        saved_GL_MAP1_TEXTURE_COORD_1 = GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_1);
+        saved_GL_MAP1_TEXTURE_COORD_2 = GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_2);
+        saved_GL_MAP1_TEXTURE_COORD_3 = GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_3);
+        saved_GL_MAP1_TEXTURE_COORD_4 = GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_4);
+        saved_GL_MAP2_COLOR_4 = GL11.glIsEnabled(GL_MAP2_COLOR_4);
+        saved_GL_MAP2_INDEX = GL11.glIsEnabled(GL_MAP2_INDEX);
+        saved_GL_MAP2_NORMAL = GL11.glIsEnabled(GL_MAP2_NORMAL);
+        saved_GL_MAP2_TEXTURE_COORD_1 = GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_1);
+        saved_GL_MAP2_TEXTURE_COORD_2 = GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_2);
+        saved_GL_MAP2_TEXTURE_COORD_3 = GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_3);
+        saved_GL_MAP2_TEXTURE_COORD_4 = GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_4);
+        saved_GL_MAP2_VERTEX_3 = GL11.glIsEnabled(GL_MAP2_VERTEX_3);
+        saved_GL_MAP2_VERTEX_4 = GL11.glIsEnabled(GL_MAP2_VERTEX_4);
+        saved_GL_MINMAX = GL11.glIsEnabled(GL_MINMAX);
+        saved_GL_MULTISAMPLE = GL11.glIsEnabled(GL_MULTISAMPLE);
+        saved_GL_NORMAL_ARRAY = GL11.glIsEnabled(GL_NORMAL_ARRAY);
+        saved_GL_NORMALIZE = GL11.glIsEnabled(GL_NORMALIZE);
+        saved_GL_POINT_SMOOTH = GL11.glIsEnabled(GL_POINT_SMOOTH);
+        saved_GL_POINT_SPRITE = GL11.glIsEnabled(GL_POINT_SPRITE);
+        saved_GL_POLYGON_SMOOTH = GL11.glIsEnabled(GL_POLYGON_SMOOTH);
+        saved_GL_POLYGON_OFFSET_FILL = GL11.glIsEnabled(GL_POLYGON_OFFSET_FILL);
+        saved_GL_POLYGON_OFFSET_LINE = GL11.glIsEnabled(GL_POLYGON_OFFSET_LINE);
+        saved_GL_POLYGON_OFFSET_POINT = GL11.glIsEnabled(GL_POLYGON_OFFSET_POINT);
+        saved_GL_POLYGON_STIPPLE = GL11.glIsEnabled(GL_POLYGON_STIPPLE);
+        saved_GL_POST_COLOR_MATRIX_COLOR_TABLE = GL11.glIsEnabled(GL_POST_COLOR_MATRIX_COLOR_TABLE);
+        saved_GL_POST_CONVOLUTION_COLOR_TABLE = GL11.glIsEnabled(GL_POST_CONVOLUTION_COLOR_TABLE);
+        saved_GL_RESCALE_NORMAL = GL11.glIsEnabled(GL_RESCALE_NORMAL);
+        saved_GL_SAMPLE_ALPHA_TO_COVERAGE = GL11.glIsEnabled(GL_SAMPLE_ALPHA_TO_COVERAGE);
+        saved_GL_SAMPLE_ALPHA_TO_ONE = GL11.glIsEnabled(GL_SAMPLE_ALPHA_TO_ONE);
+        saved_GL_SAMPLE_COVERAGE = GL11.glIsEnabled(GL_SAMPLE_COVERAGE);
+        saved_GL_SCISSOR_TEST = GL11.glIsEnabled(GL_SCISSOR_TEST);
+        saved_GL_SECONDARY_COLOR_ARRAY = GL11.glIsEnabled(GL_SECONDARY_COLOR_ARRAY);
+        saved_GL_SEPARABLE_2D = GL11.glIsEnabled(GL_SEPARABLE_2D);
+        saved_GL_STENCIL_TEST = GL11.glIsEnabled(GL_STENCIL_TEST);
+        saved_GL_TEXTURE_1D = GL11.glIsEnabled(GL_TEXTURE_1D);
+        saved_GL_TEXTURE_2D = GL11.glIsEnabled(GL_TEXTURE_2D);
+        saved_GL_TEXTURE_3D = GL11.glIsEnabled(GL_TEXTURE_3D);
+        saved_GL_TEXTURE_COORD_ARRAY = GL11.glIsEnabled(GL_TEXTURE_COORD_ARRAY);
+        saved_GL_TEXTURE_CUBE_MAP = GL11.glIsEnabled(GL_TEXTURE_CUBE_MAP);
+        saved_GL_TEXTURE_GEN_Q = GL11.glIsEnabled(GL_TEXTURE_GEN_Q);
+        saved_GL_TEXTURE_GEN_R = GL11.glIsEnabled(GL_TEXTURE_GEN_R);
+        saved_GL_TEXTURE_GEN_S = GL11.glIsEnabled(GL_TEXTURE_GEN_S);
+        saved_GL_TEXTURE_GEN_T = GL11.glIsEnabled(GL_TEXTURE_GEN_T);
+        saved_GL_VERTEX_ARRAY = GL11.glIsEnabled(GL_VERTEX_ARRAY);
+        saved_GL_VERTEX_PROGRAM_POINT_SIZE = GL11.glIsEnabled(GL_VERTEX_PROGRAM_POINT_SIZE);
+        saved_GL_VERTEX_PROGRAM_TWO_SIDE = GL11.glIsEnabled(GL_VERTEX_PROGRAM_TWO_SIDE);
+        saved_GL_ALPHA_TEST_FUNC = GL11.glGetInteger(GL_ALPHA_TEST_FUNC);
+        saved_GL_ALPHA_TEST_REF = GL11.glGetFloat(GL_ALPHA_TEST_REF);
+        saved_GL_DEPTH_FUNC = GL11.glGetInteger(GL_DEPTH_FUNC);
+        saved_GL_BLEND_DST_ALPHA = GL11.glGetInteger(GL_BLEND_DST_ALPHA);
+        saved_GL_BLEND_DST_RGB = GL11.glGetInteger(GL_BLEND_DST_RGB);
+        saved_GL_BLEND_SRC_ALPHA = GL11.glGetInteger(GL_BLEND_SRC_ALPHA);
+        saved_GL_BLEND_SRC_RGB = GL11.glGetInteger(GL_BLEND_SRC_RGB);
+    }
+
+    public static boolean checkGLStates() {
+        errorBuffer.clear();
+        if (HodgePodgeClient.renderDebugMode == 1) {
+            if (GL11.glGetBoolean(GL_BLEND) != saved_GL_BLEND) errorBuffer.add("GL_BLEND");
+            if (GL11.glGetBoolean(GL_ALPHA_TEST) != saved_GL_ALPHA_TEST) errorBuffer.add("GL_ALPHA_TEST");
+            if (GL11.glGetBoolean(GL_CULL_FACE) != saved_GL_CULL_FACE) errorBuffer.add("GL_CULL_FACE");
+            if (GL11.glGetBoolean(GL_DEPTH_TEST) != saved_GL_DEPTH_TEST) errorBuffer.add("GL_DEPTH_TEST");
+            if (GL11.glGetBoolean(GL_RESCALE_NORMAL) != saved_GL_RESCALE_NORMAL) errorBuffer.add("GL_RESCALE_NORMAL");
+            if (GL11.glGetInteger(GL_DEPTH_FUNC) != saved_GL_DEPTH_FUNC) errorBuffer.add("GL_DEPTH_FUNC");
+
+            return errorBuffer.isEmpty();
+        }
+
+        if (GL11.glIsEnabled(GL_ALPHA_TEST) != saved_GL_ALPHA_TEST) errorBuffer.add("GL_ALPHA_TEST");
+        if (GL11.glIsEnabled(GL_AUTO_NORMAL) != saved_GL_AUTO_NORMAL) errorBuffer.add("GL_AUTO_NORMAL");
+        if (GL11.glIsEnabled(GL_BLEND) != saved_GL_BLEND) errorBuffer.add("GL_BLEND");
+        if (GL11.glIsEnabled(GL_COLOR_ARRAY) != saved_GL_COLOR_ARRAY) errorBuffer.add("GL_COLOR_ARRAY");
+        if (GL11.glIsEnabled(GL_COLOR_LOGIC_OP) != saved_GL_COLOR_LOGIC_OP) errorBuffer.add("GL_COLOR_LOGIC_OP");
+        if (GL11.glIsEnabled(GL_COLOR_MATERIAL) != saved_GL_COLOR_MATERIAL) errorBuffer.add("GL_COLOR_MATERIAL");
+        if (GL11.glIsEnabled(GL_COLOR_SUM) != saved_GL_COLOR_SUM) errorBuffer.add("GL_COLOR_SUM");
+        if (GL11.glIsEnabled(GL_COLOR_TABLE) != saved_GL_COLOR_TABLE) errorBuffer.add("GL_COLOR_TABLE");
+        if (GL11.glIsEnabled(GL_CONVOLUTION_1D) != saved_GL_CONVOLUTION_1D) errorBuffer.add("GL_CONVOLUTION_1D");
+        if (GL11.glIsEnabled(GL_CONVOLUTION_2D) != saved_GL_CONVOLUTION_2D) errorBuffer.add("GL_CONVOLUTION_2D");
+        if (GL11.glIsEnabled(GL_CULL_FACE) != saved_GL_CULL_FACE) errorBuffer.add("GL_CULL_FACE");
+        if (GL11.glIsEnabled(GL_DEPTH_TEST) != saved_GL_DEPTH_TEST) errorBuffer.add("GL_DEPTH_TEST");
+        if (GL11.glIsEnabled(GL_DITHER) != saved_GL_DITHER) errorBuffer.add("GL_DITHER");
+        if (GL11.glIsEnabled(GL_EDGE_FLAG_ARRAY) != saved_GL_EDGE_FLAG_ARRAY) errorBuffer.add("GL_EDGE_FLAG_ARRAY");
+        if (GL11.glIsEnabled(GL_FOG) != saved_GL_FOG) errorBuffer.add("GL_FOG");
+        if (GL11.glIsEnabled(GL_FOG_COORD_ARRAY) != saved_GL_FOG_COORD_ARRAY) errorBuffer.add("GL_FOG_COORD_ARRAY");
+        if (GL11.glIsEnabled(GL_HISTOGRAM) != saved_GL_HISTOGRAM) errorBuffer.add("GL_HISTOGRAM");
+        if (GL11.glIsEnabled(GL_INDEX_ARRAY) != saved_GL_INDEX_ARRAY) errorBuffer.add("GL_INDEX_ARRAY");
+        if (GL11.glIsEnabled(GL_INDEX_LOGIC_OP) != saved_GL_INDEX_LOGIC_OP) errorBuffer.add("GL_INDEX_LOGIC_OP");
+        if (GL11.glIsEnabled(GL_LIGHTING) != saved_GL_LIGHTING) errorBuffer.add("GL_LIGHTING");
+        if (GL11.glIsEnabled(GL_LINE_SMOOTH) != saved_GL_LINE_SMOOTH) errorBuffer.add("GL_LINE_SMOOTH");
+        if (GL11.glIsEnabled(GL_LINE_STIPPLE) != saved_GL_LINE_STIPPLE) errorBuffer.add("GL_LINE_STIPPLE");
+        if (GL11.glIsEnabled(GL_MAP1_COLOR_4) != saved_GL_MAP1_COLOR_4) errorBuffer.add("GL_MAP1_COLOR_4");
+        if (GL11.glIsEnabled(GL_MAP1_INDEX) != saved_GL_MAP1_INDEX) errorBuffer.add("GL_MAP1_INDEX");
+        if (GL11.glIsEnabled(GL_MAP1_NORMAL) != saved_GL_MAP1_NORMAL) errorBuffer.add("GL_MAP1_NORMAL");
+        if (GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_1) != saved_GL_MAP1_TEXTURE_COORD_1) errorBuffer.add("GL_MAP1_TEXTURE_COORD_1");
+        if (GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_2) != saved_GL_MAP1_TEXTURE_COORD_2) errorBuffer.add("GL_MAP1_TEXTURE_COORD_2");
+        if (GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_3) != saved_GL_MAP1_TEXTURE_COORD_3) errorBuffer.add("GL_MAP1_TEXTURE_COORD_3");
+        if (GL11.glIsEnabled(GL_MAP1_TEXTURE_COORD_4) != saved_GL_MAP1_TEXTURE_COORD_4) errorBuffer.add("GL_MAP1_TEXTURE_COORD_4");
+        if (GL11.glIsEnabled(GL_MAP2_COLOR_4) != saved_GL_MAP2_COLOR_4) errorBuffer.add("GL_MAP2_COLOR_4");
+        if (GL11.glIsEnabled(GL_MAP2_INDEX) != saved_GL_MAP2_INDEX) errorBuffer.add("GL_MAP2_INDEX");
+        if (GL11.glIsEnabled(GL_MAP2_NORMAL) != saved_GL_MAP2_NORMAL) errorBuffer.add("GL_MAP2_NORMAL");
+        if (GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_1) != saved_GL_MAP2_TEXTURE_COORD_1) errorBuffer.add("GL_MAP2_TEXTURE_COORD_1");
+        if (GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_2) != saved_GL_MAP2_TEXTURE_COORD_2) errorBuffer.add("GL_MAP2_TEXTURE_COORD_2");
+        if (GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_3) != saved_GL_MAP2_TEXTURE_COORD_3) errorBuffer.add("GL_MAP2_TEXTURE_COORD_3");
+        if (GL11.glIsEnabled(GL_MAP2_TEXTURE_COORD_4) != saved_GL_MAP2_TEXTURE_COORD_4) errorBuffer.add("GL_MAP2_TEXTURE_COORD_4");
+        if (GL11.glIsEnabled(GL_MAP2_VERTEX_3) != saved_GL_MAP2_VERTEX_3) errorBuffer.add("GL_MAP2_VERTEX_3");
+        if (GL11.glIsEnabled(GL_MAP2_VERTEX_4) != saved_GL_MAP2_VERTEX_4) errorBuffer.add("GL_MAP2_VERTEX_4");
+        if (GL11.glIsEnabled(GL_MINMAX) != saved_GL_MINMAX) errorBuffer.add("GL_MINMAX");
+        if (GL11.glIsEnabled(GL_MULTISAMPLE) != saved_GL_MULTISAMPLE) errorBuffer.add("GL_MULTISAMPLE");
+        if (GL11.glIsEnabled(GL_NORMAL_ARRAY) != saved_GL_NORMAL_ARRAY) errorBuffer.add("GL_NORMAL_ARRAY");
+        if (GL11.glIsEnabled(GL_NORMALIZE) != saved_GL_NORMALIZE) errorBuffer.add("GL_NORMALIZE");
+        if (GL11.glIsEnabled(GL_POINT_SMOOTH) != saved_GL_POINT_SMOOTH) errorBuffer.add("GL_POINT_SMOOTH");
+        if (GL11.glIsEnabled(GL_POINT_SPRITE) != saved_GL_POINT_SPRITE) errorBuffer.add("GL_POINT_SPRITE");
+        if (GL11.glIsEnabled(GL_POLYGON_SMOOTH) != saved_GL_POLYGON_SMOOTH) errorBuffer.add("GL_POLYGON_SMOOTH");
+        if (GL11.glIsEnabled(GL_POLYGON_OFFSET_FILL) != saved_GL_POLYGON_OFFSET_FILL) errorBuffer.add("GL_POLYGON_OFFSET_FILL");
+        if (GL11.glIsEnabled(GL_POLYGON_OFFSET_LINE) != saved_GL_POLYGON_OFFSET_LINE) errorBuffer.add("GL_POLYGON_OFFSET_LINE");
+        if (GL11.glIsEnabled(GL_POLYGON_OFFSET_POINT) != saved_GL_POLYGON_OFFSET_POINT) errorBuffer.add("GL_POLYGON_OFFSET_POINT");
+        if (GL11.glIsEnabled(GL_POLYGON_STIPPLE) != saved_GL_POLYGON_STIPPLE) errorBuffer.add("GL_POLYGON_STIPPLE");
+        if (GL11.glIsEnabled(GL_POST_COLOR_MATRIX_COLOR_TABLE) != saved_GL_POST_COLOR_MATRIX_COLOR_TABLE) errorBuffer.add("GL_POST_COLOR_MATRIX_COLOR_TABLE");
+        if (GL11.glIsEnabled(GL_POST_CONVOLUTION_COLOR_TABLE) != saved_GL_POST_CONVOLUTION_COLOR_TABLE) errorBuffer.add("GL_POST_CONVOLUTION_COLOR_TABLE");
+        if (GL11.glIsEnabled(GL_RESCALE_NORMAL) != saved_GL_RESCALE_NORMAL) errorBuffer.add("GL_RESCALE_NORMAL");
+        if (GL11.glIsEnabled(GL_SAMPLE_ALPHA_TO_COVERAGE) != saved_GL_SAMPLE_ALPHA_TO_COVERAGE) errorBuffer.add("GL_SAMPLE_ALPHA_TO_COVERAGE");
+        if (GL11.glIsEnabled(GL_SAMPLE_ALPHA_TO_ONE) != saved_GL_SAMPLE_ALPHA_TO_ONE) errorBuffer.add("GL_SAMPLE_ALPHA_TO_ONE");
+        if (GL11.glIsEnabled(GL_SAMPLE_COVERAGE) != saved_GL_SAMPLE_COVERAGE) errorBuffer.add("GL_SAMPLE_COVERAGE");
+        if (GL11.glIsEnabled(GL_SCISSOR_TEST) != saved_GL_SCISSOR_TEST) errorBuffer.add("GL_SCISSOR_TEST");
+        if (GL11.glIsEnabled(GL_SECONDARY_COLOR_ARRAY) != saved_GL_SECONDARY_COLOR_ARRAY) errorBuffer.add("GL_SECONDARY_COLOR_ARRAY");
+        if (GL11.glIsEnabled(GL_SEPARABLE_2D) != saved_GL_SEPARABLE_2D) errorBuffer.add("GL_SEPARABLE_2D");
+        if (GL11.glIsEnabled(GL_STENCIL_TEST) != saved_GL_STENCIL_TEST) errorBuffer.add("GL_STENCIL_TEST");
+        if (GL11.glIsEnabled(GL_TEXTURE_1D) != saved_GL_TEXTURE_1D) errorBuffer.add("GL_TEXTURE_1D");
+        if (GL11.glIsEnabled(GL_TEXTURE_2D) != saved_GL_TEXTURE_2D) errorBuffer.add("GL_TEXTURE_2D");
+        if (GL11.glIsEnabled(GL_TEXTURE_3D) != saved_GL_TEXTURE_3D) errorBuffer.add("GL_TEXTURE_3D");
+        if (GL11.glIsEnabled(GL_TEXTURE_COORD_ARRAY) != saved_GL_TEXTURE_COORD_ARRAY) errorBuffer.add("GL_TEXTURE_COORD_ARRAY");
+        if (GL11.glIsEnabled(GL_TEXTURE_CUBE_MAP) != saved_GL_TEXTURE_CUBE_MAP) errorBuffer.add("GL_TEXTURE_CUBE_MAP");
+        if (GL11.glIsEnabled(GL_TEXTURE_GEN_Q) != saved_GL_TEXTURE_GEN_Q) errorBuffer.add("GL_TEXTURE_GEN_Q");
+        if (GL11.glIsEnabled(GL_TEXTURE_GEN_R) != saved_GL_TEXTURE_GEN_R) errorBuffer.add("GL_TEXTURE_GEN_R");
+        if (GL11.glIsEnabled(GL_TEXTURE_GEN_S) != saved_GL_TEXTURE_GEN_S) errorBuffer.add("GL_TEXTURE_GEN_S");
+        if (GL11.glIsEnabled(GL_TEXTURE_GEN_T) != saved_GL_TEXTURE_GEN_T) errorBuffer.add("GL_TEXTURE_GEN_T");
+        if (GL11.glIsEnabled(GL_VERTEX_ARRAY) != saved_GL_VERTEX_ARRAY) errorBuffer.add("GL_VERTEX_ARRAY");
+        if (GL11.glIsEnabled(GL_VERTEX_PROGRAM_POINT_SIZE) != saved_GL_VERTEX_PROGRAM_POINT_SIZE) errorBuffer.add("GL_VERTEX_PROGRAM_POINT_SIZE");
+        if (GL11.glIsEnabled(GL_VERTEX_PROGRAM_TWO_SIDE) != saved_GL_VERTEX_PROGRAM_TWO_SIDE) errorBuffer.add("GL_VERTEX_PROGRAM_TWO_SIDE");
+
+        if (saved_GL_ALPHA_TEST) {
+            // these are only significant if original state have alpha test on
+            if (GL11.glGetInteger(GL_ALPHA_TEST_FUNC) != saved_GL_ALPHA_TEST_FUNC) errorBuffer.add("GL_ALPHA_TEST_FUNC");
+            if (GL11.glGetDouble(GL_ALPHA_TEST_REF) != saved_GL_ALPHA_TEST_REF) errorBuffer.add("GL_ALPHA_TEST_REF");
+        }
+
+        if (saved_GL_DEPTH_TEST) {
+            // these are only significant if original state have depth test on
+            if (GL11.glGetInteger(GL_DEPTH_FUNC) != saved_GL_DEPTH_FUNC) errorBuffer.add("GL_DEPTH_FUNC");
+        }
+
+        if (saved_GL_BLEND) {
+            // these are only significant if original state have blending on
+            if (GL11.glGetInteger(GL_BLEND_DST_ALPHA) != saved_GL_BLEND_DST_ALPHA) errorBuffer.add("GL_BLEND_DST_ALPHA");
+            if (GL11.glGetInteger(GL_BLEND_DST_RGB) != saved_GL_BLEND_DST_RGB) errorBuffer.add("GL_BLEND_DST_RGB");
+            if (GL11.glGetInteger(GL_BLEND_SRC_ALPHA) != saved_GL_BLEND_SRC_ALPHA) errorBuffer.add("GL_BLEND_SRC_ALPHA");
+            if (GL11.glGetInteger(GL_BLEND_SRC_RGB) != saved_GL_BLEND_SRC_RGB) errorBuffer.add("GL_BLEND_SRC_RGB");
+        }
+
+        return errorBuffer.isEmpty();
+    }
+
+    public static String compose() {
+        return String.join(", ", errorBuffer);
+    }
+}
+// @formatter:on
+// spotless:on

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -100,7 +100,7 @@ public enum Mixins {
             TargetedMod.VANILLA),
     OPTIMIZE_ASMDATATABLE_INDEX(
             "forge.MixinASMDataTable", Side.BOTH, () -> Hodgepodge.config.optimizeASMDataTable, TargetedMod.VANILLA),
-    RENDER_DEBUG("forge.MixinASMDataTable", Side.CLIENT, () -> Hodgepodge.config.renderDebug, TargetedMod.VANILLA),
+    RENDER_DEBUG("minecraft.MixinRenderGlobal", Side.CLIENT, () -> Hodgepodge.config.renderDebug, TargetedMod.VANILLA),
 
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -100,6 +100,7 @@ public enum Mixins {
             TargetedMod.VANILLA),
     OPTIMIZE_ASMDATATABLE_INDEX(
             "forge.MixinASMDataTable", Side.BOTH, () -> Hodgepodge.config.optimizeASMDataTable, TargetedMod.VANILLA),
+    RENDER_DEBUG("forge.MixinASMDataTable", Side.CLIENT, () -> Hodgepodge.config.renderDebug, TargetedMod.VANILLA),
 
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
@@ -1,6 +1,8 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
+import com.mitchej123.hodgepodge.core.HodgePodgeClient.RenderDebugMode;
+import com.mitchej123.hodgepodge.core.util.ManagedEnum;
 import com.mitchej123.hodgepodge.core.util.RenderDebugHelper;
 import java.util.Collections;
 import java.util.Set;
@@ -42,15 +44,15 @@ public class MixinRenderGlobal {
                             target =
                                     "Lnet/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher;renderTileEntity(Lnet/minecraft/tileentity/TileEntity;F)V"))
     public void postTESR(TileEntityRendererDispatcher instance, TileEntity j, float k) {
-        int renderDebugMode = HodgePodgeClient.renderDebugMode;
-        if (renderDebugMode != 0)
+        ManagedEnum<RenderDebugMode> renderDebugMode = HodgePodgeClient.renderDebugMode;
+        if (!renderDebugMode.is(RenderDebugMode.Off))
             // this should be enough
             GL11.glPushAttrib(
                     GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
 
         instance.renderTileEntity(j, k);
 
-        if (renderDebugMode == 0) {
+        if (renderDebugMode.is(RenderDebugMode.Off)) {
             knownIssues.clear();
             return;
         }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
@@ -45,7 +45,8 @@ public class MixinRenderGlobal {
         int renderDebugMode = HodgePodgeClient.renderDebugMode;
         if (renderDebugMode != 0)
             // this should be enough
-            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
+            GL11.glPushAttrib(
+                    GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
 
         instance.renderTileEntity(j, k);
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
@@ -45,14 +45,14 @@ public class MixinRenderGlobal {
                                     "Lnet/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher;renderTileEntity(Lnet/minecraft/tileentity/TileEntity;F)V"))
     public void postTESR(TileEntityRendererDispatcher instance, TileEntity j, float k) {
         ManagedEnum<RenderDebugMode> renderDebugMode = HodgePodgeClient.renderDebugMode;
-        if (!renderDebugMode.is(RenderDebugMode.Off))
+        if (!renderDebugMode.is(RenderDebugMode.OFF))
             // this should be enough
             GL11.glPushAttrib(
                     GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
 
         instance.renderTileEntity(j, k);
 
-        if (renderDebugMode.is(RenderDebugMode.Off)) {
+        if (renderDebugMode.is(RenderDebugMode.OFF)) {
             knownIssues.clear();
             return;
         }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRenderGlobal.java
@@ -1,0 +1,75 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import com.mitchej123.hodgepodge.core.HodgePodgeClient;
+import com.mitchej123.hodgepodge.core.util.RenderDebugHelper;
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.client.renderer.culling.ICamera;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentText;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderGlobal.class)
+public class MixinRenderGlobal {
+    private final Set<TileEntity> knownIssues = Collections.newSetFromMap(new WeakHashMap<>());
+
+    @Inject(
+            method = "renderEntities",
+            at =
+                    @At(
+                            value = "FIELD",
+                            ordinal = 0,
+                            target = "Lnet/minecraft/client/renderer/RenderGlobal;tileEntities:Ljava/util/List;"))
+    public void prepareTESR(EntityLivingBase p_147589_1_, ICamera p_147589_2_, float p_147589_3_, CallbackInfo ci) {
+        RenderDebugHelper.recordGLStates();
+    }
+
+    @Redirect(
+            method = "renderEntities",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher;renderTileEntity(Lnet/minecraft/tileentity/TileEntity;F)V"))
+    public void postTESR(TileEntityRendererDispatcher instance, TileEntity j, float k) {
+        int renderDebugMode = HodgePodgeClient.renderDebugMode;
+        if (renderDebugMode != 0)
+            // this should be enough
+            GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LIGHTING_BIT);
+
+        instance.renderTileEntity(j, k);
+
+        if (renderDebugMode == 0) {
+            knownIssues.clear();
+            return;
+        }
+
+        if (!knownIssues.contains(j) && !RenderDebugHelper.checkGLStates()) {
+            knownIssues.add(j);
+            Minecraft.getMinecraft()
+                    .thePlayer
+                    .addChatMessage(
+                            new ChatComponentText("TileEntity (" + j.getClass().getName() + " at " + j.xCoord + ", "
+                                    + j.yCoord + ", " + j.zCoord + ") is messing up render states!"));
+            RenderDebugHelper.log.error(
+                    "TileEntity {} at ({}, {}, {}) alter render state after TESR call: {}",
+                    j.getClass(),
+                    j.xCoord,
+                    j.yCoord,
+                    j.zCoord,
+                    RenderDebugHelper.compose());
+        }
+
+        GL11.glPopAttrib();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/textures/client/MixinTextureMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/textures/client/MixinTextureMap.java
@@ -1,6 +1,7 @@
 package com.mitchej123.hodgepodge.mixins.minecraft.textures.client;
 
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
+import com.mitchej123.hodgepodge.core.HodgePodgeClient.AnimationMode;
 import com.mitchej123.hodgepodge.core.textures.IPatchedTextureAtlasSprite;
 import java.util.List;
 import net.minecraft.client.Minecraft;
@@ -30,8 +31,8 @@ public abstract class MixinTextureMap extends AbstractTexture {
      */
     @Overwrite
     public void updateAnimations() {
-        boolean renderAllAnimations = HodgePodgeClient.animationsMode == 2;
-        boolean renderVisibleAnimations = HodgePodgeClient.animationsMode == 1;
+        boolean renderAllAnimations = HodgePodgeClient.animationsMode.is(AnimationMode.AnimateAll);
+        boolean renderVisibleAnimations = HodgePodgeClient.animationsMode.is(AnimationMode.AnimateVisible);
 
         mc.mcProfiler.startSection("updateAnimations");
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.getGlTextureId());

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/textures/client/MixinTextureMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/textures/client/MixinTextureMap.java
@@ -31,8 +31,8 @@ public abstract class MixinTextureMap extends AbstractTexture {
      */
     @Overwrite
     public void updateAnimations() {
-        boolean renderAllAnimations = HodgePodgeClient.animationsMode.is(AnimationMode.AnimateAll);
-        boolean renderVisibleAnimations = HodgePodgeClient.animationsMode.is(AnimationMode.AnimateVisible);
+        boolean renderAllAnimations = HodgePodgeClient.animationsMode.is(AnimationMode.ALL);
+        boolean renderVisibleAnimations = HodgePodgeClient.animationsMode.is(AnimationMode.VISIBLE_ONLY);
 
         mc.mcProfiler.startSection("updateAnimations");
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.getGlTextureId());


### PR DESCRIPTION
This will send a chat error message when a TESR is breaking render states. Detail will be routed to logs instead for not clobbing up the entire chat menu. I didn't log the diff in value, just merely logged which got changed, because it should be pretty obvious on the cause of glitches when we know who is at fault.

currently only available for TESRs. Can be implemented for other stuff e.g. items, entities or blocks as well.