### PR TITLE
Fix fullscreen when tabing out

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -190,10 +190,7 @@ public class LoadingConfig {
                         "Fix game window becoming not resizable after toggling fullscrean in any way")
                 .getBoolean();
         fixUnfocusedFullscreen = config.get(
-                        "fixes",
-                        "fixUnfocusedFullscreen",
-                        true,
-                        "Fix exiting fullscreen when you tab out of the game")
+                        "fixes", "fixUnfocusedFullscreen", true, "Fix exiting fullscreen when you tab out of the game")
                 .getBoolean();
         speedupAnimations = config.get(
                         "fixes",

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -59,7 +59,7 @@ public class LoadingConfig {
     public boolean fixComponentsPoppingOff;
     public boolean thirstyTankContainer;
     public boolean fixWorldServerLeakingUnloadedEntities;
-    public boolean fixFullscreenResizable;
+    public boolean fixResizableFullscreen;
     public boolean fixUnfocusedFullscreen;
     public boolean speedupAnimations;
     public boolean fixPotionIterating;
@@ -183,9 +183,9 @@ public class LoadingConfig {
                         true,
                         "Fix WorldServer leaking entities when no players are present in a dimension")
                 .getBoolean();
-        fixFullscreenResizable = config.get(
+        fixResizableFullscreen = config.get(
                         "fixes",
-                        "fixFullscreenResizable",
+                        "fixResizableFullscreen",
                         true,
                         "Fix game window becoming not resizable after toggling fullscrean in any way")
                 .getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -60,6 +60,7 @@ public class LoadingConfig {
     public boolean thirstyTankContainer;
     public boolean fixWorldServerLeakingUnloadedEntities;
     public boolean fixFullscreenResizable;
+    public boolean fixUnfocusedFullscreen;
     public boolean speedupAnimations;
     public boolean fixPotionIterating;
     public boolean fixIgnisFruitAABB;
@@ -187,6 +188,12 @@ public class LoadingConfig {
                         "fixFullscreenResizable",
                         true,
                         "Fix game window becoming not resizable after toggling fullscrean in any way")
+                .getBoolean();
+        fixUnfocusedFullscreen = config.get(
+                        "fixes",
+                        "fixUnfocusedFullscreen",
+                        true,
+                        "Fix exiting fullscreen when you tab out of the game")
                 .getBoolean();
         speedupAnimations = config.get(
                         "fixes",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -70,10 +70,10 @@ public enum Mixins {
             Side.CLIENT,
             () -> Hodgepodge.config.fixGlStateBugs,
             TargetedMod.VANILLA),
-    FIX_FULLSCREEN_RESIZABLE(
-            "minecraft.MixinMinecraft_fixFullscreenResizable",
+    FIX_RESIZABLE_FULLSCREEN(
+            "minecraft.MixinMinecraft_ResizableFullscreen",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixFullscreenResizable,
+            () -> Hodgepodge.config.fixResizableFullscreen,
             TargetedMod.VANILLA),
     FIX_UNFOCUSED_FULLSCREEN(
             "minecraft.MixinMinecraft_UnfocusedFullscreen",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -71,9 +71,14 @@ public enum Mixins {
             () -> Hodgepodge.config.fixGlStateBugs,
             TargetedMod.VANILLA),
     FIX_FULLSCREEN_RESIZABLE(
-            "minecraft.MixinMinecraft",
+            "minecraft.MixinMinecraft_fixFullscreenResizable",
             Side.CLIENT,
             () -> Hodgepodge.config.fixFullscreenResizable,
+            TargetedMod.VANILLA),
+    FIX_UNFOCUSED_FULLSCREEN(
+            "minecraft.MixinMinecraft_UnfocusedFullscreen",
+            Side.CLIENT,
+            () -> Hodgepodge.config.fixUnfocusedFullscreen,
             TargetedMod.VANILLA),
     SPEEDUP_VANILLA_ANIMATIONS(
             () -> Hodgepodge.config.speedupAnimations,

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_ResizableFullscreen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_ResizableFullscreen.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
-public class MixinMinecraft_fixFullscreenResizable {
+public class MixinMinecraft_ResizableFullscreen {
 
     @Shadow
     private boolean fullscreen;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_UnfocusedFullscreen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_UnfocusedFullscreen.java
@@ -1,0 +1,14 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft_UnfocusedFullscreen {
+    @Redirect(method = "runGameLoop", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;isActive()Z"), remap = false)
+    public boolean hodgepodge$fixUnfocusedFullscreen() {
+        return true;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_UnfocusedFullscreen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_UnfocusedFullscreen.java
@@ -9,8 +9,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MixinMinecraft_UnfocusedFullscreen {
     @Redirect(
             method = "runGameLoop",
-            at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;isActive()Z"),
-            remap = false)
+            at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;isActive()Z", remap = false))
     public boolean hodgepodge$fixUnfocusedFullscreen() {
         return true;
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_UnfocusedFullscreen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_UnfocusedFullscreen.java
@@ -7,7 +7,10 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(Minecraft.class)
 public class MixinMinecraft_UnfocusedFullscreen {
-    @Redirect(method = "runGameLoop", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;isActive()Z"), remap = false)
+    @Redirect(
+            method = "runGameLoop",
+            at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;isActive()Z"),
+            remap = false)
     public boolean hodgepodge$fixUnfocusedFullscreen() {
         return true;
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_fixFullscreenResizable.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinMinecraft_fixFullscreenResizable.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Minecraft.class)
-public class MixinMinecraft {
+public class MixinMinecraft_fixFullscreenResizable {
 
     @Shadow
     private boolean fullscreen;
@@ -21,7 +21,7 @@ public class MixinMinecraft {
     @Inject(
             method = "toggleFullscreen",
             at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/Display;setVSyncEnabled(Z)V", remap = false))
-    private void toggleResizable(CallbackInfo ci) {
+    private void hodgepodge$fixFullscreenResizable(CallbackInfo ci) {
         if (!this.fullscreen && (Util.getOSType() == Util.EnumOS.WINDOWS)) {
             Display.setResizable(false);
             Display.setResizable(true);


### PR DESCRIPTION
fix the vanilla 1.7.10 bug that makes your game exit fullscreen when the game looses focus (if you use alt tab)

tested and working in full pack