### PR TITLE
fix fireballs that stay immobile on world/chunk reload

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -35,8 +35,8 @@ public class LoadingConfig {
     public boolean fixPotionEffectRender;
     public boolean fixPotionRenderOffset;
     public boolean fixPotionLimit;
-    public boolean fixPerspectiveCamera;
     public boolean fixImmobileFireballs;
+    public boolean fixPerspectiveCamera;
     public boolean fixHopperVoidingItems;
     public boolean fixHugeChatKick;
     public boolean logHugeChat;
@@ -165,17 +165,17 @@ public class LoadingConfig {
                 .getBoolean();
         fixPotionLimit = config.get("fixes", "fixPotionLimit", true, "Fix potions >= 128")
                 .getBoolean();
-        fixPerspectiveCamera = config.get(
-                        "fixes",
-                        "fixPerspectiveCamera",
-                        true,
-                        "Prevent tall grass and such to affect the perspective camera")
-                .getBoolean();
         fixImmobileFireballs = config.get(
                         "fixes",
                         "fixImmobileFireballs",
                         true,
                         "Fix the bug that makes fireballs stop moving when chunk unloads")
+                .getBoolean();
+        fixPerspectiveCamera = config.get(
+                        "fixes",
+                        "fixPerspectiveCamera",
+                        true,
+                        "Prevent tall grass and such to affect the perspective camera")
                 .getBoolean();
         fixGlStateBugs = config.get(
                         "fixes",

--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -36,6 +36,7 @@ public class LoadingConfig {
     public boolean fixPotionRenderOffset;
     public boolean fixPotionLimit;
     public boolean fixPerspectiveCamera;
+    public boolean fixImmobileFireballs;
     public boolean fixHopperVoidingItems;
     public boolean fixHugeChatKick;
     public boolean logHugeChat;
@@ -169,6 +170,12 @@ public class LoadingConfig {
                         "fixPerspectiveCamera",
                         true,
                         "Prevent tall grass and such to affect the perspective camera")
+                .getBoolean();
+        fixImmobileFireballs = config.get(
+                        "fixes",
+                        "fixImmobileFireballs",
+                        true,
+                        "Fix the bug that makes fireballs stop moving when chunk unloads")
                 .getBoolean();
         fixGlStateBugs = config.get(
                         "fixes",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -11,8 +11,6 @@ public enum Mixins {
     // Vanilla Fixes
     FIX_PERSPECTIVE_CAMERA(
             "minecraft.MixinEntityRenderer", () -> Hodgepodge.config.fixPerspectiveCamera, TargetedMod.VANILLA),
-    FIX_IMMOBILE_FIREBALLS(
-            "minecraft.MixinEntityFireball", () -> Hodgepodge.config.fixImmobileFireballs, TargetedMod.VANILLA),
     FENCE_CONNECTIONS_FIX(
             "minecraft.MixinBlockFence", () -> Hodgepodge.config.fixFenceConnections, TargetedMod.VANILLA),
     FIX_INVENTORY_OFFSET_WITH_POTIONS(
@@ -25,6 +23,8 @@ public enum Mixins {
             Side.CLIENT,
             () -> Hodgepodge.config.fixPotionEffectRender,
             TargetedMod.VANILLA),
+    FIX_IMMOBILE_FIREBALLS(
+            "minecraft.MixinEntityFireball", () -> Hodgepodge.config.fixImmobileFireballs, TargetedMod.VANILLA),
     CHUNK_COORDINATES_HASHCODE(
             "minecraft.MixinChunkCoordinates",
             () -> Hodgepodge.config.speedupChunkCoordinatesHashCode,

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -11,6 +11,8 @@ public enum Mixins {
     // Vanilla Fixes
     FIX_PERSPECTIVE_CAMERA(
             "minecraft.MixinEntityRenderer", () -> Hodgepodge.config.fixPerspectiveCamera, TargetedMod.VANILLA),
+    FIX_IMMOBILE_FIREBALLS(
+            "minecraft.MixinEntityFireball", ()-> Hodgepodge.config.fixImmobileFireballs, TargetedMod.VANILLA),
     FENCE_CONNECTIONS_FIX(
             "minecraft.MixinBlockFence", () -> Hodgepodge.config.fixFenceConnections, TargetedMod.VANILLA),
     FIX_INVENTORY_OFFSET_WITH_POTIONS(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -12,7 +12,7 @@ public enum Mixins {
     FIX_PERSPECTIVE_CAMERA(
             "minecraft.MixinEntityRenderer", () -> Hodgepodge.config.fixPerspectiveCamera, TargetedMod.VANILLA),
     FIX_IMMOBILE_FIREBALLS(
-            "minecraft.MixinEntityFireball", ()-> Hodgepodge.config.fixImmobileFireballs, TargetedMod.VANILLA),
+            "minecraft.MixinEntityFireball", () -> Hodgepodge.config.fixImmobileFireballs, TargetedMod.VANILLA),
     FENCE_CONNECTIONS_FIX(
             "minecraft.MixinBlockFence", () -> Hodgepodge.config.fixFenceConnections, TargetedMod.VANILLA),
     FIX_INVENTORY_OFFSET_WITH_POTIONS(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityFireball.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityFireball.java
@@ -14,15 +14,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(EntityFireball.class)
 public abstract class MixinEntityFireball extends Entity {
 
-    @Shadow public double accelerationX;
+    @Shadow
+    public double accelerationX;
 
-    @Shadow public double accelerationY;
+    @Shadow
+    public double accelerationY;
 
-    @Shadow public double accelerationZ;
+    @Shadow
+    public double accelerationZ;
 
     @Inject(method = "writeEntityToNBT", at = @At("TAIL"))
     public void hodgepodge$writeFireballAcceleration(NBTTagCompound p_70014_1_, CallbackInfo ci) {
-        p_70014_1_.setTag("acceleration", this.newDoubleNBTList(this.accelerationX, this.accelerationY, this.accelerationZ));
+        p_70014_1_.setTag(
+                "acceleration", this.newDoubleNBTList(this.accelerationX, this.accelerationY, this.accelerationZ));
     }
 
     @Inject(method = "readEntityFromNBT", at = @At(value = "TAIL"))
@@ -41,5 +45,4 @@ public abstract class MixinEntityFireball extends Entity {
     public MixinEntityFireball(World p_i1582_1_) {
         super(p_i1582_1_);
     }
-
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityFireball.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityFireball.java
@@ -1,0 +1,45 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.EntityFireball;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityFireball.class)
+public abstract class MixinEntityFireball extends Entity {
+
+    @Shadow public double accelerationX;
+
+    @Shadow public double accelerationY;
+
+    @Shadow public double accelerationZ;
+
+    @Inject(method = "writeEntityToNBT", at = @At("TAIL"))
+    public void hodgepodge$writeFireballAcceleration(NBTTagCompound p_70014_1_, CallbackInfo ci) {
+        p_70014_1_.setTag("acceleration", this.newDoubleNBTList(this.accelerationX, this.accelerationY, this.accelerationZ));
+    }
+
+    @Inject(method = "readEntityFromNBT", at = @At(value = "TAIL"))
+    public void hodgepodge$readFireballAcceleration(NBTTagCompound p_70037_1_, CallbackInfo ci) {
+        if (p_70037_1_.hasKey("acceleration", 9)) {
+            NBTTagList nbttaglist = p_70037_1_.getTagList("acceleration", 6);
+            this.accelerationX = nbttaglist.func_150309_d(0);
+            this.accelerationY = nbttaglist.func_150309_d(1);
+            this.accelerationZ = nbttaglist.func_150309_d(2);
+        } else {
+            this.setDead();
+        }
+    }
+
+    /*Forced to have constructor*/
+    public MixinEntityFireball(World p_i1582_1_) {
+        super(p_i1582_1_);
+    }
+
+}


### PR DESCRIPTION
fix the vanilla bug that doesn't save the firecharge's acceleration to the NBT causing the fire charge to stay immobile on world/chunk reload