### PR TITLE
Fix `speedupBOPFogHandling` incompatibility

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/biomesoplenty/BOPFogHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/biomesoplenty/BOPFogHandler.java
@@ -1,0 +1,137 @@
+package com.mitchej123.hodgepodge.client.biomesoplenty;
+
+import biomesoplenty.client.fog.FogHandler;
+import biomesoplenty.client.fog.IBiomeFog;
+import com.mitchej123.hodgepodge.mixins.biomesoplenty.AccessorFogHandler;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.client.event.EntityViewRenderEvent;
+
+public class BOPFogHandler {
+    private static AtomicInteger ticks = new AtomicInteger(-100);
+
+    private static float farPlaneDistanceScale = 0.75f;
+    private static float farPlaneDistanceM;
+
+    public static void onRenderFog(EntityViewRenderEvent.RenderFogEvent event, FogHandler fogHandler) {
+        EntityLivingBase entity = event.entity;
+        int playerX = MathHelper.floor_double(entity.posX);
+        int playerZ = MathHelper.floor_double(entity.posZ);
+
+        if (playerX == AccessorFogHandler.getFogX()
+                && playerZ == AccessorFogHandler.getFogZ()
+                && AccessorFogHandler.isFogInit())
+            AccessorFogHandler.callRenderFog(event.fogMode, AccessorFogHandler.getFogFarPlaneDistance(), 0.75f);
+
+        farPlaneDistanceM = event.farPlaneDistance;
+
+        if (ticks.get() < -50) {
+            new ClientTickThread().start();
+            ticks.set(0);
+        }
+
+        if (Math.random() < 0.1) ticks.incrementAndGet();
+
+        AccessorFogHandler.callRenderFog(
+                event.fogMode, AccessorFogHandler.getFogFarPlaneDistance(), farPlaneDistanceScale);
+    }
+
+    private static class ClientTickThread extends Thread {
+
+        @Override
+        public void run() {
+            while (true) {
+                if (Minecraft.getMinecraft().theWorld == null) {
+                    ticks.set(0);
+                    try {
+                        sleep(1000);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+                if (ticks.get() > 0) {
+                    try {
+                        int distance = 20;
+                        float fpDistanceBiomeFog = 0.0f;
+                        float weightBiomeFog = 0.0f;
+
+                        for (int x = -distance; x <= distance; x++) {
+                            for (int z = -distance; z <= distance; z++) {
+
+                                EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
+                                int playerX = MathHelper.floor_double(player.posX);
+                                int playerY = MathHelper.floor_double(player.posY);
+                                int playerZ = MathHelper.floor_double(player.posZ);
+                                BiomeGenBase biome = Minecraft.getMinecraft()
+                                        .theWorld
+                                        .getBiomeGenForCoords(playerX + x, playerZ + z);
+
+                                if (biome instanceof IBiomeFog) {
+                                    float distancePart =
+                                            ((IBiomeFog) biome).getFogDensity(playerX + x, playerY, playerZ + z);
+                                    float weightPart = 1.0f;
+
+                                    if (x == -distance) {
+                                        double xDiff = 1.0 - (player.posX - playerX);
+                                        distancePart *= xDiff;
+                                        weightPart *= xDiff;
+                                    } else if (x == distance) {
+                                        double xDiff = player.posX - playerX;
+                                        distancePart *= xDiff;
+                                        weightPart *= xDiff;
+                                    }
+
+                                    if (z == -distance) {
+                                        double zDiff = 1.0 - (player.posZ - playerZ);
+                                        distancePart *= zDiff;
+                                        weightPart *= zDiff;
+                                    } else if (z == distance) {
+                                        double zDiff = player.posZ - playerZ;
+                                        distancePart *= zDiff;
+                                        weightPart *= zDiff;
+                                    }
+
+                                    fpDistanceBiomeFog += distancePart;
+                                    weightBiomeFog += weightPart;
+                                }
+                            }
+                        }
+
+                        float weightMixed = distance * distance * 4.0f;
+                        float weightDefault = weightMixed - weightBiomeFog;
+                        float fpDistanceBiomeFogAvg =
+                                weightBiomeFog == 0.0f ? 0.0f : fpDistanceBiomeFog / weightBiomeFog;
+                        float farPlaneDistance =
+                                (fpDistanceBiomeFog * 240.0f + farPlaneDistanceM * weightDefault) / weightMixed;
+                        float farPlaneDistanceScaleBiome =
+                                (0.1f * (1.0f - fpDistanceBiomeFogAvg) + 0.75f * fpDistanceBiomeFogAvg);
+
+                        AccessorFogHandler.setFogX(Minecraft.getMinecraft().thePlayer.posX);
+                        AccessorFogHandler.setFogZ(Minecraft.getMinecraft().thePlayer.posZ);
+                        farPlaneDistanceScale =
+                                (farPlaneDistanceScaleBiome * weightBiomeFog + 0.75f * weightDefault) / weightMixed;
+                        AccessorFogHandler.setFogFarPlaneDistance(Math.min(farPlaneDistance, farPlaneDistanceM));
+
+                        AccessorFogHandler.setFogInit(true);
+
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    ticks.decrementAndGet();
+
+                } else {
+                    try {
+                        sleep(1000);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -245,6 +245,11 @@ public enum Mixins {
             TargetedMod.BOP),
     SPEEDUP_BOP_BIOME_FOG(
             "biomesoplenty.MixinFogHandler", Side.CLIENT, () -> Common.config.speedupBOPFogHandling, TargetedMod.BOP),
+    SPEEDUP_BOP_BIOME_FOG_ACCESSOR(
+            "biomesoplenty.AccessorFogHandler",
+            Side.CLIENT,
+            () -> Common.config.speedupBOPFogHandling,
+            TargetedMod.BOP),
     BIG_FIR_TREES("biomesoplenty.MixinBlockBOPSapling", () -> Common.config.makeBigFirsPlantable, TargetedMod.BOP),
 
     // MrTJPCore (Project Red)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/biomesoplenty/AccessorFogHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/biomesoplenty/AccessorFogHandler.java
@@ -1,0 +1,55 @@
+package com.mitchej123.hodgepodge.mixins.biomesoplenty;
+
+import biomesoplenty.client.fog.FogHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(FogHandler.class)
+public interface AccessorFogHandler {
+
+    @Accessor(remap = false)
+    static double getFogX() {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static void setFogX(double fogX) {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static double getFogZ() {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static void setFogZ(double fogZ) {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static boolean isFogInit() {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static void setFogInit(boolean fogInit) {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static float getFogFarPlaneDistance() {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Accessor(remap = false)
+    static void setFogFarPlaneDistance(float fogFarPlaneDistance) {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+
+    @Invoker(remap = false)
+    static void callRenderFog(int fogMode, float farPlaneDistance, float farPlaneDistanceScale) {
+        throw new IllegalStateException("Mixin stub invoked");
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/biomesoplenty/MixinFogHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/biomesoplenty/MixinFogHandler.java
@@ -1,156 +1,22 @@
 package com.mitchej123.hodgepodge.mixins.biomesoplenty;
 
 import biomesoplenty.client.fog.FogHandler;
-import biomesoplenty.client.fog.IBiomeFog;
+import com.mitchej123.hodgepodge.client.biomesoplenty.BOPFogHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import java.util.concurrent.atomic.AtomicInteger;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.EntityClientPlayerMP;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.util.MathHelper;
-import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.client.event.EntityViewRenderEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(FogHandler.class)
 public class MixinFogHandler {
 
-    @Shadow(remap = false)
-    private static double fogX, fogZ;
-
-    @Shadow(remap = false)
-    private static boolean fogInit;
-
-    @Shadow(remap = false)
-    private static float fogFarPlaneDistance;
-
-    private static float farPlaneDistanceScale = 0.75f;
-    private static float farPlaneDistanceM;
-
     /**
      * @author glowredman, TataTawa
-     * @reason It is not useful to calculate 1600 times per frame only to get newest {@link #fogX} and {@link #fogZ}
+     * @reason It is not useful to calculate 1600 times per frame only to get newest fogX and fogZ
      */
     @Overwrite(remap = false)
     @SubscribeEvent
     public void onRenderFog(EntityViewRenderEvent.RenderFogEvent event) {
-        EntityLivingBase entity = event.entity;
-        int playerX = MathHelper.floor_double(entity.posX);
-        int playerZ = MathHelper.floor_double(entity.posZ);
-
-        if (playerX == fogX && playerZ == fogZ && fogInit) renderFog(event.fogMode, fogFarPlaneDistance, 0.75f);
-
-        farPlaneDistanceM = event.farPlaneDistance;
-
-        if (ticks.get() < -50) {
-            new ClientTickThread().start();
-            ticks.set(0);
-        }
-
-        if (Math.random() < 0.1) ticks.incrementAndGet();
-
-        renderFog(event.fogMode, fogFarPlaneDistance, farPlaneDistanceScale);
+        BOPFogHandler.onRenderFog(event, (FogHandler) (Object) this);
     }
-
-    private static AtomicInteger ticks = new AtomicInteger(-100);
-
-    private class ClientTickThread extends Thread {
-
-        @Override
-        public void run() {
-            while (true) {
-                if (Minecraft.getMinecraft().theWorld == null) {
-                    ticks.set(0);
-                    try {
-                        sleep(1000);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-                if (ticks.get() > 0) {
-                    try {
-                        int distance = 20;
-                        float fpDistanceBiomeFog = 0.0f;
-                        float weightBiomeFog = 0.0f;
-
-                        for (int x = -distance; x <= distance; x++) {
-                            for (int z = -distance; z <= distance; z++) {
-
-                                EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
-                                int playerX = MathHelper.floor_double(player.posX);
-                                int playerY = MathHelper.floor_double(player.posY);
-                                int playerZ = MathHelper.floor_double(player.posZ);
-                                BiomeGenBase biome = Minecraft.getMinecraft()
-                                        .theWorld
-                                        .getBiomeGenForCoords(playerX + x, playerZ + z);
-
-                                if (biome instanceof IBiomeFog) {
-                                    float distancePart =
-                                            ((IBiomeFog) biome).getFogDensity(playerX + x, playerY, playerZ + z);
-                                    float weightPart = 1.0f;
-
-                                    if (x == -distance) {
-                                        double xDiff = 1.0 - (player.posX - playerX);
-                                        distancePart *= xDiff;
-                                        weightPart *= xDiff;
-                                    } else if (x == distance) {
-                                        double xDiff = player.posX - playerX;
-                                        distancePart *= xDiff;
-                                        weightPart *= xDiff;
-                                    }
-
-                                    if (z == -distance) {
-                                        double zDiff = 1.0 - (player.posZ - playerZ);
-                                        distancePart *= zDiff;
-                                        weightPart *= zDiff;
-                                    } else if (z == distance) {
-                                        double zDiff = player.posZ - playerZ;
-                                        distancePart *= zDiff;
-                                        weightPart *= zDiff;
-                                    }
-
-                                    fpDistanceBiomeFog += distancePart;
-                                    weightBiomeFog += weightPart;
-                                }
-                            }
-                        }
-
-                        float weightMixed = distance * distance * 4.0f;
-                        float weightDefault = weightMixed - weightBiomeFog;
-                        float fpDistanceBiomeFogAvg =
-                                weightBiomeFog == 0.0f ? 0.0f : fpDistanceBiomeFog / weightBiomeFog;
-                        float farPlaneDistance =
-                                (fpDistanceBiomeFog * 240.0f + farPlaneDistanceM * weightDefault) / weightMixed;
-                        float farPlaneDistanceScaleBiome =
-                                (0.1f * (1.0f - fpDistanceBiomeFogAvg) + 0.75f * fpDistanceBiomeFogAvg);
-
-                        fogX = Minecraft.getMinecraft().thePlayer.posX;
-                        fogZ = Minecraft.getMinecraft().thePlayer.posZ;
-                        farPlaneDistanceScale =
-                                (farPlaneDistanceScaleBiome * weightBiomeFog + 0.75f * weightDefault) / weightMixed;
-                        fogFarPlaneDistance = Math.min(farPlaneDistance, farPlaneDistanceM);
-
-                        fogInit = true;
-
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-
-                    ticks.decrementAndGet();
-
-                } else {
-                    try {
-                        sleep(1000);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-    }
-
-    @Shadow(remap = false)
-    private static void renderFog(int fogMode, float farPlaneDistance, float farPlaneDistanceScale) {}
 }


### PR DESCRIPTION
When using GasStation, `speedupBOPFogHandling` produces a very similar crash to #72. This happens because GasStation doesn't handle inner mixin classes correctly. (https://github.com/FalsePattern/GasStation/issues/3)

This gave me the idea to refactor the mixin to not use an inner class, and instead move its implementation into a helper class. This fixes the crash, and the crash with BetterFPS as well.

I verified that the mixin still works. `EntityRenderer#setupFog` takes up 4.7% of CPU time when it's disabled, which goes down to 0.1% when it's enabled.