### PR TITLE
Fix ASM transformer causing cascading classloading

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Common.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Common.java
@@ -8,9 +8,6 @@ import org.apache.logging.log4j.Logger;
 
 public class Common {
     public static final Logger log = LogManager.getLogger("Hodgepodge");
-    public static final String MODID = "hodgepodge";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String NAME = "A Hodgepodge of Patches";
     public static LoadingConfig config;
     public static boolean thermosTainted;
     public static XSTR RNG = new XSTR();

--- a/src/main/java/com/mitchej123/hodgepodge/Common.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Common.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge;
+
+import com.mitchej123.hodgepodge.core.LoadingConfig;
+import java.io.File;
+import net.minecraft.launchwrapper.Launch;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Common {
+    public static final Logger log = LogManager.getLogger("Hodgepodge");
+    public static final String MODID = "hodgepodge";
+    public static final String VERSION = "GRADLETOKEN_VERSION";
+    public static final String NAME = "A Hodgepodge of Patches";
+    public static LoadingConfig config;
+    public static boolean thermosTainted;
+    public static XSTR RNG = new XSTR();
+
+    static {
+        Common.log.info("Initializing Hodgepodge");
+        Common.config = new LoadingConfig(new File(Launch.minecraftHome, "config/hodgepodge.cfg"));
+        Common.log.info("Looking for Thermos/Bukkit taint.");
+        try {
+            Class.forName("org.bukkit.World");
+            Common.thermosTainted = true;
+            Common.log.warn(
+                    "Thermos/Bukkit detected; This is an unsupported configuration -- Things may not function properly.");
+            Common.log.warn(
+                    " Using `{}` for CraftServer Package.  If this is not correct, please update your config file!",
+                    Common.config.thermosCraftServerClass);
+        } catch (ClassNotFoundException e) {
+            Common.thermosTainted = false;
+            Common.log.info("Thermos/Bukkit NOT detected :-D");
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -12,13 +12,16 @@ import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.relauncher.Side;
 
 @Mod(
-        modid = Common.MODID,
-        version = Common.VERSION,
-        name = Common.NAME,
+        modid = Hodgepodge.MODID,
+        version = Hodgepodge.VERSION,
+        name = Hodgepodge.NAME,
         acceptableRemoteVersions = "*",
         dependencies = "required-after:spongemixins@[1.4.0,);")
 public class Hodgepodge {
     public static final AnchorAlarm ANCHOR_ALARM = new AnchorAlarm();
+    public static final String MODID = "hodgepodge";
+    public static final String VERSION = "GRADLETOKEN_VERSION";
+    public static final String NAME = "A Hodgepodge of Patches";
 
     @EventHandler
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -1,7 +1,6 @@
 package com.mitchej123.hodgepodge;
 
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
-import com.mitchej123.hodgepodge.core.LoadingConfig;
 import com.mitchej123.hodgepodge.core.commands.DebugCommand;
 import com.mitchej123.hodgepodge.core.util.AnchorAlarm;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -11,46 +10,15 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.relauncher.Side;
-import java.io.File;
-import net.minecraft.launchwrapper.Launch;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @Mod(
-        modid = Hodgepodge.MODID,
-        version = Hodgepodge.VERSION,
-        name = Hodgepodge.NAME,
+        modid = Common.MODID,
+        version = Common.VERSION,
+        name = Common.NAME,
         acceptableRemoteVersions = "*",
         dependencies = "required-after:spongemixins@[1.4.0,);")
 public class Hodgepodge {
-    public static final Logger log = LogManager.getLogger("Hodgepodge");
-    public static final String MODID = "hodgepodge";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String NAME = "A Hodgepodge of Patches";
-
-    public static LoadingConfig config;
-    public static boolean thermosTainted;
-
-    public static XSTR RNG = new XSTR();
     public static final AnchorAlarm ANCHOR_ALARM = new AnchorAlarm();
-
-    static {
-        Hodgepodge.log.info("Initializing Hodgepodge");
-        config = new LoadingConfig(new File(Launch.minecraftHome, "config/hodgepodge.cfg"));
-        Hodgepodge.log.info("Looking for Thermos/Bukkit taint.");
-        try {
-            Class.forName("org.bukkit.World");
-            thermosTainted = true;
-            Hodgepodge.log.warn(
-                    "Thermos/Bukkit detected; This is an unsupported configuration -- Things may not function properly.");
-            Hodgepodge.log.warn(
-                    " Using `{}` for CraftServer Package.  If this is not correct, please update your config file!",
-                    config.thermosCraftServerClass);
-        } catch (ClassNotFoundException e) {
-            thermosTainted = false;
-            Hodgepodge.log.info("Thermos/Bukkit NOT detected :-D");
-        }
-    }
 
     @EventHandler
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/mitchej123/hodgepodge/asm/BibliocraftTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/BibliocraftTransformer.java
@@ -2,7 +2,7 @@ package com.mitchej123.hodgepodge.asm;
 
 import static org.objectweb.asm.Opcodes.ASM5;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.launchwrapper.IClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -20,7 +20,7 @@ public class BibliocraftTransformer implements IClassTransformer {
                 || "jds.bibliowood.forestrywood.WoodsLoader".equals(transformedName)
                 || "jds.bibliowood.naturawood.WoodsLoader".equals(transformedName)
                 || "jds.bibliowood.bopwood.WoodsLoader".equals(transformedName)) {
-            Hodgepodge.log.info("Patching Bibliocraft {}", transformedName);
+            Common.log.info("Patching Bibliocraft {}", transformedName);
             final ClassReader cr = new ClassReader(basicClass);
             final ClassWriter cw = new ClassWriter(0);
 
@@ -28,7 +28,7 @@ public class BibliocraftTransformer implements IClassTransformer {
             cr.accept(cn, 0);
             for (MethodNode m : cn.methods) {
                 if ("addRecipies".equals(m.name) || "initRecipes".equals(m.name)) {
-                    Hodgepodge.log.info("Taking a sledgehammer to {}.{}()", transformedName, m.name);
+                    Common.log.info("Taking a sledgehammer to {}.{}()", transformedName, m.name);
                     // Replace the body with a RETURN opcode
                     InsnList insnList = new InsnList();
                     insnList.add(new InsnNode(Opcodes.RETURN));

--- a/src/main/java/com/mitchej123/hodgepodge/asm/HodgePodgeASMLoader.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/HodgePodgeASMLoader.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.asm;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,28 +28,28 @@ public class HodgePodgeASMLoader
     public enum AsmTransformers {
         POLLUTION_TRANSFORMER(
                 "Pollution Transformer",
-                () -> Hodgepodge.config.pollutionAsm,
+                () -> Common.config.pollutionAsm,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.PollutionClassTransformer")),
         CoFHWorldTransformer(
                 "World Transformer - Remove CoFH tile entity cache",
-                () -> Hodgepodge.config.cofhWorldTransformer,
+                () -> Common.config.cofhWorldTransformer,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.WorldTransformer")),
         SpeedupProgressBar(
                 "Speed up Progress Bar by speeding up stripSpecialCharacters",
-                () -> Hodgepodge.config.speedupProgressBar,
+                () -> Common.config.speedupProgressBar,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.SpeedupProgressBarTransformer")),
         FIX_TINKER_POTION_EFFECT_OFFSET(
                 "Prevents the inventory from shifting when the player has active potion effects",
-                () -> Hodgepodge.config.fixPotionRenderOffset,
+                () -> Common.config.fixPotionRenderOffset,
                 Collections.singletonList(
                         "com.mitchej123.hodgepodge.asm.transformers.tconstruct.TabRegistryTransformer")),
         THERMOS_SLEDGEHAMMER_FURNACE_FIX(
                 "Take a sledgehammer to CraftServer.resetRecipes() to prevent it from breaking our Furnace Fix",
-                () -> Hodgepodge.thermosTainted && Hodgepodge.config.speedupVanillaFurnace,
+                () -> Common.thermosTainted && Common.config.speedupVanillaFurnace,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.ThermosFurnaceSledgeHammer")),
         BIBLIOCRAFT_RECIPE_SLEDGEHAMMER(
                 "Remove recipes from Bibliocraft BlockLoader and Itemloader : addRecipies()",
-                () -> Hodgepodge.config.biblocraftRecipes,
+                () -> Common.config.biblocraftRecipes,
                 Collections.singletonList("com.mitchej123.hodgepodge.asm.BibliocraftTransformer"));
 
         private final String name;

--- a/src/main/java/com/mitchej123/hodgepodge/asm/ThermosFurnaceSledgeHammer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/ThermosFurnaceSledgeHammer.java
@@ -2,7 +2,7 @@ package com.mitchej123.hodgepodge.asm;
 
 import static org.objectweb.asm.Opcodes.ASM5;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.launchwrapper.IClassTransformer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -20,7 +20,7 @@ public class ThermosFurnaceSledgeHammer implements IClassTransformer {
 
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
-        if (Hodgepodge.config.thermosCraftServerClass.equals(transformedName)) {
+        if (Common.config.thermosCraftServerClass.equals(transformedName)) {
             LOGGER.info("Patching Thermos or derivative to not break our furnace fix");
             final ClassReader cr = new ClassReader(basicClass);
             final ClassWriter cw = new ClassWriter(0);

--- a/src/main/java/com/mitchej123/hodgepodge/asm/transformers/tconstruct/TabRegistryTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/transformers/tconstruct/TabRegistryTransformer.java
@@ -2,7 +2,7 @@ package com.mitchej123.hodgepodge.asm.transformers.tconstruct;
 
 import static org.objectweb.asm.Opcodes.ASM5;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.launchwrapper.IClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -14,7 +14,7 @@ public class TabRegistryTransformer implements IClassTransformer {
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
         if ("tconstruct.client.tabs.TabRegistry".equals(transformedName)) {
-            Hodgepodge.log.info("Patching TConstruct {}", transformedName);
+            Common.log.info("Patching TConstruct {}", transformedName);
             final ClassReader cr = new ClassReader(basicClass);
             final ClassWriter cw = new ClassWriter(0);
             final ClassNode cn = new ClassNode(ASM5);

--- a/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/DebugScreenHandler.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.client;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.client.Minecraft;
@@ -42,11 +42,11 @@ public class DebugScreenHandler {
             event.right.add(6, "CPU Cores: " + Runtime.getRuntime().availableProcessors());
             event.right.add(7, "OS: " + this.osName + " (" + this.osVersion + ", " + this.osArch + ")");
 
-            if (Hodgepodge.config.speedupAnimations || Hodgepodge.config.renderDebug) {
+            if (Common.config.speedupAnimations || Common.config.renderDebug) {
                 event.right.add(8, null); // Empty Line
-                if (Hodgepodge.config.speedupAnimations)
+                if (Common.config.speedupAnimations)
                     event.right.add(9, "animationsMode: " + HodgePodgeClient.animationsMode);
-                if (Hodgepodge.config.renderDebug)
+                if (Common.config.renderDebug)
                     event.right.add(9, "renderDebugMode: " + HodgePodgeClient.renderDebugMode);
             }
         }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgePodgeClient.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.core;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.asm.References;
 import com.mitchej123.hodgepodge.client.ClientTicker;
 import com.mitchej123.hodgepodge.client.DebugScreenHandler;
@@ -24,18 +24,18 @@ public class HodgePodgeClient {
         colorLeaves = References.gt_PollutionRenderer.getMethod("colorLeaves").resolve();
         colorFoliage = References.gt_PollutionRenderer.getMethod("colorFoliage").resolve();
 
-        if (Hodgepodge.config.renderDebug) {
-            renderDebugMode.set(Hodgepodge.config.renderDebugMode);
+        if (Common.config.renderDebug) {
+            renderDebugMode.set(Common.config.renderDebugMode);
         } else {
             renderDebugMode.set(RenderDebugMode.OFF);
         }
 
-        if (Hodgepodge.config.enableDefaultLanPort) {
-            if (Hodgepodge.config.defaultLanPort < 0 || Hodgepodge.config.defaultLanPort > 65535) {
-                Hodgepodge.log.error(String.format(
+        if (Common.config.enableDefaultLanPort) {
+            if (Common.config.defaultLanPort < 0 || Common.config.defaultLanPort > 65535) {
+                Common.log.error(String.format(
                         "Default LAN port number must be in range of 0-65535, but %s was given. Defaulting to 0.",
-                        Hodgepodge.config.defaultLanPort));
-                Hodgepodge.config.defaultLanPort = 0;
+                        Common.config.defaultLanPort));
+                Common.config.defaultLanPort = 0;
             }
         }
 
@@ -50,11 +50,11 @@ public class HodgePodgeClient {
 
         FMLCommonHandler.instance().bus().register(ClientTicker.INSTANCE);
 
-        if (Hodgepodge.config.addSystemInfo) {
+        if (Common.config.addSystemInfo) {
             MinecraftForge.EVENT_BUS.register(DebugScreenHandler.INSTANCE);
         }
 
-        if (Hodgepodge.config.speedupAnimations) {
+        if (Common.config.speedupAnimations) {
             FMLCommonHandler.instance().bus().register(new ClientKeyListener());
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeMixinPlugin.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.core;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.mixins.Mixins;
 import com.mitchej123.hodgepodge.mixins.TargetedMod;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -50,15 +50,15 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
 
         for (TargetedMod mod : TargetedMod.values()) {
             if (loadedMods.contains(mod)) {
-                Hodgepodge.log.info("Found Mod " + mod.modName + "!");
-            } else if (ArrayUtils.contains(Hodgepodge.config.requiredMods, mod.modName)
-                    && (!isEnvironmentDeobfuscated || Hodgepodge.config.requiredModsInDev)) {
-                Hodgepodge.log.error(
+                Common.log.info("Found Mod " + mod.modName + "!");
+            } else if (ArrayUtils.contains(Common.config.requiredMods, mod.modName)
+                    && (!isEnvironmentDeobfuscated || Common.config.requiredModsInDev)) {
+                Common.log.error(
                         "CRITICAL ERROR: Could not find required jar {}.  If this mod is not required please remove it from the 'requiredMods' section of the config.",
                         mod.modName);
                 FMLCommonHandler.instance().exitJava(-1, true);
             } else {
-                Hodgepodge.log.info("Could not find " + mod.modName + "! Skipping mixins....");
+                Common.log.info("Could not find " + mod.modName + "! Skipping mixins....");
             }
         }
 
@@ -66,9 +66,9 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
         for (Mixins mixin : Mixins.values()) {
             if (mixin.shouldLoad(loadedMods)) {
                 mixins.addAll(mixin.mixinClass);
-                Hodgepodge.log.info("Loading hodgepodge mixin: " + mixin.mixinClass);
+                Common.log.info("Loading hodgepodge mixin: " + mixin.mixinClass);
             } else {
-                Hodgepodge.log.info("NOT loading mixin: " + mixin.mixinClass);
+                Common.log.info("NOT loading mixin: " + mixin.mixinClass);
             }
         }
 
@@ -85,13 +85,13 @@ public class HodgepodgeMixinPlugin implements IMixinConfigPlugin {
         try {
             File jar = MinecraftURLClassPath.getJarInModPath(mod.jarName);
             if (jar == null) {
-                Hodgepodge.log.info("Jar not found for " + mod);
+                Common.log.info("Jar not found for " + mod);
                 return false;
             }
             // TODO it loads the wrong .jar for certain mods that contains the same same
             //  for instance with TargetedMod = TINKERSCONSTRUCT("TConstruct", "TConstruct", "TinkersConstruct")
             //  it loads IguanaTweaksTConstruct-1.7.10-2.2.2.jar instead
-            Hodgepodge.log.info("Attempting to add " + jar + " to the URL Class Path");
+            Common.log.info("Attempting to add " + jar + " to the URL Class Path");
             if (!jar.exists()) {
                 throw new FileNotFoundException(jar.toString());
             }

--- a/src/main/java/com/mitchej123/hodgepodge/core/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/handlers/ClientKeyListener.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.core.handlers;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.core.HodgePodgeClient;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
@@ -20,7 +20,7 @@ public class ClientKeyListener {
         if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown() && released) {
             if (key == Keyboard.KEY_N) {
                 HodgePodgeClient.animationsMode.next();
-            } else if (key == Keyboard.KEY_D && Hodgepodge.config.renderDebug) {
+            } else if (key == Keyboard.KEY_D && Common.config.renderDebug) {
                 HodgePodgeClient.renderDebugMode.next();
             }
         }

--- a/src/main/java/com/mitchej123/hodgepodge/core/util/AnchorAlarm.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/util/AnchorAlarm.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.core.util;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import io.netty.buffer.ByteBuf;
@@ -40,7 +40,7 @@ public class AnchorAlarm {
             if (((EntityPlayer) obj).getDisplayName().equals(playerName)) {
                 NBTTagCompound nbt = ((EntityPlayer) obj).getEntityData();
                 if (!nbt.hasKey(NBT_KEY)) {
-                    Hodgepodge.log.debug("[AnchorDebug] No anchors listed for player " + playerName);
+                    Common.log.debug("[AnchorDebug] No anchors listed for player " + playerName);
                 } else {
                     byte[] bytes = nbt.getByteArray(NBT_KEY);
                     ByteBuf buf = Unpooled.wrappedBuffer(bytes);
@@ -50,7 +50,7 @@ public class AnchorAlarm {
                         int x = buf.readInt();
                         int y = buf.readInt();
                         int z = buf.readInt();
-                        Hodgepodge.log.debug("[AnchorDebug] Anchor (" + x + ", " + y + ", " + z + ") at dim " + dim
+                        Common.log.debug("[AnchorDebug] Anchor (" + x + ", " + y + ", " + z + ") at dim " + dim
                                 + " for player " + playerName);
                     }
                 }
@@ -73,7 +73,7 @@ public class AnchorAlarm {
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.player instanceof EntityPlayerMP) {
             if (AnchorDebug) {
-                Hodgepodge.log.debug("[AnchorDebug] Loading anchors for player " + event.player.getDisplayName());
+                Common.log.debug("[AnchorDebug] Loading anchors for player " + event.player.getDisplayName());
             }
             if (event.player.getEntityData().hasKey(NBT_KEY)) {
                 byte[] bytes = event.player.getEntityData().getByteArray(NBT_KEY);
@@ -125,7 +125,7 @@ public class AnchorAlarm {
                         } else if (AnchorDebug) System.out.println("[AnchorDebug] Failed loading dimension " + dim);
                     }
                 } catch (IndexOutOfBoundsException ignored) {
-                    Hodgepodge.log.error("Error reading anchor list!");
+                    Common.log.error("Error reading anchor list!");
                 }
                 byte[] newbytes = new byte[validAlarmCount * 16];
                 newbuf.readBytes(newbytes);

--- a/src/main/java/com/mitchej123/hodgepodge/core/util/BlockMatcher.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/util/BlockMatcher.java
@@ -2,7 +2,7 @@ package com.mitchej123.hodgepodge.core.util;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.registry.FMLControlledNamespacedRegistry;
 import cpw.mods.fml.common.registry.GameData;
@@ -32,14 +32,14 @@ public class BlockMatcher {
         whiteList.clear();
         blackList.clear();
         for (String line : cfg) {
-            Hodgepodge.log.info("Checking for block:" + line);
+            Common.log.info("Checking for block:" + line);
             String[] lines = line.split(":");
             ColorOverrideType type = null;
             if (lines.length > 1) {
                 try {
                     type = ColorOverrideType.get(lines[1].trim());
                 } catch (NumberFormatException e) {
-                    Hodgepodge.log.error(String.format("Invalid type [%s]", line));
+                    Common.log.error(String.format("Invalid type [%s]", line));
                     continue;
                 }
             }
@@ -47,18 +47,18 @@ public class BlockMatcher {
             if (lines[0].startsWith("-")) {
                 try {
                     blackList.add(Class.forName(lines[0].substring(1)));
-                    Hodgepodge.log.info("\t added blacklist:" + lines[0].substring(1));
+                    Common.log.info("\t added blacklist:" + lines[0].substring(1));
                 } catch (ClassNotFoundException ignored) {
                 }
             } else {
                 if (type == null) {
-                    Hodgepodge.log.error(String.format("Invalid type [%s]", line));
+                    Common.log.error(String.format("Invalid type [%s]", line));
                     continue;
                 }
 
                 try {
                     whiteList.put(Class.forName(lines[0]), type);
-                    Hodgepodge.log.info("\t added whitelist:" + lines[0]);
+                    Common.log.info("\t added whitelist:" + lines[0]);
                 } catch (ClassNotFoundException ignored) {
                 }
             }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -10,22 +10,15 @@ import java.util.function.Supplier;
 public enum Mixins {
     // Vanilla Fixes
     THROTTLE_ITEMPICKUPEVENT(
-            "minecraft.MixinEntityPlayer",
-            Side.BOTH,
-            () -> Common.config.throttleItemPickupEvent,
-            TargetedMod.VANILLA),
+            "minecraft.MixinEntityPlayer", Side.BOTH, () -> Common.config.throttleItemPickupEvent, TargetedMod.VANILLA),
     FIX_PERSPECTIVE_CAMERA(
             "minecraft.MixinEntityRenderer",
             Side.CLIENT,
             () -> Common.config.fixPerspectiveCamera,
             TargetedMod.VANILLA),
     FIX_DEBUG_BOUNDING_BOX(
-            "minecraft.MixinRenderManager",
-            Side.CLIENT,
-            () -> Common.config.fixDebugBoundingBox,
-            TargetedMod.VANILLA),
-    FENCE_CONNECTIONS_FIX(
-            "minecraft.MixinBlockFence", () -> Common.config.fixFenceConnections, TargetedMod.VANILLA),
+            "minecraft.MixinRenderManager", Side.CLIENT, () -> Common.config.fixDebugBoundingBox, TargetedMod.VANILLA),
+    FENCE_CONNECTIONS_FIX("minecraft.MixinBlockFence", () -> Common.config.fixFenceConnections, TargetedMod.VANILLA),
     FIX_INVENTORY_OFFSET_WITH_POTIONS(
             "minecraft.MixinInventoryEffectRenderer_PotionOffset",
             Side.CLIENT,
@@ -84,8 +77,7 @@ public enum Mixins {
             Side.CLIENT,
             () -> Common.config.increaseParticleLimit,
             TargetedMod.VANILLA),
-    FIX_POTION_LIMIT(
-            "minecraft.MixinPotionEffect", Side.BOTH, () -> Common.config.fixPotionLimit, TargetedMod.VANILLA),
+    FIX_POTION_LIMIT("minecraft.MixinPotionEffect", Side.BOTH, () -> Common.config.fixPotionLimit, TargetedMod.VANILLA),
     FIX_HOPPER_VOIDING_ITEMS(
             "minecraft.MixinTileEntityHopper", () -> Common.config.fixHopperVoidingItems, TargetedMod.VANILLA),
     FIX_HUGE_CHAT_KICK("minecraft.MixinS02PacketChat", () -> Common.config.fixHugeChatKick, TargetedMod.VANILLA),
@@ -154,19 +146,13 @@ public enum Mixins {
     GRASS_GET_BLOCK_FIX(
             "minecraft.MixinBlockGrass", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     FIRE_GET_BLOCK_FIX(
-            "minecraft.MixinBlockFireGetBlock",
-            () -> Common.config.fixVanillaUnprotectedGetBlock,
-            TargetedMod.VANILLA),
+            "minecraft.MixinBlockFireGetBlock", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     VILLAGE_GET_BLOCK_FIX(
             "minecraft.MixinVillage", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     VILLAGE_COLLECTION_GET_BLOCK_FIX(
-            "minecraft.MixinVillageCollection",
-            () -> Common.config.fixVanillaUnprotectedGetBlock,
-            TargetedMod.VANILLA),
+            "minecraft.MixinVillageCollection", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     FLUID_CLASSIC_GET_BLOCK_FIX(
-            "minecraft.MixinBlockFluidClassic",
-            () -> Common.config.fixVanillaUnprotectedGetBlock,
-            TargetedMod.VANILLA),
+            "minecraft.MixinBlockFluidClassic", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(
@@ -175,16 +161,12 @@ public enum Mixins {
             "ic2.MixinItemCropSeed", () -> Common.config.fixIc2DirectInventoryAccess, TargetedMod.IC2),
     IC2_DIRECT_INV_ACCESS_CROP(
             "ic2.MixinTileEntityCrop", () -> Common.config.fixIc2DirectInventoryAccess, TargetedMod.IC2),
-    IC2_NIGHT_VISION_NANO(
-            "ic2.MixinIc2NanoSuitNightVision", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
+    IC2_NIGHT_VISION_NANO("ic2.MixinIc2NanoSuitNightVision", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
     IC2_NIGHT_VISION_QUANTUM(
             "ic2.MixinIc2QuantumSuitNightVision", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
-    IC2_NIGHT_VISION_GOGGLES(
-            "ic2.MixinIc2NightVisionGoggles", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
+    IC2_NIGHT_VISION_GOGGLES("ic2.MixinIc2NightVisionGoggles", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
     IC2_REACTOR_DUPE(
-            "ic2.MixinTileEntityReactorChamberElectricNoDupe",
-            () -> Common.config.fixIc2ReactorDupe,
-            TargetedMod.IC2),
+            "ic2.MixinTileEntityReactorChamberElectricNoDupe", () -> Common.config.fixIc2ReactorDupe, TargetedMod.IC2),
     IC2_REACTOR_INVENTORY_SPEEDUP(
             "ic2.MixinTileEntityReactorChamberElectricInvSpeedup",
             () -> Common.config.optimizeIc2ReactorInventoryAccess,
@@ -194,8 +176,7 @@ public enum Mixins {
     IC2_HAZMAT("ic2.MixinIc2Hazmat", () -> Common.config.fixIc2Hazmat, TargetedMod.IC2, TargetedMod.GT5U),
     IC2_FLUID_CONTAINER_TOOLTIP(
             "ic2.MixinItemIC2FluidContainer", () -> Common.config.displayIc2FluidLocalizedName, TargetedMod.IC2),
-    IC2_FLUID_RENDER_FIX(
-            "ic2.textures.MixinRenderLiquidCell", () -> Common.config.speedupAnimations, TargetedMod.IC2),
+    IC2_FLUID_RENDER_FIX("ic2.textures.MixinRenderLiquidCell", () -> Common.config.speedupAnimations, TargetedMod.IC2),
 
     // gregtech
     GREGTECH_FLUID_RENDER_FIX(
@@ -227,17 +208,11 @@ public enum Mixins {
 
     // Thaumcraft
     THAUMCRAFT_ARCANE_LAMP_GET_BLOCK_FIX(
-            "thaumcraft.MixinArcaneLamp",
-            () -> Common.config.fixThaumcraftUnprotectedGetBlock,
-            TargetedMod.THAUMCRAFT),
+            "thaumcraft.MixinArcaneLamp", () -> Common.config.fixThaumcraftUnprotectedGetBlock, TargetedMod.THAUMCRAFT),
     THAUMCRAFT_WISP_GET_BLOCK_FIX(
-            "thaumcraft.MixinEntityWisp",
-            () -> Common.config.fixThaumcraftUnprotectedGetBlock,
-            TargetedMod.THAUMCRAFT),
+            "thaumcraft.MixinEntityWisp", () -> Common.config.fixThaumcraftUnprotectedGetBlock, TargetedMod.THAUMCRAFT),
     ADD_CV_SUPPORT_TO_WAND_PEDESTAL(
-            "thaumcraft.MixinTileWandPedestal",
-            () -> Common.config.addCVSupportToWandPedestal,
-            TargetedMod.THAUMCRAFT),
+            "thaumcraft.MixinTileWandPedestal", () -> Common.config.addCVSupportToWandPedestal, TargetedMod.THAUMCRAFT),
 
     // BOP
     DEDUPLICATE_FORESTRY_COMPAT_IN_BOP(
@@ -245,34 +220,26 @@ public enum Mixins {
             () -> Common.config.deduplicateForestryCompatInBOP,
             TargetedMod.BOP),
     SPEEDUP_BOP_BIOME_FOG(
-            "biomesoplenty.MixinFogHandler",
-            Side.CLIENT,
-            () -> Common.config.speedupBOPFogHandling,
-            TargetedMod.BOP),
+            "biomesoplenty.MixinFogHandler", Side.CLIENT, () -> Common.config.speedupBOPFogHandling, TargetedMod.BOP),
     BIG_FIR_TREES("biomesoplenty.MixinBlockBOPSapling", () -> Common.config.makeBigFirsPlantable, TargetedMod.BOP),
 
     // MrTJPCore (Project Red)
-    FIX_HUD_LIGHTING_GLITCH(
-            "mrtjpcore.MixinFXEngine", () -> Common.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE),
-    FIX_POPPING_OFF(
-            "mrtjpcore.MixinPlacementLib", () -> Common.config.fixComponentsPoppingOff, TargetedMod.MRTJPCORE),
+    FIX_HUD_LIGHTING_GLITCH("mrtjpcore.MixinFXEngine", () -> Common.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE),
+    FIX_POPPING_OFF("mrtjpcore.MixinPlacementLib", () -> Common.config.fixComponentsPoppingOff, TargetedMod.MRTJPCORE),
 
     // Automagy
     IMPLEMENTS_CONTAINER_FOR_THIRSTY_TANK(
             "automagy.MixinItemBlockThirstyTank", () -> Common.config.thirstyTankContainer, TargetedMod.AUTOMAGY),
 
     // ProjectE
-    FIX_FURNACE_ITERATION(
-            "projecte.MixinObjHandler", () -> Common.config.speedupVanillaFurnace, TargetedMod.PROJECTE),
+    FIX_FURNACE_ITERATION("projecte.MixinObjHandler", () -> Common.config.speedupVanillaFurnace, TargetedMod.PROJECTE),
 
     FIX_JOURNEYMAP_KEYBINDS(
             "journeymap.MixinConstants", () -> Common.config.fixJourneymapKeybinds, TargetedMod.JOURNEYMAP),
 
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(
-            "harvestthenether.MixinBlockPamFruit",
-            () -> Common.config.fixIgnisFruitAABB,
-            TargetedMod.HARVESTTHENETHER),
+            "harvestthenether.MixinBlockPamFruit", () -> Common.config.fixIgnisFruitAABB, TargetedMod.HARVESTTHENETHER),
     FIX_NETHER_LEAVES_FACE_RENDERING(
             "harvestthenether.MixinBlockNetherLeaves",
             Side.CLIENT,

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,109 +12,109 @@ public enum Mixins {
     THROTTLE_ITEMPICKUPEVENT(
             "minecraft.MixinEntityPlayer",
             Side.BOTH,
-            () -> Hodgepodge.config.throttleItemPickupEvent,
+            () -> Common.config.throttleItemPickupEvent,
             TargetedMod.VANILLA),
     FIX_PERSPECTIVE_CAMERA(
             "minecraft.MixinEntityRenderer",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixPerspectiveCamera,
+            () -> Common.config.fixPerspectiveCamera,
             TargetedMod.VANILLA),
     FIX_DEBUG_BOUNDING_BOX(
             "minecraft.MixinRenderManager",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixDebugBoundingBox,
+            () -> Common.config.fixDebugBoundingBox,
             TargetedMod.VANILLA),
     FENCE_CONNECTIONS_FIX(
-            "minecraft.MixinBlockFence", () -> Hodgepodge.config.fixFenceConnections, TargetedMod.VANILLA),
+            "minecraft.MixinBlockFence", () -> Common.config.fixFenceConnections, TargetedMod.VANILLA),
     FIX_INVENTORY_OFFSET_WITH_POTIONS(
             "minecraft.MixinInventoryEffectRenderer_PotionOffset",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixPotionRenderOffset,
+            () -> Common.config.fixPotionRenderOffset,
             TargetedMod.VANILLA),
     FIX_POTION_EFFECT_RENDERING(
             "minecraft.MixinInventoryEffectRenderer_PotionEffectRendering",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixPotionEffectRender,
+            () -> Common.config.fixPotionEffectRender,
             TargetedMod.VANILLA),
     FIX_IMMOBILE_FIREBALLS(
-            "minecraft.MixinEntityFireball", () -> Hodgepodge.config.fixImmobileFireballs, TargetedMod.VANILLA),
+            "minecraft.MixinEntityFireball", () -> Common.config.fixImmobileFireballs, TargetedMod.VANILLA),
     CHUNK_COORDINATES_HASHCODE(
             "minecraft.MixinChunkCoordinates",
-            () -> Hodgepodge.config.speedupChunkCoordinatesHashCode,
+            () -> Common.config.speedupChunkCoordinatesHashCode,
             TargetedMod.VANILLA),
-    TCP_NODELAY("minecraft.MixinTcpNoDelay", () -> Hodgepodge.config.tcpNoDelay, TargetedMod.VANILLA),
+    TCP_NODELAY("minecraft.MixinTcpNoDelay", () -> Common.config.tcpNoDelay, TargetedMod.VANILLA),
     WORLD_UNPROTECTED_GET_BLOCK(
-            "minecraft.MixinWorldGetBlock", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
+            "minecraft.MixinWorldGetBlock", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     WORLD_UNPROTECTED_LIGHT_VALUE(
-            "minecraft.MixinWorldLightValue", () -> Hodgepodge.config.fixGetBlockLightValue, TargetedMod.VANILLA),
-    FORGE_HOOKS_URL_FIX("minecraft.MixinForgeHooks", () -> Hodgepodge.config.fixUrlDetection, TargetedMod.VANILLA),
+            "minecraft.MixinWorldLightValue", () -> Common.config.fixGetBlockLightValue, TargetedMod.VANILLA),
+    FORGE_HOOKS_URL_FIX("minecraft.MixinForgeHooks", () -> Common.config.fixUrlDetection, TargetedMod.VANILLA),
     NORTHWEST_BIAS_FIX(
-            "minecraft.MixinRandomPositionGenerator", () -> Hodgepodge.config.fixNorthWestBias, TargetedMod.VANILLA),
+            "minecraft.MixinRandomPositionGenerator", () -> Common.config.fixNorthWestBias, TargetedMod.VANILLA),
     SPEEDUP_VANILLA_FURNACE(
-            "minecraft.MixinFurnaceRecipes", () -> Hodgepodge.config.speedupVanillaFurnace, TargetedMod.GTNHLIB),
+            "minecraft.MixinFurnaceRecipes", () -> Common.config.speedupVanillaFurnace, TargetedMod.GTNHLIB),
     GAMEOVER_GUI_LOCKED_DISABLED(
-            "minecraft.MixinGuiGameOver", Side.CLIENT, () -> Hodgepodge.config.fixGuiGameOver, TargetedMod.VANILLA),
+            "minecraft.MixinGuiGameOver", Side.CLIENT, () -> Common.config.fixGuiGameOver, TargetedMod.VANILLA),
     PREVENT_PICKUP_LOOT(
-            "minecraft.MixinEntityLivingPickup", () -> Hodgepodge.config.preventPickupLoot, TargetedMod.VANILLA),
+            "minecraft.MixinEntityLivingPickup", () -> Common.config.preventPickupLoot, TargetedMod.VANILLA),
     DROP_PICKED_LOOT_ON_DESPAWN(
-            "minecraft.MixinEntityLivingDrop", () -> Hodgepodge.config.dropPickedLootOnDespawn, TargetedMod.VANILLA),
-    FIX_HOPPER_HIT_BOX("minecraft.MixinBlockHopper", () -> Hodgepodge.config.fixHopperHitBox, TargetedMod.VANILLA),
+            "minecraft.MixinEntityLivingDrop", () -> Common.config.dropPickedLootOnDespawn, TargetedMod.VANILLA),
+    FIX_HOPPER_HIT_BOX("minecraft.MixinBlockHopper", () -> Common.config.fixHopperHitBox, TargetedMod.VANILLA),
     TILE_RENDERER_PROFILER_DISPATCHER(
             "minecraft.profiler.TileEntityRendererDispatcherMixin",
             Side.CLIENT,
-            () -> Hodgepodge.config.enableTileRendererProfiler,
+            () -> Common.config.enableTileRendererProfiler,
             TargetedMod.VANILLA),
     TILE_RENDERER_PROFILER_MINECRAFT(
             "minecraft.profiler.MinecraftMixin",
             Side.CLIENT,
-            () -> Hodgepodge.config.enableTileRendererProfiler,
+            () -> Common.config.enableTileRendererProfiler,
             TargetedMod.VANILLA),
     DIMENSION_CHANGE_FIX(
             "minecraft.MixinServerConfigurationManager",
             Side.BOTH,
-            () -> Hodgepodge.config.fixDimensionChangeHearts,
+            () -> Common.config.fixDimensionChangeHearts,
             TargetedMod.VANILLA),
     CLONE_PLAYER_HEART_FIX(
             "minecraft.MixinEntityPlayerMP",
             Side.BOTH,
-            () -> Hodgepodge.config.fixDimensionChangeHearts,
+            () -> Common.config.fixDimensionChangeHearts,
             TargetedMod.VANILLA),
     INCREASE_PARTICLE_LIMIT(
             "minecraft.MixinEffectRenderer",
             Side.CLIENT,
-            () -> Hodgepodge.config.increaseParticleLimit,
+            () -> Common.config.increaseParticleLimit,
             TargetedMod.VANILLA),
     FIX_POTION_LIMIT(
-            "minecraft.MixinPotionEffect", Side.BOTH, () -> Hodgepodge.config.fixPotionLimit, TargetedMod.VANILLA),
+            "minecraft.MixinPotionEffect", Side.BOTH, () -> Common.config.fixPotionLimit, TargetedMod.VANILLA),
     FIX_HOPPER_VOIDING_ITEMS(
-            "minecraft.MixinTileEntityHopper", () -> Hodgepodge.config.fixHopperVoidingItems, TargetedMod.VANILLA),
-    FIX_HUGE_CHAT_KICK("minecraft.MixinS02PacketChat", () -> Hodgepodge.config.fixHugeChatKick, TargetedMod.VANILLA),
+            "minecraft.MixinTileEntityHopper", () -> Common.config.fixHopperVoidingItems, TargetedMod.VANILLA),
+    FIX_HUGE_CHAT_KICK("minecraft.MixinS02PacketChat", () -> Common.config.fixHugeChatKick, TargetedMod.VANILLA),
     FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES(
             "minecraft.MixinWorldServerUpdateEntities",
-            () -> Hodgepodge.config.fixWorldServerLeakingUnloadedEntities,
+            () -> Common.config.fixWorldServerLeakingUnloadedEntities,
             TargetedMod.VANILLA),
     FIX_ARROW_WRONG_LIGHTING(
             "minecraft.MixinRendererLivingEntity",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixGlStateBugs,
+            () -> Common.config.fixGlStateBugs,
             TargetedMod.VANILLA),
     FIX_RESIZABLE_FULLSCREEN(
             "minecraft.MixinMinecraft_ResizableFullscreen",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixResizableFullscreen,
+            () -> Common.config.fixResizableFullscreen,
             TargetedMod.VANILLA),
     FIX_UNFOCUSED_FULLSCREEN(
             "minecraft.MixinMinecraft_UnfocusedFullscreen",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixUnfocusedFullscreen,
+            () -> Common.config.fixUnfocusedFullscreen,
             TargetedMod.VANILLA),
     ADD_TOGGLE_DEBUG_MESSAGE(
             "minecraft.MixinMinecraft_ToggleDebugMessage",
             Side.CLIENT,
-            () -> Hodgepodge.config.addToggleDebugMessage,
+            () -> Common.config.addToggleDebugMessage,
             TargetedMod.GTNHLIB),
     SPEEDUP_VANILLA_ANIMATIONS(
-            () -> Hodgepodge.config.speedupAnimations,
+            () -> Common.config.speedupAnimations,
             Side.CLIENT,
             TargetedMod.VANILLA,
             "minecraft.textures.client.MixinTextureAtlasSprite",
@@ -129,166 +129,166 @@ public enum Mixins {
     SPEEDUP_VANILLA_ANIMATIONS_FC(
             "minecraft.textures.client.fastcraft.MixinTextureMap",
             Side.CLIENT,
-            () -> Hodgepodge.config.speedupAnimations,
+            () -> Common.config.speedupAnimations,
             TargetedMod.FASTCRAFT),
     FIX_POTION_ITERATING(
             "minecraft.MixinEntityLivingPotions",
             Side.BOTH,
-            () -> Hodgepodge.config.fixPotionIterating,
+            () -> Common.config.fixPotionIterating,
             TargetedMod.VANILLA),
     OPTIMIZE_ASMDATATABLE_INDEX(
-            "forge.MixinASMDataTable", Side.BOTH, () -> Hodgepodge.config.optimizeASMDataTable, TargetedMod.VANILLA),
+            "forge.MixinASMDataTable", Side.BOTH, () -> Common.config.optimizeASMDataTable, TargetedMod.VANILLA),
     SQUASH_BED_ERROR_MESSAGE(
             "minecraft.MixinNetHandlePlayClient",
             Side.CLIENT,
-            () -> Hodgepodge.config.squashBedErrorMessage,
+            () -> Common.config.squashBedErrorMessage,
             TargetedMod.VANILLA),
-    RENDER_DEBUG("minecraft.MixinRenderGlobal", Side.CLIENT, () -> Hodgepodge.config.renderDebug, TargetedMod.VANILLA),
+    RENDER_DEBUG("minecraft.MixinRenderGlobal", Side.CLIENT, () -> Common.config.renderDebug, TargetedMod.VANILLA),
     STATIC_LAN_PORT(
             "minecraft.server.MixinHttpUtil",
             Side.CLIENT,
-            () -> Hodgepodge.config.enableDefaultLanPort,
+            () -> Common.config.enableDefaultLanPort,
             TargetedMod.VANILLA),
 
     // Potentially obsolete vanilla fixes
     GRASS_GET_BLOCK_FIX(
-            "minecraft.MixinBlockGrass", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
+            "minecraft.MixinBlockGrass", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     FIRE_GET_BLOCK_FIX(
             "minecraft.MixinBlockFireGetBlock",
-            () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock,
+            () -> Common.config.fixVanillaUnprotectedGetBlock,
             TargetedMod.VANILLA),
     VILLAGE_GET_BLOCK_FIX(
-            "minecraft.MixinVillage", () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
+            "minecraft.MixinVillage", () -> Common.config.fixVanillaUnprotectedGetBlock, TargetedMod.VANILLA),
     VILLAGE_COLLECTION_GET_BLOCK_FIX(
             "minecraft.MixinVillageCollection",
-            () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock,
+            () -> Common.config.fixVanillaUnprotectedGetBlock,
             TargetedMod.VANILLA),
     FLUID_CLASSIC_GET_BLOCK_FIX(
             "minecraft.MixinBlockFluidClassic",
-            () -> Hodgepodge.config.fixVanillaUnprotectedGetBlock,
+            () -> Common.config.fixVanillaUnprotectedGetBlock,
             TargetedMod.VANILLA),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(
-            "ic2.MixinIc2WaterKinetic", () -> Hodgepodge.config.fixIc2UnprotectedGetBlock, TargetedMod.IC2),
+            "ic2.MixinIc2WaterKinetic", () -> Common.config.fixIc2UnprotectedGetBlock, TargetedMod.IC2),
     IC2_DIRECT_INV_ACCESS_SEED(
-            "ic2.MixinItemCropSeed", () -> Hodgepodge.config.fixIc2DirectInventoryAccess, TargetedMod.IC2),
+            "ic2.MixinItemCropSeed", () -> Common.config.fixIc2DirectInventoryAccess, TargetedMod.IC2),
     IC2_DIRECT_INV_ACCESS_CROP(
-            "ic2.MixinTileEntityCrop", () -> Hodgepodge.config.fixIc2DirectInventoryAccess, TargetedMod.IC2),
+            "ic2.MixinTileEntityCrop", () -> Common.config.fixIc2DirectInventoryAccess, TargetedMod.IC2),
     IC2_NIGHT_VISION_NANO(
-            "ic2.MixinIc2NanoSuitNightVision", () -> Hodgepodge.config.fixIc2Nightvision, TargetedMod.IC2),
+            "ic2.MixinIc2NanoSuitNightVision", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
     IC2_NIGHT_VISION_QUANTUM(
-            "ic2.MixinIc2QuantumSuitNightVision", () -> Hodgepodge.config.fixIc2Nightvision, TargetedMod.IC2),
+            "ic2.MixinIc2QuantumSuitNightVision", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
     IC2_NIGHT_VISION_GOGGLES(
-            "ic2.MixinIc2NightVisionGoggles", () -> Hodgepodge.config.fixIc2Nightvision, TargetedMod.IC2),
+            "ic2.MixinIc2NightVisionGoggles", () -> Common.config.fixIc2Nightvision, TargetedMod.IC2),
     IC2_REACTOR_DUPE(
             "ic2.MixinTileEntityReactorChamberElectricNoDupe",
-            () -> Hodgepodge.config.fixIc2ReactorDupe,
+            () -> Common.config.fixIc2ReactorDupe,
             TargetedMod.IC2),
     IC2_REACTOR_INVENTORY_SPEEDUP(
             "ic2.MixinTileEntityReactorChamberElectricInvSpeedup",
-            () -> Hodgepodge.config.optimizeIc2ReactorInventoryAccess,
+            () -> Common.config.optimizeIc2ReactorInventoryAccess,
             TargetedMod.IC2),
     HIDE_IC2_REACTOR_COOLANT_SLOTS(
-            "ic2.MixinTileEntityNuclearReactorElectric", () -> Hodgepodge.config.hideIc2ReactorSlots, TargetedMod.IC2),
-    IC2_HAZMAT("ic2.MixinIc2Hazmat", () -> Hodgepodge.config.fixIc2Hazmat, TargetedMod.IC2, TargetedMod.GT5U),
+            "ic2.MixinTileEntityNuclearReactorElectric", () -> Common.config.hideIc2ReactorSlots, TargetedMod.IC2),
+    IC2_HAZMAT("ic2.MixinIc2Hazmat", () -> Common.config.fixIc2Hazmat, TargetedMod.IC2, TargetedMod.GT5U),
     IC2_FLUID_CONTAINER_TOOLTIP(
-            "ic2.MixinItemIC2FluidContainer", () -> Hodgepodge.config.displayIc2FluidLocalizedName, TargetedMod.IC2),
+            "ic2.MixinItemIC2FluidContainer", () -> Common.config.displayIc2FluidLocalizedName, TargetedMod.IC2),
     IC2_FLUID_RENDER_FIX(
-            "ic2.textures.MixinRenderLiquidCell", () -> Hodgepodge.config.speedupAnimations, TargetedMod.IC2),
+            "ic2.textures.MixinRenderLiquidCell", () -> Common.config.speedupAnimations, TargetedMod.IC2),
 
     // gregtech
     GREGTECH_FLUID_RENDER_FIX(
             "gregtech.textures.MixinGT_GeneratedMaterial_Renderer",
-            () -> Hodgepodge.config.speedupAnimations,
+            () -> Common.config.speedupAnimations,
             TargetedMod.GT5U),
     FIX_SAW_ICE_BREAK(
-            "minecraft.MixinBlockIce", () -> Hodgepodge.config.fixGTSawSpawningWaterWithIceBLock, TargetedMod.GT5U),
+            "minecraft.MixinBlockIce", () -> Common.config.fixGTSawSpawningWaterWithIceBLock, TargetedMod.GT5U),
 
     // COFH
     COFH_CORE_UPDATE_CHECK(
-            "cofhcore.MixinCoFHCoreUpdateCheck", () -> Hodgepodge.config.removeUpdateChecks, TargetedMod.COFH_CORE),
+            "cofhcore.MixinCoFHCoreUpdateCheck", () -> Common.config.removeUpdateChecks, TargetedMod.COFH_CORE),
 
     // Railcraft Anchors
     WAKE_ANCHORS_ON_LOGIN_PASSIVE(
-            "railcraft.MixinTileAnchorPassive", () -> Hodgepodge.config.installAnchorAlarm, TargetedMod.RAILCRAFT),
+            "railcraft.MixinTileAnchorPassive", () -> Common.config.installAnchorAlarm, TargetedMod.RAILCRAFT),
     WAKE_ANCHORS_ON_LOGIN_PERSONAL(
-            "railcraft.MixinTileAnchorPersonal", () -> Hodgepodge.config.installAnchorAlarm, TargetedMod.RAILCRAFT),
+            "railcraft.MixinTileAnchorPersonal", () -> Common.config.installAnchorAlarm, TargetedMod.RAILCRAFT),
 
     // Hunger overhaul
     HUNGER_OVERHAUL_LOW_STAT_EFFECT(
             "hungeroverhaul.MixinHungerOverhaulLowStatEffect",
-            () -> Hodgepodge.config.fixHungerOverhaul,
+            () -> Common.config.fixHungerOverhaul,
             TargetedMod.HUNGER_OVERHAUL),
     HUNGER_OVERHAUL_REGEN(
             "hungeroverhaul.MixinHungerOverhaulHealthRegen",
-            () -> Hodgepodge.config.fixHungerOverhaul,
+            () -> Common.config.fixHungerOverhaul,
             TargetedMod.HUNGER_OVERHAUL),
 
     // Thaumcraft
     THAUMCRAFT_ARCANE_LAMP_GET_BLOCK_FIX(
             "thaumcraft.MixinArcaneLamp",
-            () -> Hodgepodge.config.fixThaumcraftUnprotectedGetBlock,
+            () -> Common.config.fixThaumcraftUnprotectedGetBlock,
             TargetedMod.THAUMCRAFT),
     THAUMCRAFT_WISP_GET_BLOCK_FIX(
             "thaumcraft.MixinEntityWisp",
-            () -> Hodgepodge.config.fixThaumcraftUnprotectedGetBlock,
+            () -> Common.config.fixThaumcraftUnprotectedGetBlock,
             TargetedMod.THAUMCRAFT),
     ADD_CV_SUPPORT_TO_WAND_PEDESTAL(
             "thaumcraft.MixinTileWandPedestal",
-            () -> Hodgepodge.config.addCVSupportToWandPedestal,
+            () -> Common.config.addCVSupportToWandPedestal,
             TargetedMod.THAUMCRAFT),
 
     // BOP
     DEDUPLICATE_FORESTRY_COMPAT_IN_BOP(
             "biomesoplenty.MixinForestryIntegration",
-            () -> Hodgepodge.config.deduplicateForestryCompatInBOP,
+            () -> Common.config.deduplicateForestryCompatInBOP,
             TargetedMod.BOP),
     SPEEDUP_BOP_BIOME_FOG(
             "biomesoplenty.MixinFogHandler",
             Side.CLIENT,
-            () -> Hodgepodge.config.speedupBOPFogHandling,
+            () -> Common.config.speedupBOPFogHandling,
             TargetedMod.BOP),
-    BIG_FIR_TREES("biomesoplenty.MixinBlockBOPSapling", () -> Hodgepodge.config.makeBigFirsPlantable, TargetedMod.BOP),
+    BIG_FIR_TREES("biomesoplenty.MixinBlockBOPSapling", () -> Common.config.makeBigFirsPlantable, TargetedMod.BOP),
 
     // MrTJPCore (Project Red)
     FIX_HUD_LIGHTING_GLITCH(
-            "mrtjpcore.MixinFXEngine", () -> Hodgepodge.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE),
+            "mrtjpcore.MixinFXEngine", () -> Common.config.fixHudLightingGlitch, TargetedMod.MRTJPCORE),
     FIX_POPPING_OFF(
-            "mrtjpcore.MixinPlacementLib", () -> Hodgepodge.config.fixComponentsPoppingOff, TargetedMod.MRTJPCORE),
+            "mrtjpcore.MixinPlacementLib", () -> Common.config.fixComponentsPoppingOff, TargetedMod.MRTJPCORE),
 
     // Automagy
     IMPLEMENTS_CONTAINER_FOR_THIRSTY_TANK(
-            "automagy.MixinItemBlockThirstyTank", () -> Hodgepodge.config.thirstyTankContainer, TargetedMod.AUTOMAGY),
+            "automagy.MixinItemBlockThirstyTank", () -> Common.config.thirstyTankContainer, TargetedMod.AUTOMAGY),
 
     // ProjectE
     FIX_FURNACE_ITERATION(
-            "projecte.MixinObjHandler", () -> Hodgepodge.config.speedupVanillaFurnace, TargetedMod.PROJECTE),
+            "projecte.MixinObjHandler", () -> Common.config.speedupVanillaFurnace, TargetedMod.PROJECTE),
 
     FIX_JOURNEYMAP_KEYBINDS(
-            "journeymap.MixinConstants", () -> Hodgepodge.config.fixJourneymapKeybinds, TargetedMod.JOURNEYMAP),
+            "journeymap.MixinConstants", () -> Common.config.fixJourneymapKeybinds, TargetedMod.JOURNEYMAP),
 
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(
             "harvestthenether.MixinBlockPamFruit",
-            () -> Hodgepodge.config.fixIgnisFruitAABB,
+            () -> Common.config.fixIgnisFruitAABB,
             TargetedMod.HARVESTTHENETHER),
     FIX_NETHER_LEAVES_FACE_RENDERING(
             "harvestthenether.MixinBlockNetherLeaves",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixIgnisFruitAABB,
+            () -> Common.config.fixIgnisFruitAABB,
             TargetedMod.HARVESTTHENETHER),
     FIX_BAUBLES_INVENTORY_OFFSET_WITH_POTIONS(
-            "baubles.MixinGuiEvents", Side.CLIENT, () -> Hodgepodge.config.fixPotionRenderOffset, TargetedMod.BAUBLES),
+            "baubles.MixinGuiEvents", Side.CLIENT, () -> Common.config.fixPotionRenderOffset, TargetedMod.BAUBLES),
     FIX_GALACTICRAFT_INVENTORY_OFFSET_WITH_POTIONS(
             "galacticraftcore.MixinGuiExtendedInventory",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixPotionRenderOffset,
+            () -> Common.config.fixPotionRenderOffset,
             TargetedMod.GALACTICRAFT_CORE),
     FIX_TRAVELLERSGEAR_INVENTORY_OFFSET_WITH_POTIONS(
             "travellersgear.MixinClientProxy",
             Side.CLIENT,
-            () -> Hodgepodge.config.fixPotionRenderOffset,
+            () -> Common.config.fixPotionRenderOffset,
             TargetedMod.TRAVELLERSGEAR);
 
     public final List<String> mixinClass;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hungeroverhaul/MixinHungerOverhaulLowStatEffect.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hungeroverhaul/MixinHungerOverhaulLowStatEffect.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.hungeroverhaul;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import iguanaman.hungeroverhaul.config.IguanaConfig;
 import iguanaman.hungeroverhaul.util.IguanaEventHook;
@@ -29,8 +29,8 @@ public class MixinHungerOverhaulLowStatEffect {
     public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
         // Slow growth and egg rates
         if (event.entityLiving instanceof EntityAnimal) {
-            float rndBreed = RandomHelper.nextFloat(Hodgepodge.RNG, IguanaConfig.breedingTimeoutMultiplier);
-            float rndChild = RandomHelper.nextFloat(Hodgepodge.RNG, IguanaConfig.childDurationMultiplier);
+            float rndBreed = RandomHelper.nextFloat(Common.RNG, IguanaConfig.breedingTimeoutMultiplier);
+            float rndChild = RandomHelper.nextFloat(Common.RNG, IguanaConfig.childDurationMultiplier);
             EntityAgeable ageable = (EntityAgeable) event.entityLiving;
             int growingAge = ageable.getGrowingAge();
 
@@ -38,7 +38,7 @@ public class MixinHungerOverhaulLowStatEffect {
             else if (growingAge < 0 && rndChild >= 1) ageable.setGrowingAge(--growingAge);
 
             if (IguanaConfig.eggTimeoutMultiplier > 1 && event.entityLiving instanceof EntityChicken) {
-                float rnd = RandomHelper.nextFloat(Hodgepodge.RNG, IguanaConfig.eggTimeoutMultiplier);
+                float rnd = RandomHelper.nextFloat(Common.RNG, IguanaConfig.eggTimeoutMultiplier);
                 EntityChicken chicken = (EntityChicken) event.entityLiving;
                 if (chicken.timeUntilNextEgg > 0 && rnd >= 1) chicken.timeUntilNextEgg += 1;
             }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/ic2/MixinItemCropSeed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/ic2/MixinItemCropSeed.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.ic2;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import ic2.core.init.InternalName;
 import ic2.core.item.ItemCropSeed;
 import net.minecraft.entity.player.EntityPlayer;
@@ -43,9 +43,9 @@ public class MixinItemCropSeed extends Item {
 
     @Inject(at = @At("RETURN"), method = "<init>(Lic2/core/init/InternalName;)V", remap = false)
     public void AdjustMaxStackSize(InternalName internalName, CallbackInfo ci) {
-        final int maxStackSize = Hodgepodge.config.ic2SeedMaxStackSize;
+        final int maxStackSize = Common.config.ic2SeedMaxStackSize;
         if (maxStackSize != 1) {
-            Hodgepodge.log.info("Setting IC2 seed max stack size to " + maxStackSize);
+            Common.log.info("Setting IC2 seed max stack size to " + maxStackSize);
             setMaxStackSize(maxStackSize);
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEffectRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEffectRenderer.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.client.particle.EffectRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
@@ -13,6 +13,6 @@ public class MixinEffectRenderer {
             constant = @Constant(intValue = 4000, ordinal = 0),
             require = 1)
     private int getParticleLimit(int constant) {
-        return Hodgepodge.config.particleLimit;
+        return Common.config.particleLimit;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityPlayer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinEntityPlayer.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -48,7 +48,7 @@ public abstract class MixinEntityPlayer {
                                                     "Lnet/minecraft/world/World;getEntitiesWithinAABBExcludingEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/AxisAlignedBB;)Ljava/util/List;")))
     public void hodgepodge$ThrottleItemPickupEvent(EntityPlayer instance, Entity entity) {
         if (entity instanceof EntityItem) {
-            if (hodgepodge$itemEntityCounter < Hodgepodge.config.itemStacksPickedUpPerTick) {
+            if (hodgepodge$itemEntityCounter < Common.config.itemStacksPickedUpPerTick) {
                 this.collideWithPlayer(entity);
             }
             hodgepodge$itemEntityCounter++;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinFurnaceRecipes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinFurnaceRecipes.java
@@ -1,7 +1,7 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
 import com.gtnewhorizon.gtnhlib.util.map.ItemStackMap;
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import java.util.Map;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
@@ -31,7 +31,7 @@ public abstract class MixinFurnaceRecipes {
     @Overwrite(remap = false)
     public void func_151394_a /* addSmeltingRecipe */(ItemStack input, ItemStack stack, float experience) {
         if (getSmeltingResult(input) != null) {
-            Hodgepodge.log.info(
+            Common.log.info(
                     "Overwriting smelting recipe for input: {} and output {} with {}",
                     input,
                     getSmeltingResult(input),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRandomPositionGenerator.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinRandomPositionGenerator.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.ai.RandomPositionGenerator;
 import net.minecraft.util.MathHelper;
@@ -34,9 +34,9 @@ public class MixinRandomPositionGenerator {
         }
 
         for (int i = 0; i < 10; ++i) {
-            final int x1 = Hodgepodge.RNG.nextInt(2 * hor + 1) - hor;
-            final int y1 = Hodgepodge.RNG.nextInt(2 * ver + 1) - ver;
-            final int z1 = Hodgepodge.RNG.nextInt(2 * hor + 1) - hor;
+            final int x1 = Common.RNG.nextInt(2 * hor + 1) - hor;
+            final int y1 = Common.RNG.nextInt(2 * ver + 1) - ver;
+            final int z1 = Common.RNG.nextInt(2 * hor + 1) - hor;
 
             if (facing == null || (double) x1 * facing.xCoord + (double) z1 * facing.zCoord >= 0.0D) {
                 // Use the rounded coordinates for comparision since `isWithinHomeDistance` takes int params

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinS02PacketChat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinS02PacketChat.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadLocalRandom;
 import net.minecraft.network.PacketBuffer;
@@ -32,7 +32,7 @@ public abstract class MixinS02PacketChat {
     public void redirectSerialize(PacketBuffer instance, String s) {
         byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > 32767) {
-            if (Hodgepodge.config.logHugeChat) {
+            if (Common.config.logHugeChat) {
                 String incidentId = "" + System.currentTimeMillis()
                         + ThreadLocalRandom.current().nextInt(1000);
                 LOGGER.info("HUGE chat message caught. Incident ID {}. Serialized message {}.", incidentId, s);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinWorldGetBlock.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/MixinWorldGetBlock.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.minecraft;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
@@ -23,7 +23,7 @@ public class MixinWorldGetBlock {
      */
     public Block getBlock(Chunk chunk, int x, int y, int z) {
         if (chunk == null) {
-            Hodgepodge.log.info("NULL chunk found at {}, {}, {}, returning Blocks.air", x, y, z);
+            Common.log.info("NULL chunk found at {}, {}, {}, returning Blocks.air", x, y, z);
             return Blocks.air;
         }
         return chunk.getBlock(x, y, z);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/server/MixinHttpUtil.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/minecraft/server/MixinHttpUtil.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.minecraft.server;
 
-import com.mitchej123.hodgepodge.Hodgepodge;
+import com.mitchej123.hodgepodge.Common;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import java.io.IOException;
@@ -23,10 +23,10 @@ public class MixinHttpUtil {
         int port = 0;
 
         try {
-            serversocket = new ServerSocket(Hodgepodge.config.defaultLanPort);
+            serversocket = new ServerSocket(Common.config.defaultLanPort);
         } catch (SecurityException securityException) {
             // Assign an automatically allocated port number
-            Hodgepodge.log.warn(
+            Common.log.warn(
                     String.format("Designated port %s is already in use, using automatically assigned instead", port));
             serversocket = new ServerSocket(0);
         } finally {


### PR DESCRIPTION
The HodgePodgeASMLoader makes references to the LoadingConfig instance inside the Hodgepodge class.

This unfortunately causes cascading classloading, because the Hodgepodge class also refers to classes in minecraft/forge code that shouldn't be loaded this early (for instance, the arguments of the event handlers). This cascading classloading can cause the infamous MixinTargetAlreadyLoadedException crash.

This PR fixes this cascading classloading by migrating the `log`, `config`, `thermosTained`, and `RNG` fields from the Hodgepodge class to a new utility class specifically designed to prevent the previously mentioned cascade.