### PR TITLE
throttle Item Pickup Event for huge performance boost when lots of it…

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/LoadingConfig.java
@@ -14,6 +14,7 @@ public class LoadingConfig {
     // Adjustments
     public int ic2SeedMaxStackSize;
     public int particleLimit;
+    public int itemStacksPickedUpPerTick;
     public boolean addSystemInfo;
 
     // Mixins
@@ -75,6 +76,7 @@ public class LoadingConfig {
     public boolean fixNetherLeavesFaceRendering;
     public boolean optimizeASMDataTable;
     public boolean squashBedErrorMessage;
+    public boolean throttleItemPickupEvent;
 
     public boolean enableDefaultLanPort;
 
@@ -324,11 +326,21 @@ public class LoadingConfig {
                         "Prevent unbinded keybinds from triggering when pressing certain keys")
                 .getBoolean();
         squashBedErrorMessage = config.get(
-                        "fixes",
+                        Category.FIXES.toString(),
                         "squashBedErrorMessage",
                         true,
                         "Stop \"You can only sleep at night\" message filling the chat")
                 .getBoolean();
+        throttleItemPickupEvent = config.get(
+                        Category.FIXES.toString(),
+                        "throttleItemPickupEvent",
+                        true,
+                        "Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag")
+                .getBoolean();
+        itemStacksPickedUpPerTick = Math.max(
+                1,
+                config.get(Category.TWEAKS.toString(), "itemStacksPickedUpPerTick", 36, "Stacks picked up per tick")
+                        .getInt());
 
         increaseParticleLimit = config.get(
                         Category.TWEAKS.toString(), "increaseParticleLimit", true, "Increase particle limit")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -9,6 +9,11 @@ import java.util.function.Supplier;
 
 public enum Mixins {
     // Vanilla Fixes
+    THROTTLE_ITEMPICKUPEVENT(
+            "minecraft.MixinEntityPlayer",
+            Side.BOTH,
+            () -> Hodgepodge.config.throttleItemPickupEvent,
+            TargetedMod.VANILLA),
     FIX_PERSPECTIVE_CAMERA(
             "minecraft.MixinEntityRenderer",
             Side.CLIENT,

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityPlayer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityPlayer.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.minecraft;
+
+import com.mitchej123.hodgepodge.Hodgepodge;
+import java.util.List;
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(EntityPlayer.class)
+public class MixinEntityPlayer {
+
+    @Redirect(
+            method = "onLivingUpdate",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;size()I", remap = false),
+            slice =
+                    @Slice(
+                            from =
+                                    @At(
+                                            value = "INVOKE",
+                                            target =
+                                                    "Lnet/minecraft/world/World;getEntitiesWithinAABBExcludingEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/AxisAlignedBB;)Ljava/util/List;")))
+    public int hodgepodge$ThrottleItemPickupEvent(List instance) {
+        return Math.min(Hodgepodge.config.itemStacksPickedUpPerTick, instance.size());
+    }
+}


### PR DESCRIPTION
…ems are on the ground

When lots of items are on the ground the TPS can drop rapidly because of mods running code on the ItemPickupEvent, this PR prevents this from happening by limiting the amount of times the ITemPickupEvent is fired per tick.

![image](https://user-images.githubusercontent.com/57050655/190813336-7a6f2c6b-23be-44f1-9986-652e564801af.png)

With default config the player will now attemps to pick up 36 items stacks per tick, which is a full inventory.
Allows to still have a solid 20 TPS with 10 ms tick time with a magnet activated and 1000 stacks of items dropped

![2022-09-16_23 39 08](https://user-images.githubusercontent.com/57050655/190812328-43e9f697-3d45-48bd-8dff-3cb7a2b1c655.png)
