### PR TITLE
Faster tileentity removal for World.updateEntities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,7 +341,7 @@ dependencies {
         annotationProcessor('org.spongepowered:mixin:0.8.5-GTNH:processor')
     }
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        compile('com.gtnewhorizon:gtnhmixins:2.0.0')
+        compile('com.gtnewhorizon:gtnhmixins:2.0.1')
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:EnderIO:2.3.1.43:dev")
     compile("com.github.GTNewHorizons:StructureLib:1.1.9:dev")
     compile("com.github.GTNewHorizons:GTNHLib:0.0.5:dev")
-    compile('com.gtnewhorizon:gtnhmixins:2.0.0')
+    compile('com.gtnewhorizon:gtnhmixins:2.0.1')
     compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
     compile("com.github.GTNewHorizons:AppleCore:3.2.0:dev")
     compileOnly("mrtjp:MrTJPCore:1.7.10-1.1.0.33:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,6 +29,9 @@ dependencies {
     compileOnly fileTree(dir: 'dependencies', includes: ['TravellersGear-1.7.10-1.16.8-GTNH.jar'])
     compileOnly('curse.maven:journeymap-32274:2367915')
     compileOnly('curse.maven:extra-utilities-225561:2264383')
+    compileOnly('curse.maven:bibliocraft-228027:2423369')
+    compileOnly('curse.maven:ztones-224369:2223720')
+    
 
     // Thermos Compat, compile only not run in dev by default
     compileOnly files("dependencies/Thermos-1.7.10-1614-stripped.jar")

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -16,7 +16,7 @@ import cpw.mods.fml.relauncher.Side;
         version = Hodgepodge.VERSION,
         name = Hodgepodge.NAME,
         acceptableRemoteVersions = "*",
-        dependencies = "required-after:gtnhmixins@[2.0.0,);")
+        dependencies = "required-after:gtnhmixins@[2.0.1,);")
 public class Hodgepodge {
     public static final AnchorAlarm ANCHOR_ALARM = new AnchorAlarm();
     public static final String MODID = "hodgepodge";

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -8,95 +8,108 @@ import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.common.config.Configuration;
 
 public class LoadingConfig {
-    public String[] requiredMods;
-    public boolean requiredModsInDev;
-
     // Adjustments
-    public int ic2SeedMaxStackSize;
-    public int particleLimit;
-    public int itemStacksPickedUpPerTick;
-    public int chatLength;
     public boolean addSystemInfo;
+    public int chatLength;
+    public int ic2SeedMaxStackSize;
+    public int itemStacksPickedUpPerTick;
+    public int particleLimit;
 
     // Mixins
+
     public boolean addCVSupportToWandPedestal;
+    public boolean addToggleDebugMessage;
+    public boolean deduplicateForestryCompatInBOP;
+    public boolean dimensionManagerDebug;
+    public boolean displayIc2FluidLocalizedName;
     public boolean dropPickedLootOnDespawn;
+    public boolean enableDefaultLanPort;
+    public boolean fixBibliocraftPackets;
+    public boolean fixComponentsPoppingOff;
+    public boolean fixDebugBoundingBox;
+    public boolean fixDimensionChangeHearts;
+    public boolean fixExtraUtilitiesUnEnchanting;
     public boolean fixFenceConnections;
     public boolean fixFireSpread;
     public boolean fixGetBlockLightValue;
+    public boolean fixGlStateBugs;
     public boolean fixGuiGameOver;
     public boolean fixHopperHitBox;
+    public boolean fixHopperVoidingItems;
+    public boolean fixHudLightingGlitch;
+    public boolean fixHugeChatKick;
     public boolean fixHungerOverhaul;
     public boolean fixIc2DirectInventoryAccess;
     public boolean fixIc2Hazmat;
     public boolean fixIc2Nightvision;
     public boolean fixIc2ReactorDupe;
-    public boolean longerChat;
-    public boolean transparentChat;
-    public boolean optimizeIc2ReactorInventoryAccess;
     public boolean fixIc2UnprotectedGetBlock;
-    public boolean fixNorthWestBias;
-    public boolean fixPotionEffectRender;
-    public boolean fixPotionRenderOffset;
-    public boolean fixPotionLimit;
+    public boolean fixIgnisFruitAABB;
     public boolean fixImmobileFireballs;
+    public boolean fixJourneymapKeybinds;
+    public boolean fixNetherLeavesFaceRendering;
+    public boolean fixNorthWestBias;
+    public boolean fixOptifineChunkLoadingCrash;
     public boolean fixPerspectiveCamera;
-    public boolean fixDebugBoundingBox;
-    public boolean fixHopperVoidingItems;
-    public boolean fixHugeChatKick;
-    public boolean logHugeChat;
+    public boolean fixPotionEffectRender;
+    public boolean fixPotionIterating;
+    public boolean fixPotionLimit;
+    public boolean fixPotionRenderOffset;
+    public boolean fixResizableFullscreen;
+    public boolean fixTimeCommandWithGC;
+    public boolean fixUnfocusedFullscreen;
     public boolean fixUrlDetection;
     public boolean fixVanillaUnprotectedGetBlock;
     public boolean fixWorldGetBlock;
-    public boolean fixDimensionChangeHearts;
-    public boolean increaseParticleLimit;
-    public boolean fixGlStateBugs;
+    public boolean fixWorldServerLeakingUnloadedEntities;
+    public boolean fixZTonesPackets;
+    public boolean hideCrosshairInThirdPerson;
     public boolean hideIc2ReactorSlots;
-    public boolean displayIc2FluidLocalizedName;
+    public boolean hidePotionParticlesFromSelf;
+    public boolean increaseParticleLimit;
     public boolean installAnchorAlarm;
+    public boolean logHugeChat;
+    public boolean longerChat;
+    public boolean makeBigFirsPlantable;
+    public boolean optimizeASMDataTable;
+    public boolean optimizeIc2ReactorInventoryAccess;
+    public boolean optimizeTileentityRemoval;
     public boolean preventPickupLoot;
     public boolean removeUpdateChecks;
-    public boolean tcpNoDelay;
+    public boolean speedupAnimations;
+    public boolean speedupBOPFogHandling;
     public boolean speedupChunkCoordinatesHashCode;
     public boolean speedupProgressBar;
     public boolean speedupVanillaFurnace;
-    public boolean fixJourneymapKeybinds;
-    public boolean deduplicateForestryCompatInBOP;
-    public boolean speedupBOPFogHandling;
-    public boolean makeBigFirsPlantable;
-    public boolean fixHudLightingGlitch;
-    public boolean fixComponentsPoppingOff;
-    public boolean thirstyTankContainer;
-    public boolean fixWorldServerLeakingUnloadedEntities;
-    public boolean fixResizableFullscreen;
-    public boolean fixUnfocusedFullscreen;
-    public boolean addToggleDebugMessage;
-    public boolean speedupAnimations;
-    public boolean optimizeTileentityRemoval;
-    public boolean fixPotionIterating;
-    public boolean fixIgnisFruitAABB;
-    public boolean fixNetherLeavesFaceRendering;
-    public boolean optimizeASMDataTable;
     public boolean squashBedErrorMessage;
+    public boolean tcpNoDelay;
+    public boolean thirstyTankContainer;
     public boolean throttleItemPickupEvent;
-    public boolean fixOptifineChunkLoadingCrash;
-    public boolean hideCrosshairInThirdPerson;
-    public boolean hidePotionParticlesFromSelf;
-    public boolean fixExtraUtilitiesUnEnchanting;
-    public boolean dimensionManagerDebug;
-    public boolean enableDefaultLanPort;
-
+    public boolean transparentChat;
     public int defaultLanPort;
 
     // render debug
     public boolean renderDebug;
     public int renderDebugMode;
 
+    // Pollution :nauseous:
+    public boolean furnacesPollute;
+    public boolean rocketsPollute;
+    public boolean railcraftPollutes;
+    public int furnacePollutionAmount;
+    public int fireboxPollutionAmount;
+    public int rocketPollutionAmount;
+    public int cokeOvenPollutionAmount;
+    public int advancedCokeOvenPollutionAmount;
+    public int hobbyistEnginePollutionAmount;
+    public int tunnelBorePollutionAmount;
+    public double explosionPollutionAmount;
+
     // ASM
-    public boolean pollutionAsm;
+    public boolean biblocraftRecipes;
     public boolean cofhWorldTransformer;
     public boolean enableTileRendererProfiler;
-    public boolean biblocraftRecipes;
+    public boolean pollutionAsm;
 
     public String thermosCraftServerClass;
 
@@ -115,7 +128,8 @@ public class LoadingConfig {
         OVERALL,
         SPEEDUPS,
         TWEAKS,
-        POLLUTION_RECOLOR;
+        POLLUTION_RECOLOR,
+        POLLUTION;
 
         @Override
         public String toString() {
@@ -126,450 +140,112 @@ public class LoadingConfig {
     public LoadingConfig(File file) {
         config = new Configuration(file);
 
-        requiredMods = config.get(
-                        Category.OVERALL.toString(),
-                        "requiredMods",
-                        defaultRequiredMods,
-                        "Subset of TargetMods that are required")
-                .getStringList();
-        requiredModsInDev = config.get(
-                        Category.OVERALL.toString(), "requiredModsInDev", false, "Require the Required Mods in dev")
-                .getBoolean();
+        // spotless:off
 
-        fixWorldGetBlock = config.get(
-                        Category.FIXES.toString(), "fixWorldGetBlock", true, "Fix unprotected getBlock() in World")
-                .getBoolean();
-        fixNorthWestBias = config.get(
-                        Category.FIXES.toString(),
-                        "fixNorthWestBias",
-                        true,
-                        "Fix northwest bias on RandomPositionGenerator")
-                .getBoolean();
-        fixFenceConnections = config.get(
-                        Category.FIXES.toString(),
-                        "fixFenceConnections",
-                        true,
-                        "Fix fence connections with other types of fence")
-                .getBoolean();
-        fixIc2DirectInventoryAccess = config.get(
-                        Category.FIXES.toString(),
-                        "fixIc2DirectInventoryAccess",
-                        true,
-                        "Fix IC2's direct inventory access")
-                .getBoolean();
-        fixIc2ReactorDupe = config.get(Category.FIXES.toString(), "fixIc2ReactorDupe", true, "Fix IC2's reactor dupe")
-                .getBoolean();
-        optimizeIc2ReactorInventoryAccess = config.get(
-                        Category.FIXES.toString(),
-                        "optimizeIc2ReactorInventoryAccess",
-                        true,
-                        "Optimize inventory access to IC2 nuclear reactor")
-                .getBoolean();
-        fixIc2Nightvision = config.get(
-                        Category.FIXES.toString(),
-                        "fixIc2Nightvision",
-                        true,
-                        "Prevent IC2's nightvision from blinding you")
-                .getBoolean();
-        fixIc2Hazmat = config.get(
-                        Category.FIXES.toString(), "fixIc2Hazmat", true, "Fix IC2 armors to avoid giving poison")
-                .getBoolean();
-        fixVanillaUnprotectedGetBlock = config.get(
-                        Category.FIXES.toString(),
-                        "fixVanillaUnprotectedGetBlock",
-                        true,
-                        "Fixes various unchecked vanilla getBlock() methods")
-                .getBoolean();
-        fixIc2UnprotectedGetBlock = config.get(
-                        Category.FIXES.toString(),
-                        "fixIc2UnprotectedGetBlock",
-                        true,
-                        "Fixes various unchecked IC2 getBlock() methods")
-                .getBoolean();
-        fixHungerOverhaul = config.get(
-                        Category.FIXES.toString(), "fixHungerOverhaul", true, "Fix hunger overhaul low stat effects")
-                .getBoolean();
-        removeUpdateChecks = config.get(
-                        Category.FIXES.toString(),
-                        "removeUpdateChecks",
-                        true,
-                        "Remove old/stale/outdated update checks.")
-                .getBoolean();
-        fixGuiGameOver = config.get(
-                        Category.FIXES.toString(),
-                        "fixGuiGameOver",
-                        true,
-                        "Fix Game Over GUI buttons disabled if switching fullscreen")
-                .getBoolean();
-        fixHopperHitBox = config.get(Category.FIXES.toString(), "fixHopperHitBox", true, "Fix vanilla hopper hit box")
-                .getBoolean();
-        fixGetBlockLightValue = config.get(
-                        Category.FIXES.toString(),
-                        "fixGetBlockLightValue",
-                        true,
-                        "Fix vanilla light calculation sometimes cause NPE on thermos")
-                .getBoolean();
-        fixFireSpread = config.get(
-                        Category.FIXES.toString(),
-                        "fixFireSpread",
-                        true,
-                        "Fix vanilla fire spread sometimes cause NPE on thermos")
-                .getBoolean();
-        fixUrlDetection = config.get(
-                        Category.FIXES.toString(), "fixUrlDetection", true, "Fix URISyntaxException in forge.")
-                .getBoolean();
-        fixDimensionChangeHearts = config.get(
-                        Category.FIXES.toString(),
-                        "fixDimensionChangeHearts",
-                        true,
-                        "Fix losing bonus hearts on dimension change")
-                .getBoolean();
-        fixPotionLimit = config.get(Category.FIXES.toString(), "fixPotionLimit", true, "Fix potions >= 128")
-                .getBoolean();
-        fixImmobileFireballs = config.get(
-                        Category.FIXES.toString(),
-                        "fixImmobileFireballs",
-                        true,
-                        "Fix the bug that makes fireballs stop moving when chunk unloads")
-                .getBoolean();
-        fixPerspectiveCamera = config.get(
-                        Category.FIXES.toString(),
-                        "fixPerspectiveCamera",
-                        true,
-                        "Prevent tall grass and such to affect the perspective camera")
-                .getBoolean();
-        fixDebugBoundingBox = config.get(
-                        Category.FIXES.toString(),
-                        "fixDebugBoundingBox",
-                        true,
-                        "Fixes the debug hitbox of the player beeing offset")
-                .getBoolean();
-        fixGlStateBugs = config.get(
-                        Category.FIXES.toString(),
-                        "fixGlStateBugs",
-                        true,
-                        "Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).")
-                .getBoolean();
-        deduplicateForestryCompatInBOP = config.get(
-                        Category.FIXES.toString(),
-                        "deduplicateForestryCompatInBOP",
-                        true,
-                        "Removes duplicate Fermenter and Squeezer recipes and flower registration")
-                .getBoolean();
-        fixHopperVoidingItems = config.get(
-                        Category.FIXES.toString(), "fixHopperVoidingItems", true, "Fix Drawer + Hopper voiding items")
-                .getBoolean();
-        fixHugeChatKick = config.get(
-                        Category.FIXES.toString(),
-                        "fixHugeChatKick",
-                        true,
-                        "Fix oversized chat message kicking player.")
-                .getBoolean();
-        logHugeChat = config.get(
-                        Category.FIXES.toString(),
-                        "logHugeChat",
-                        true,
-                        "Log oversized chat message to console. WARNING: might create huge log files if this happens very often.")
-                .getBoolean();
-        fixWorldServerLeakingUnloadedEntities = config.get(
-                        Category.FIXES.toString(),
-                        "fixWorldServerLeakingUnloadedEntities",
-                        true,
-                        "Fix WorldServer leaking entities when no players are present in a dimension")
-                .getBoolean();
-        fixResizableFullscreen = config.get(
-                        Category.FIXES.toString(),
-                        "fixResizableFullscreen",
-                        true,
-                        "Fix game window becoming not resizable after toggling fullscrean in any way")
-                .getBoolean();
-        fixUnfocusedFullscreen = config.get(
-                        Category.FIXES.toString(),
-                        "fixUnfocusedFullscreen",
-                        true,
-                        "Fix exiting fullscreen when you tab out of the game")
-                .getBoolean();
-        speedupAnimations = config.get(
-                        Category.FIXES.toString(),
-                        "speedupAnimations",
-                        true,
-                        "Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working)")
-                .getBoolean();
-        optimizeTileentityRemoval = config.get(
-                        Category.SPEEDUPS.toString(),
-                        "optimizeTileentityRemoval",
-                        true,
-                        "Optimize tileEntity removal in World.class")
-                .getBoolean();
-        fixPotionIterating = config.get(
-                        Category.FIXES.toString(),
-                        "fixPotionIterating",
-                        true,
-                        "Fix crashes with ConcurrentModificationException because of incorrectly iterating over active potions")
-                .getBoolean();
-        fixIgnisFruitAABB = config.get(
-                        Category.FIXES.toString(),
-                        "fixIgnisFruitAABB",
-                        true,
-                        "Fix Axis aligned Bounding Box of Ignis Fruit")
-                .getBoolean();
-        fixNetherLeavesFaceRendering = config.get(
-                        Category.FIXES.toString(),
-                        "fixNetherLeavesFaceRendering",
-                        true,
-                        "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too")
-                .getBoolean();
-        fixJourneymapKeybinds = config.get(
-                        Category.FIXES.toString(),
-                        "fixJourneymapKeybinds",
-                        true,
-                        "Prevent unbinded keybinds from triggering when pressing certain keys")
-                .getBoolean();
-        squashBedErrorMessage = config.get(
-                        Category.FIXES.toString(),
-                        "squashBedErrorMessage",
-                        true,
-                        "Stop \"You can only sleep at night\" message filling the chat")
-                .getBoolean();
-        throttleItemPickupEvent = config.get(
-                        Category.FIXES.toString(),
-                        "throttleItemPickupEvent",
-                        true,
-                        "Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag")
-                .getBoolean();
-        itemStacksPickedUpPerTick = Math.max(
-                1,
-                config.get(Category.FIXES.toString(), "itemStacksPickedUpPerTick", 36, "Stacks picked up per tick")
-                        .getInt());
-        fixOptifineChunkLoadingCrash = config.get(
-                        Category.FIXES.toString(),
-                        "fixOptifineChunkLoadingCrash",
-                        true,
-                        "Forces the chunk loading option from optifine to default since other values can crash the game")
-                .getBoolean();
+        addCVSupportToWandPedestal = config.get(Category.TWEAKS.toString(), "addCVSupportToWandPedestal", true, "Add CV support to Thaumcraft wand recharge pedestal").getBoolean();
+        addSystemInfo = config.get(Category.TWEAKS.toString(), "addSystemInfo", true, "Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture)").getBoolean();
+        addToggleDebugMessage = config.get(Category.TWEAKS.toString(), "addToggleDebugMessage", true, "Add a debug message in the chat when toggling vanilla debug options").getBoolean();
+        biblocraftRecipes = config.get(Category.ASM.toString(), "biblocraftRecipes", true, "Remove recipe generation from BiblioCraft").getBoolean();
+        chatLength = Math.max(100, Math.min(32767, config.get(Category.TWEAKS.toString(), "chatLength", 8191, "Amount of chat lines kept [100(Vanilla) - 32767]").getInt()));
+        cofhWorldTransformer = config.get(Category.ASM.toString(), "cofhWorldTransformer", true, "Enable Glease's ASM patch to disable unused CoFH tileentity cache").getBoolean();
+        deduplicateForestryCompatInBOP = config.get(Category.FIXES.toString(), "deduplicateForestryCompatInBOP", true, "Removes duplicate Fermenter and Squeezer recipes and flower registration").getBoolean();
+        defaultLanPort = config.get(Category.TWEAKS.toString(), "defaultLanPort", 25565, "Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port.").getInt();
+        dimensionManagerDebug = config.get(Category.DEBUG.toString(), "dimensionManagerDebug", true, "Prints debug log if DimensionManager got crashed").getBoolean();
+        displayIc2FluidLocalizedName = config.get(Category.TWEAKS.toString(), "displayIc2FluidLocalizedName", true, "Display fluid localized name in IC2 fluid cell tooltip").getBoolean();
+        dropPickedLootOnDespawn = config.get(Category.TWEAKS.toString(), "dropPickedLootOnDespawn", true, "Drop picked loot on entity despawn").getBoolean();
+        enableDefaultLanPort = config.get(Category.TWEAKS.toString(), "enableDefaultLanPort", true, "Open an integrated server on a static port.").getBoolean();
+        enableTileRendererProfiler = config.get(Category.TWEAKS.toString(), "enableTileRendererProfiler", true, "Shows renderer's impact on FPS in vanilla lagometer").getBoolean();
 
-        increaseParticleLimit = config.get(
-                        Category.TWEAKS.toString(), "increaseParticleLimit", true, "Increase particle limit")
-                .getBoolean();
-        particleLimit = Math.max(
-                Math.min(
-                        config.get(Category.TWEAKS.toString(), "particleLimit", 8000, "Particle limit [4000-16000]")
-                                .getInt(),
-                        16000),
-                4000);
-        fixPotionEffectRender = config.get(
-                        Category.TWEAKS.toString(),
-                        "fixPotionEffectRender",
-                        true,
-                        "Fix vanilla potion effects rendering above the NEI tooltips in the inventory")
-                .getBoolean();
-        fixPotionRenderOffset = config.get(
-                        Category.TWEAKS.toString(),
-                        "fixPotionRenderOffset",
-                        true,
-                        "Prevents the inventory from shifting when the player has active potion effects")
-                .getBoolean();
-        installAnchorAlarm = config.get(
-                        Category.TWEAKS.toString(),
-                        "installAnchorAlarm",
-                        true,
-                        "Wake up passive & personal anchors on player login")
-                .getBoolean();
-        preventPickupLoot = config.get(
-                        Category.TWEAKS.toString(), "preventPickupLoot", true, "Prevent monsters from picking up loot.")
-                .getBoolean();
-        dropPickedLootOnDespawn = config.get(
-                        Category.TWEAKS.toString(),
-                        "dropPickedLootOnDespawn",
-                        true,
-                        "Drop picked loot on entity despawn")
-                .getBoolean();
-        hideIc2ReactorSlots = config.get(
-                        Category.TWEAKS.toString(),
-                        "hideIc2ReactorSlots",
-                        true,
-                        "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor")
-                .getBoolean();
-        displayIc2FluidLocalizedName = config.get(
-                        Category.TWEAKS.toString(),
-                        "displayIc2FluidLocalizedName",
-                        true,
-                        "Display fluid localized name in IC2 fluid cell tooltip")
-                .getBoolean();
-        enableTileRendererProfiler = config.get(
-                        Category.TWEAKS.toString(),
-                        "enableTileRendererProfiler",
-                        true,
-                        "Shows renderer's impact on FPS in vanilla lagometer")
-                .getBoolean();
-        addCVSupportToWandPedestal = config.get(
-                        Category.TWEAKS.toString(),
-                        "addCVSupportToWandPedestal",
-                        true,
-                        "Add CV support to Thaumcraft wand recharge pedestal")
-                .getBoolean();
-        makeBigFirsPlantable = config.get(
-                        Category.TWEAKS.toString(),
-                        "makeBigFirsPlantable",
-                        true,
-                        "Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree")
-                .getBoolean();
-        ic2SeedMaxStackSize = config.get(
-                        Category.TWEAKS.toString(), "ic2SeedMaxStackSize", 64, "IC2 seed max stack size")
-                .getInt();
-        addSystemInfo = config.get(
-                        Category.TWEAKS.toString(),
-                        "addSystemInfo",
-                        true,
-                        "Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture)")
-                .getBoolean();
-        fixHudLightingGlitch = config.get(
-                        Category.TWEAKS.toString(),
-                        "fixHudLightingGlitch",
-                        true,
-                        "Fix hotbars being dark when Project Red is installed")
-                .getBoolean();
-        fixComponentsPoppingOff = config.get(
-                        Category.TWEAKS.toString(),
-                        "fixComponentsPoppingOff",
-                        true,
-                        "Fix Project Red components popping off on unloaded chunks")
-                .getBoolean();
-        thirstyTankContainer = config.get(
-                        Category.TWEAKS.toString(),
-                        "thirstyTankContainer",
-                        true,
-                        "Implement container for thirsty tank")
-                .getBoolean();
-        enableDefaultLanPort = config.get(
-                        Category.TWEAKS.toString(),
-                        "enableDefaultLanPort",
-                        true,
-                        "Open an integrated server on a static port.")
-                .getBoolean();
-        defaultLanPort = config.get(
-                        Category.TWEAKS.toString(),
-                        "defaultLanPort",
-                        25565,
-                        "Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port.")
-                .getInt();
-        addToggleDebugMessage = config.get(
-                        Category.TWEAKS.toString(),
-                        "addToggleDebugMessage",
-                        true,
-                        "Add a debug message in the chat when toggling vanilla debug options")
-                .getBoolean();
-        hideCrosshairInThirdPerson = config.get(
-                        Category.TWEAKS.toString(),
-                        "hideCrosshairInThirdPerson",
-                        true,
-                        "Stops rendering the crosshair when you are playing in third person")
-                .getBoolean();
-        longerChat = config.get(
-                        Category.TWEAKS.toString(),
-                        "longerChat",
-                        true,
-                        "Makes the chat history longer instead of 100 lines")
-                .getBoolean();
-        chatLength = Math.max(
-                100,
-                Math.min(
-                        32767,
-                        config.get(
-                                        Category.TWEAKS.toString(),
-                                        "chatLength",
-                                        8191,
-                                        "Amount of chat lines kept [100(Vanilla) - 32767]")
-                                .getInt()));
-        transparentChat = config.get(
-                        Category.TWEAKS.toString(),
-                        "transparentChat",
-                        true,
-                        "Doesn't render the black box behind messages when the chat is closed")
-                .getBoolean();
-        hidePotionParticlesFromSelf = config.get(
-                        Category.TWEAKS.toString(),
-                        "hidePotionParticlesFromSelf",
-                        true,
-                        "Stops rendering potion particles from yourself")
-                .getBoolean();
-        fixExtraUtilitiesUnEnchanting = config.get(
-                        Category.FIXES.toString(),
-                        "fixExtraUtilitiesUnEnchanting",
-                        true,
-                        "Fix dupe bug with division sigil removing enchantment")
-                .getBoolean();
-        optimizeASMDataTable = config.get(
-                        Category.SPEEDUPS.toString(),
-                        "optimizeASMDataTable",
-                        true,
-                        "Optimize ASMDataTable getAnnotationsFor for faster startup")
-                .getBoolean();
-        tcpNoDelay = config.get(
-                        Category.SPEEDUPS.toString(),
-                        "tcpNoDelay",
-                        true,
-                        "Sets TCP_NODELAY to true, reducing network latency in multiplayer. Works on server as well as client. From makamys/CoreTweaks")
-                .getBoolean();
-        speedupChunkCoordinatesHashCode = config.get(
-                        Category.SPEEDUPS.toString(),
-                        "speedupChunkCoordinatesHashCode",
-                        true,
-                        "Speedup ChunkCoordinates hashCode")
-                .getBoolean();
-        speedupVanillaFurnace = config.get(
-                        Category.SPEEDUPS.toString(),
-                        "speedupVanillaFurnace",
-                        true,
-                        "Speedup Vanilla Furnace recipe lookup")
-                .getBoolean();
-        speedupBOPFogHandling = config.get(
-                        Category.SPEEDUPS.toString(),
-                        "speedupBOPFogHandling",
-                        true,
-                        "Speedup biome fog rendering in BiomesOPlenty")
-                .getBoolean();
+        fixComponentsPoppingOff = config.get(Category.TWEAKS.toString(), "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();
+        fixDebugBoundingBox = config.get(Category.FIXES.toString(), "fixDebugBoundingBox", true, "Fixes the debug hitbox of the player beeing offset").getBoolean();
+        fixDimensionChangeHearts = config.get(Category.FIXES.toString(), "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();
+        fixExtraUtilitiesUnEnchanting = config.get(Category.FIXES.toString(), "fixExtraUtilitiesUnEnchanting", true, "Fix dupe bug with division sigil removing enchantment").getBoolean();
+        fixFenceConnections = config.get(Category.FIXES.toString(), "fixFenceConnections", true, "Fix fence connections with other types of fence").getBoolean();
+        fixFireSpread = config.get(Category.FIXES.toString(), "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();
+        fixGetBlockLightValue = config.get(Category.FIXES.toString(), "fixGetBlockLightValue", true, "Fix vanilla light calculation sometimes cause NPE on thermos").getBoolean();
+        fixGlStateBugs = config.get(Category.FIXES.toString(), "fixGlStateBugs", true, "Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).").getBoolean();
+        fixGuiGameOver = config.get(Category.FIXES.toString(), "fixGuiGameOver", true, "Fix Game Over GUI buttons disabled if switching fullscreen").getBoolean();
+        fixTimeCommandWithGC = config.get(Category.FIXES.toString(), "fixTimeCommandWithGC", true, "Fix time commands with GC").getBoolean();
+        fixBibliocraftPackets = config.get(Category.FIXES.toString(), "fixBibliocraftPackets", true, "Fix Biblocraft packet exploits").getBoolean();
+        fixZTonesPackets = config.get(Category.FIXES.toString(), "fixZTonesPackets", true, "Fix ZTones packet exploits").getBoolean();
+        fixHopperHitBox = config.get(Category.FIXES.toString(), "fixHopperHitBox", true, "Fix vanilla hopper hit box").getBoolean();
+        fixHopperVoidingItems = config.get(Category.FIXES.toString(), "fixHopperVoidingItems", true, "Fix Drawer + Hopper voiding items").getBoolean();
+        fixHudLightingGlitch = config.get(Category.TWEAKS.toString(), "fixHudLightingGlitch", true, "Fix hotbars being dark when Project Red is installed").getBoolean();
+        fixHugeChatKick = config.get(Category.FIXES.toString(), "fixHugeChatKick", true, "Fix oversized chat message kicking player.").getBoolean();
+        fixHungerOverhaul = config.get(Category.FIXES.toString(), "fixHungerOverhaul", true, "Fix hunger overhaul low stat effects").getBoolean();
+        fixIc2DirectInventoryAccess = config.get(Category.FIXES.toString(), "fixIc2DirectInventoryAccess", true, "Fix IC2's direct inventory access").getBoolean();
+        fixIc2Hazmat = config.get(Category.FIXES.toString(), "fixIc2Hazmat", true, "Fix IC2 armors to avoid giving poison").getBoolean();
+        fixIc2Nightvision = config.get(Category.FIXES.toString(), "fixIc2Nightvision", true, "Prevent IC2's nightvision from blinding you").getBoolean();
+        fixIc2ReactorDupe = config.get(Category.FIXES.toString(), "fixIc2ReactorDupe", true, "Fix IC2's reactor dupe").getBoolean();
+        fixIc2UnprotectedGetBlock = config.get(Category.FIXES.toString(), "fixIc2UnprotectedGetBlock", true, "Fixes various unchecked IC2 getBlock() methods").getBoolean();
+        fixIgnisFruitAABB = config.get(Category.FIXES.toString(), "fixIgnisFruitAABB", true, "Fix Axis aligned Bounding Box of Ignis Fruit").getBoolean();
+        fixImmobileFireballs = config.get(Category.FIXES.toString(), "fixImmobileFireballs", true, "Fix the bug that makes fireballs stop moving when chunk unloads").getBoolean();
+        fixJourneymapKeybinds = config.get(Category.FIXES.toString(), "fixJourneymapKeybinds", true, "Prevent unbinded keybinds from triggering when pressing certain keys").getBoolean();
+        fixNetherLeavesFaceRendering = config.get(Category.FIXES.toString(), "fixNetherLeavesFaceRendering", true, "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too").getBoolean();
+        fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
+        fixOptifineChunkLoadingCrash = config.get(Category.FIXES.toString(), "fixOptifineChunkLoadingCrash", true, "Forces the chunk loading option from optifine to default since other values can crash the game").getBoolean();
+        fixPerspectiveCamera = config.get(Category.FIXES.toString(), "fixPerspectiveCamera", true, "Prevent tall grass and such to affect the perspective camera").getBoolean();
+        fixPotionEffectRender = config.get(Category.TWEAKS.toString(), "fixPotionEffectRender", true, "Fix vanilla potion effects rendering above the NEI tooltips in the inventory").getBoolean();
+        fixPotionIterating = config.get(Category.FIXES.toString(), "fixPotionIterating", true, "Fix crashes with ConcurrentModificationException because of incorrectly iterating over active potions").getBoolean();
+        fixPotionLimit = config.get(Category.FIXES.toString(), "fixPotionLimit", true, "Fix potions >= 128").getBoolean();
+        fixPotionRenderOffset = config.get(Category.TWEAKS.toString(), "fixPotionRenderOffset", true, "Prevents the inventory from shifting when the player has active potion effects").getBoolean();
+        fixResizableFullscreen = config.get(Category.FIXES.toString(), "fixResizableFullscreen", true, "Fix game window becoming not resizable after toggling fullscrean in any way").getBoolean();
+        fixUnfocusedFullscreen = config.get(Category.FIXES.toString(), "fixUnfocusedFullscreen", true, "Fix exiting fullscreen when you tab out of the game").getBoolean();
+        fixUrlDetection = config.get(Category.FIXES.toString(), "fixUrlDetection", true, "Fix URISyntaxException in forge.").getBoolean();
+        fixVanillaUnprotectedGetBlock = config.get(Category.FIXES.toString(), "fixVanillaUnprotectedGetBlock", true, "Fixes various unchecked vanilla getBlock() methods").getBoolean();
+        fixWorldGetBlock = config.get(Category.FIXES.toString(), "fixWorldGetBlock", true, "Fix unprotected getBlock() in World").getBoolean();
+        fixWorldServerLeakingUnloadedEntities = config.get(Category.FIXES.toString(), "fixWorldServerLeakingUnloadedEntities", true, "Fix WorldServer leaking entities when no players are present in a dimension").getBoolean();
 
-        speedupProgressBar = config.get(Category.ASM.toString(), "speedupProgressBar", true, "Speedup progressbar")
-                .getBoolean();
+        hideCrosshairInThirdPerson = config.get(Category.TWEAKS.toString(), "hideCrosshairInThirdPerson", true, "Stops rendering the crosshair when you are playing in third person").getBoolean();
+        hideIc2ReactorSlots = config.get(Category.TWEAKS.toString(), "hideIc2ReactorSlots", true, "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor").getBoolean();
+        hidePotionParticlesFromSelf = config.get(Category.TWEAKS.toString(), "hidePotionParticlesFromSelf", true, "Stops rendering potion particles from yourself").getBoolean();
+        ic2SeedMaxStackSize = config.get(Category.TWEAKS.toString(), "ic2SeedMaxStackSize", 64, "IC2 seed max stack size").getInt();
+        increaseParticleLimit = config.get(Category.TWEAKS.toString(), "increaseParticleLimit", true, "Increase particle limit").getBoolean();
+        installAnchorAlarm = config.get(Category.TWEAKS.toString(), "installAnchorAlarm", true, "Wake up passive & personal anchors on player login").getBoolean();
+        itemStacksPickedUpPerTick = Math.max(1, config.get(Category.FIXES.toString(), "itemStacksPickedUpPerTick", 36, "Stacks picked up per tick").getInt());
+        logHugeChat = config.get(Category.FIXES.toString(), "logHugeChat", true, "Log oversized chat message to console. WARNING: might create huge log files if this happens very often.").getBoolean();
+        longerChat = config.get(Category.TWEAKS.toString(), "longerChat", true, "Makes the chat history longer instead of 100 lines").getBoolean();
+        makeBigFirsPlantable = config.get(Category.TWEAKS.toString(), "makeBigFirsPlantable", true, "Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree").getBoolean();
+        optimizeASMDataTable = config.get(Category.SPEEDUPS.toString(), "optimizeASMDataTable", true, "Optimize ASMDataTable getAnnotationsFor for faster startup").getBoolean();
+        optimizeIc2ReactorInventoryAccess = config.get(Category.FIXES.toString(), "optimizeIc2ReactorInventoryAccess", true, "Optimize inventory access to IC2 nuclear reactor").getBoolean();
+        optimizeTileentityRemoval = config.get(Category.SPEEDUPS.toString(), "optimizeTileentityRemoval", true, "Optimize tileEntity removal in World.class").getBoolean();
+        particleLimit = Math.max(Math.min(config.get(Category.TWEAKS.toString(), "particleLimit", 8000, "Particle limit [4000-16000]").getInt(), 16000), 4000);
+        preventPickupLoot = config.get(Category.TWEAKS.toString(), "preventPickupLoot", true, "Prevent monsters from picking up loot.").getBoolean();
+        removeUpdateChecks = config.get(Category.FIXES.toString(), "removeUpdateChecks", true, "Remove old/stale/outdated update checks.").getBoolean();
+        renderDebug = config.get(Category.DEBUG.toString(), "renderDebug", true, "Enable GL state debug hooks. Will not do anything useful unless mode is changed to nonzero.").getBoolean();
+        renderDebugMode = config.get(Category.DEBUG.toString(), "renderDebugMode", 0, "Default GL state debug mode. 0 - off, 1 - reduced, 2 - full").setMinValue(0).setMaxValue(2).getInt();
+        speedupAnimations = config.get(Category.FIXES.toString(), "speedupAnimations", true, "Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working)").getBoolean();
+        speedupBOPFogHandling = config.get(Category.SPEEDUPS.toString(), "speedupBOPFogHandling", true, "Speedup biome fog rendering in BiomesOPlenty").getBoolean();
+        speedupChunkCoordinatesHashCode = config.get(Category.SPEEDUPS.toString(), "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
+        speedupProgressBar = config.get(Category.ASM.toString(), "speedupProgressBar", true, "Speedup progressbar").getBoolean();
+        speedupVanillaFurnace = config.get(Category.SPEEDUPS.toString(), "speedupVanillaFurnace", true, "Speedup Vanilla Furnace recipe lookup").getBoolean();
+        squashBedErrorMessage = config.get(Category.FIXES.toString(), "squashBedErrorMessage", true, "Stop \"You can only sleep at night\" message filling the chat").getBoolean();
+        tcpNoDelay = config.get(Category.SPEEDUPS.toString(), "tcpNoDelay", true, "Sets TCP_NODELAY to true, reducing network latency in multiplayer. Works on server as well as client. From makamys/CoreTweaks").getBoolean();
+        thermosCraftServerClass = config.get(Category.ASM.toString(), "thermosCraftServerClass", "org.bukkit.craftbukkit.v1_7_R4.CraftServer", "If using Bukkit/Thermos, the CraftServer package.").getString();
+        thirstyTankContainer = config.get(Category.TWEAKS.toString(), "thirstyTankContainer", true, "Implement container for thirsty tank").getBoolean();
+        throttleItemPickupEvent = config.get(Category.FIXES.toString(), "throttleItemPickupEvent", true, "Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag").getBoolean();
+        transparentChat = config.get(Category.TWEAKS.toString(), "transparentChat", true, "Doesn't render the black box behind messages when the chat is closed").getBoolean();
+        
         // Disable for now as it is not compatible with anything modifying RenderBlocks
-        pollutionAsm = config.get(Category.ASM.toString(), "pollutionAsm", false, "Enable pollution rendering ASM")
-                .getBoolean();
-        cofhWorldTransformer = config.get(
-                        Category.ASM.toString(),
-                        "cofhWorldTransformer",
-                        true,
-                        "Enable Glease's ASM patch to disable unused CoFH tileentity cache")
-                .getBoolean();
-        biblocraftRecipes = config.get(
-                        Category.ASM.toString(), "biblocraftRecipes", true, "Remove recipe generation from BiblioCraft")
-                .getBoolean();
-        thermosCraftServerClass = config.get(
-                        Category.ASM.toString(),
-                        "thermosCraftServerClass",
-                        "org.bukkit.craftbukkit.v1_7_R4.CraftServer",
-                        "If using Bukkit/Thermos, the CraftServer package.")
-                .getString();
-        renderDebug = config.get(
-                        Category.DEBUG.toString(),
-                        "renderDebug",
-                        true,
-                        "Enable GL state debug hooks. Will not do anything useful unless mode is changed to nonzero.")
-                .getBoolean();
-        renderDebugMode = config.get(
-                        Category.DEBUG.toString(),
-                        "renderDebugMode",
-                        0,
-                        "Default GL state debug mode. 0 - off, 1 - reduced, 2 - full")
-                .setMinValue(0)
-                .setMaxValue(2)
-                .getInt();
-        dimensionManagerDebug = config.get(
-                        Category.DEBUG.toString(),
-                        "dimensionManagerDebug",
-                        true,
-                        "Prints debug log if DimensionManager got crashed")
-                .getBoolean();
+        pollutionAsm = config.get(Category.ASM.toString(), "pollutionAsm", false, "Enable pollution rendering ASM").getBoolean();
+        
+        // Pollution :nauseous:
+        furnacesPollute = config.get(Category.POLLUTION.toString(), "furnacesPollute", true, "Make furnaces Pollute").getBoolean();
+        rocketsPollute = config.get(Category.POLLUTION.toString(), "rocketsPollute", true, "Make rockets Pollute").getBoolean();
+        railcraftPollutes = config.get(Category.POLLUTION.toString(), "railcraftPollutes", true, "Make Railcraft Pollute").getBoolean();
+        
+        
+        furnacePollutionAmount = config.get(Category.POLLUTION.toString(), "furnacePollution", 20, "Furnace pollution per second, min 1!", 1, Integer.MAX_VALUE).getInt();
+        fireboxPollutionAmount = config.get(Category.POLLUTION.toString(), "fireboxPollution", 15, "Pollution Amount for RC Firebox", 1, Integer.MAX_VALUE).getInt();
+        rocketPollutionAmount = config.get(Category.POLLUTION.toString(), "rocketPollution", 1000, "Pollution Amount for Rockets", 1, Integer.MAX_VALUE).getInt();
+        cokeOvenPollutionAmount = config.get(Category.POLLUTION.toString(), "cokeOvenPollution", 3, "Pollution Amount for Coke Ovens", 1, Integer.MAX_VALUE).getInt();
+        advancedCokeOvenPollutionAmount = config.get(Category.POLLUTION.toString(), "advancedCokeOvenPollution", 80, "Pollution Amount for Advanced Coke Ovens", 1, Integer.MAX_VALUE).getInt();
+        hobbyistEnginePollutionAmount = config.get(Category.POLLUTION.toString(), "hobbyistEnginePollution", 20, "Pollution Amount for hobbyist steam engine", 1, Integer.MAX_VALUE).getInt();
+        tunnelBorePollutionAmount = config.get(Category.POLLUTION.toString(), "tunnelBorePollution", 2, "Pollution Amount for tunnel bore", 1, Integer.MAX_VALUE).getInt();
+        explosionPollutionAmount = config.get(Category.POLLUTION.toString(), "explosionPollution", 33.34, "Explosion pollution").getDouble();
+        
+        
+        // spotless:on
         if (config.hasChanged()) config.save();
     }
 
@@ -580,30 +256,15 @@ public class LoadingConfig {
             config = new Configuration(new File(Launch.minecraftHome, "config/hodgepodge.cfg"));
         }
 
-        standardBlocks.updateClassList(config.get(
-                        Category.POLLUTION_RECOLOR.toString(),
-                        "renderStandardBlock",
-                        defaultPollutionRenderStandardBlock)
-                .getStringList());
-        liquidBlocks.updateClassList(config.get(
-                        Category.POLLUTION_RECOLOR.toString(), "renderBlockLiquid", defaultPollutionRenderLiquidBlocks)
-                .getStringList());
-        doublePlants.updateClassList(config.get(
-                        Category.POLLUTION_RECOLOR.toString(),
-                        "renderBlockDoublePlant",
-                        defaultPollutionRenderDoublePlant)
-                .getStringList());
-        crossedSquares.updateClassList(config.get(
-                        Category.POLLUTION_RECOLOR.toString(),
-                        "renderCrossedSquares",
-                        defaultPollutionRenderCrossedSquares)
-                .getStringList());
-        blockVine.updateClassList(
-                config.get(Category.POLLUTION_RECOLOR.toString(), "renderblockVine", defaultPollutionRenderblockVine)
-                        .getStringList());
+        // spotless:off
+        standardBlocks.updateClassList(config.get(Category.POLLUTION_RECOLOR.toString(), "renderStandardBlock", defaultPollutionRenderStandardBlock).getStringList());
+        liquidBlocks.updateClassList(config.get(Category.POLLUTION_RECOLOR.toString(), "renderBlockLiquid", defaultPollutionRenderLiquidBlocks).getStringList());
+        doublePlants.updateClassList(config.get(Category.POLLUTION_RECOLOR.toString(), "renderBlockDoublePlant", defaultPollutionRenderDoublePlant).getStringList());
+        crossedSquares.updateClassList(config.get(Category.POLLUTION_RECOLOR.toString(), "renderCrossedSquares", defaultPollutionRenderCrossedSquares).getStringList());
+        blockVine.updateClassList(config.get(Category.POLLUTION_RECOLOR.toString(), "renderblockVine", defaultPollutionRenderblockVine).getStringList());
 
         config.getCategory(Category.POLLUTION_RECOLOR.toString()).setComment(pollutionRecolorComment);
-
+        // spotless:on
         if (config.hasChanged()) config.save();
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -72,6 +72,7 @@ public class LoadingConfig {
     public boolean fixUnfocusedFullscreen;
     public boolean addToggleDebugMessage;
     public boolean speedupAnimations;
+    public boolean optimizeTileentityRemoval;
     public boolean fixPotionIterating;
     public boolean fixIgnisFruitAABB;
     public boolean fixNetherLeavesFaceRendering;
@@ -293,6 +294,12 @@ public class LoadingConfig {
                         "speedupAnimations",
                         true,
                         "Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working)")
+                .getBoolean();
+        optimizeTileentityRemoval = config.get(
+                        Category.SPEEDUPS.toString(),
+                        "optimizeTileentityRemoval",
+                        true,
+                        "Optimize tileEntity removal in World.class")
                 .getBoolean();
         fixPotionIterating = config.get(
                         Category.FIXES.toString(),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -228,6 +228,13 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinDimensionManager")
             .setApplyIf(() -> Common.config.dimensionManagerDebug)
             .addTargetedMod(TargetedMod.VANILLA)),
+    OPTIMIZE_TILEENTITY_REMOVAL(new Builder("Optimize TileEntity Removal")
+            .setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinWorldUpdateEntities")
+            .setApplyIf(() -> Common.config.optimizeTileentityRemoval)
+            .addTargetedMod(TargetedMod.VANILLA)
+            .addExcludedMod(TargetedMod.FASTCRAFT)
+            .addExcludedMod(TargetedMod.BUKKIT)),
     FIX_POTION_ITERATING(new Builder("Fix Potion Iterating")
             .setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityLivingBase_FixPotionException")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -15,12 +15,14 @@ public enum TargetedMod {
     AUTOMAGY("Automagy", null, "Automagy"),
     PROJECTE("ProjectE", null, "projecte"),
     HARVESTTHENETHER("harvestthenether", null, "harvestthenether"),
-    GALACTICRAFT_CORE("GalacticraftCore", null, "GalacticraftCore"),
+    GALACTICRAFT_CORE("GalacticraftCore", "micdoodle8.mods.galacticraft.core.asm.GCLoadingPlugin", "GalacticraftCore"),
     BAUBLES("Baubles", null, "Baubles"),
     TRAVELLERSGEAR("TravellersGear", null, "TravellersGear"),
     JOURNEYMAP("JourneyMap", null, "journeymap"),
     OPTIFINE("Optifine", "optifine.OptiFineForgeTweaker", "Optifine"),
     EXTRA_UTILITIES("ExtraUtilities", null, "ExtraUtilities"),
+    BIBLIOCRAFT("Bibliocraft", null, "BiblioCraft"),
+    ZTONES("ZTones", null, "Ztones"),
     BUKKIT("Bukkit/Thermos", "Bukkit", null);
 
     public final String modName;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -20,7 +20,8 @@ public enum TargetedMod {
     TRAVELLERSGEAR("TravellersGear", null, "TravellersGear"),
     JOURNEYMAP("JourneyMap", null, "journeymap"),
     OPTIFINE("Optifine", "optifine.OptiFineForgeTweaker", "Optifine"),
-    EXTRA_UTILITIES("ExtraUtilities", null, "ExtraUtilities");
+    EXTRA_UTILITIES("ExtraUtilities", null, "ExtraUtilities"),
+    BUKKIT("Bukkit/Thermos", "Bukkit", null);
 
     public final String modName;
     public final String coreModClass;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnacePollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnacePollution.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityFurnace;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.libraries.org.objectweb.asm.Opcodes;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(TileEntityFurnace.class)
+public abstract class MixinTileEntityFurnacePollution extends TileEntity {
+    @Inject(
+            method = "updateEntity",
+            at =
+                    @At(
+                            value = "FIELD",
+                            target = "net/minecraft/tileentity/TileEntityFurnace.furnaceBurnTime:I",
+                            opcode = Opcodes.PUTFIELD))
+    void addPollution(CallbackInfo ci) {
+        if (!this.worldObj.isRemote && (this.worldObj.getTotalWorldTime() % 20) == 0)
+            PollutionHelper.addPollution(
+                    this.worldObj.getChunkFromBlockCoords(this.xCoord, this.zCoord),
+                    Common.config.furnacePollutionAmount);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTimeCommandGalacticraftFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTimeCommandGalacticraftFix.java
@@ -1,0 +1,45 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import micdoodle8.mods.galacticraft.api.prefab.world.gen.WorldProviderSpace;
+import net.minecraft.command.CommandTime;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(CommandTime.class)
+public class MixinTimeCommandGalacticraftFix {
+    @Inject(method = "setTime", at = @At("HEAD"), cancellable = true)
+    protected final void setTime(ICommandSender p_71552_1_, int p_71552_2_, CallbackInfo x) {
+        for (WorldServer server : MinecraftServer.getServer().worldServers) {
+            if (server.provider instanceof WorldProviderSpace) {
+                ((WorldProviderSpace) server.provider).setWorldTimeCommand(p_71552_2_);
+            } else {
+                server.setWorldTime(p_71552_2_);
+            }
+        }
+
+        x.cancel();
+    }
+
+    @Inject(method = "addTime", at = @At("HEAD"), cancellable = true)
+    protected final void addTime(ICommandSender p_71553_1_, int p_71553_2_, CallbackInfo x) {
+        for (WorldServer server : MinecraftServer.getServer().worldServers) {
+            if (server.provider instanceof WorldProviderSpace) {
+                final WorldProviderSpace provider = (WorldProviderSpace) server.provider;
+                provider.setWorldTimeCommand(provider.getWorldTimeCommand() + p_71553_2_);
+            } else {
+                server.setWorldTime(server.getWorldTime() + p_71553_2_);
+            }
+        }
+
+        x.cancel();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(World.class)
+public class MixinWorldUpdateEntities {
+    @Redirect(
+            method = "updateEntities",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;removeAll(Ljava/util/Collection;)Z"))
+    public boolean fasterRemoveAll(List<TileEntity> targetList, Collection<TileEntity> collectionToRemove) {
+        // Borrowed from Forge for 1.12.2 -- forge: faster "contains" makes this removal much more efficient
+        final Set<TileEntity> setToRemove = Collections.newSetFromMap(new IdentityHashMap());
+        setToRemove.addAll(collectionToRemove);
+        return targetList.removeAll(setToRemove);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBibliocraftPatchPacketExploits.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBibliocraftPatchPacketExploits.java
@@ -1,0 +1,86 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import com.mitchej123.hodgepodge.Common;
+import cpw.mods.fml.common.network.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import jds.bibliocraft.Config;
+import jds.bibliocraft.items.ItemAtlas;
+import jds.bibliocraft.network.ServerPacketHandler;
+import jds.bibliocraft.tileentities.TileEntityMapFrame;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemMap;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(ServerPacketHandler.class)
+public class MixinBibliocraftPatchPacketExploits {
+    @Inject(
+            method = {"transferWaypointsToAtlas"},
+            at = {@At("HEAD")},
+            remap = false,
+            cancellable = true)
+    private void fixTransferWaypointsToAtlas(
+            TileEntityMapFrame frameTile, ItemStack atlasStack, EntityPlayerMP player, CallbackInfo c) {
+        if (!(atlasStack.getItem() instanceof ItemAtlas)) {
+            this.kickAndWarn(player, c, "BiblioAtlasGive");
+        }
+    }
+
+    @Inject(
+            method = {"handleAtlasSwapUpdate"},
+            at = {@At("HEAD")},
+            remap = false,
+            cancellable = true)
+    private void fixHandleAtlasSwapUpdate(ByteBuf packet, EntityPlayerMP player, CallbackInfo c) {
+        packet.markReaderIndex();
+        final ItemStack insecureStack = ByteBufUtils.readItemStack(packet);
+        if (insecureStack == null) return;
+        packet.resetReaderIndex();
+
+        NBTTagCompound tags = insecureStack.getTagCompound();
+        if (tags == null) return;
+
+        NBTTagList inventoryTagList = tags.getTagList("Inventory", 10);
+        if (inventoryTagList == null) return;
+        for (int i = 0; i < inventoryTagList.tagCount(); i++) {
+            if (!(ItemStack.loadItemStackFromNBT(inventoryTagList.getCompoundTagAt(i))
+                            .getItem()
+                    instanceof ItemMap)) {
+                kickAndWarn(player, c, "BiblioFrameGive");
+            }
+        }
+    }
+
+    @Inject(
+            method = {"handleBookEdit"},
+            at = {@At("HEAD")},
+            remap = false,
+            cancellable = true)
+    private void fixHandleBookEdit(ByteBuf packet, EntityPlayerMP player, CallbackInfo c) {
+        packet.markReaderIndex();
+        ItemStack insecureStack = ByteBufUtils.readItemStack(packet);
+        packet.resetReaderIndex();
+        String namePrior = insecureStack.getDisplayName();
+        insecureStack.func_135074_t();
+        String nameAfter = insecureStack.getDisplayName();
+        if (!namePrior.equals(nameAfter) && !Config.testBookValidity(insecureStack)) {
+            this.kickAndWarn(player, c, "BiblioTableGive");
+        }
+    }
+
+    private void kickAndWarn(EntityPlayerMP player, CallbackInfo c, String exploitName) {
+        player.playerNetServerHandler.kickPlayerFromServer(
+                player.getDisplayName() + " tried to cheat with \"" + exploitName + "\"-Exploit!");
+        Common.log.error(player.getDisplayName() + " tried to cheat with \"" + exploitName + "\"-Exploit!");
+        c.cancel();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/galacticraftcore/MixinGalacticraftRocketPollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/galacticraftcore/MixinGalacticraftRocketPollution.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.late.galacticraftcore;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import micdoodle8.mods.galacticraft.api.entity.IRocketType;
+import micdoodle8.mods.galacticraft.api.prefab.entity.EntityAutoRocket;
+import micdoodle8.mods.galacticraft.api.prefab.entity.EntityTieredRocket;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(EntityTieredRocket.class)
+public abstract class MixinGalacticraftRocketPollution extends EntityAutoRocket implements IRocketType {
+
+    public MixinGalacticraftRocketPollution(World world) {
+        super(world);
+    }
+
+    @Inject(method = "onUpdate", at = @At("HEAD"))
+    private void addRocketPollution(CallbackInfo ci) {
+        if (this.worldObj.isRemote
+                || !(launchPhase == EnumLaunchPhase.LAUNCHED.ordinal()
+                        || launchPhase == EnumLaunchPhase.IGNITED.ordinal())) return;
+        int pollutionAmount = Common.config.rocketPollutionAmount;
+
+        // Note: Linear instead of growing by powers of 2
+        if (launchPhase == EnumLaunchPhase.LAUNCHED.ordinal())
+            pollutionAmount = (pollutionAmount * this.getRocketTier());
+        else if (launchPhase == EnumLaunchPhase.IGNITED.ordinal())
+            pollutionAmount = (pollutionAmount * (this.getRocketTier())) / 100;
+        else pollutionAmount = 0;
+
+        PollutionHelper.addPollution(worldObj.getChunkFromBlockCoords((int) posX, (int) posZ), pollutionAmount);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIC2IronFurnacePollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIC2IronFurnacePollution.java
@@ -1,0 +1,30 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import ic2.core.block.machine.tileentity.TileEntityIronFurnace;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(value = TileEntityIronFurnace.class, remap = false)
+public abstract class MixinIC2IronFurnacePollution extends TileEntity {
+    @Shadow
+    public abstract boolean isBurning();
+
+    @Inject(method = "updateEntityServer", at = @At("TAIL"))
+    private void updateEntityServer(CallbackInfo ci) {
+        if (worldObj.isRemote || !isBurning()) return;
+        if ((worldObj.getTotalWorldTime() % 20) == 0) {
+            PollutionHelper.addPollution(
+                    worldObj.getChunkFromBlockCoords(xCoord, zCoord), Common.config.furnacePollutionAmount);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minecraft/MixinExplosionPollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minecraft/MixinExplosionPollution.java
@@ -1,0 +1,38 @@
+package com.mitchej123.hodgepodge.mixins.late.minecraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(Explosion.class)
+public class MixinExplosionPollution {
+    @Shadow
+    float explosionSize;
+
+    @Shadow
+    World worldObj;
+
+    @Shadow
+    double explosionX;
+
+    @Shadow
+    double explosionZ;
+
+    @Inject(method = "doExplosionA", at = @At(value = "TAIL"))
+    public void addExplosionPollution(CallbackInfo ci) {
+        if (!this.worldObj.isRemote)
+            PollutionHelper.addPollution(
+                    this.worldObj.getChunkFromBlockCoords((int) this.explosionX, (int) this.explosionZ),
+                    (int) Math.ceil(explosionSize * Common.config.explosionPollutionAmount));
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/railcraft/MixinRailcraftBoilerPollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/railcraft/MixinRailcraftBoilerPollution.java
@@ -1,0 +1,45 @@
+package com.mitchej123.hodgepodge.mixins.late.railcraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import mods.railcraft.common.blocks.RailcraftTileEntity;
+import mods.railcraft.common.blocks.machine.TileMultiBlock;
+import mods.railcraft.common.blocks.machine.beta.TileEngineSteamHobby;
+import mods.railcraft.common.util.steam.SteamBoiler;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(SteamBoiler.class)
+public class MixinRailcraftBoilerPollution {
+    @Shadow(remap = false)
+    RailcraftTileEntity tile;
+
+    @Shadow(remap = false)
+    boolean isBurning;
+
+    @Inject(method = "tick", at = @At(value = "HEAD"), remap = false)
+    private void tick(int x, CallbackInfo ci) {
+        if (!this.isBurning || this.tile == null || this.tile.getWorld() == null) return;
+        final World world = this.tile.getWorldObj();
+        if ((world.getTotalWorldTime() % 20) == 0) {
+            int pollutionAmount;
+            if (this.tile instanceof TileMultiBlock)
+                pollutionAmount = (((TileMultiBlock) this.tile).getComponents().size() - x)
+                        * Common.config.fireboxPollutionAmount;
+            else if (this.tile instanceof TileEngineSteamHobby)
+                pollutionAmount = Common.config.hobbyistEnginePollutionAmount;
+            else pollutionAmount = 40;
+
+            PollutionHelper.addPollution(
+                    world.getChunkFromBlockCoords(this.tile.getX(), this.tile.getZ()), pollutionAmount);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/railcraft/MixinRailcraftCokeOvenPollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/railcraft/MixinRailcraftCokeOvenPollution.java
@@ -1,0 +1,39 @@
+package com.mitchej123.hodgepodge.mixins.late.railcraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import java.util.List;
+import mods.railcraft.common.blocks.machine.MultiBlockPattern;
+import mods.railcraft.common.blocks.machine.TileMultiBlock;
+import mods.railcraft.common.blocks.machine.TileMultiBlockOven;
+import mods.railcraft.common.blocks.machine.alpha.TileBlastFurnace;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(TileMultiBlockOven.class)
+public abstract class MixinRailcraftCokeOvenPollution extends TileMultiBlock {
+    @Shadow(remap = false)
+    boolean cooking;
+
+    public MixinRailcraftCokeOvenPollution(List<? extends MultiBlockPattern> patterns) {
+        super(patterns);
+    }
+
+    @Inject(method = "updateEntity", at = @At("HEAD"))
+    private void addPollution(CallbackInfo ci) {
+        if (this.worldObj.isRemote || !this.cooking || !this.isMaster) return;
+        if ((this.worldObj.getTotalWorldTime() % 20) == 0) {
+            final int pollution = (((TileMultiBlock) this) instanceof TileBlastFurnace)
+                    ? Common.config.advancedCokeOvenPollutionAmount
+                    : Common.config.cokeOvenPollutionAmount;
+            PollutionHelper.addPollution(this.worldObj.getChunkFromBlockCoords(this.xCoord, this.zCoord), pollution);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/railcraft/MixinRailcraftTunnelBorePollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/railcraft/MixinRailcraftTunnelBorePollution.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.late.railcraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import mods.railcraft.common.carts.EntityTunnelBore;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(EntityTunnelBore.class)
+public abstract class MixinRailcraftTunnelBorePollution extends EntityTunnelBore {
+    @Shadow(remap = false)
+    boolean active;
+
+    public MixinRailcraftTunnelBorePollution(World world) {
+        super(world);
+    }
+
+    @Inject(method = "onUpdate", at = @At("HEAD"))
+    private void addPollution(CallbackInfo ci) {
+        if (!worldObj.isRemote || !active) return;
+        PollutionHelper.addPollution(
+                worldObj.getChunkFromBlockCoords((int) posX, (int) posZ), Common.config.tunnelBorePollutionAmount);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinThaumcraftAlchemyFurnacePollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinThaumcraftAlchemyFurnacePollution.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.libraries.org.objectweb.asm.Opcodes;
+import thaumcraft.common.tiles.TileAlchemyFurnace;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(TileAlchemyFurnace.class)
+public abstract class MixinThaumcraftAlchemyFurnacePollution extends TileEntity {
+    @Inject(
+            method = "updateEntity",
+            at =
+                    @At(
+                            value = "FIELD",
+                            target = "thaumcraft/common/tiles/TileAlchemyFurnace.furnaceBurnTime:I",
+                            opcode = Opcodes.PUTFIELD,
+                            remap = false))
+    public void addPollution(CallbackInfo ci) {
+        if (!this.worldObj.isRemote && (this.worldObj.getTotalWorldTime() % 20) == 0)
+            PollutionHelper.addPollution(
+                    this.worldObj.getChunkFromBlockCoords(this.xCoord, this.zCoord),
+                    Common.config.furnacePollutionAmount);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ztones/MixinZtonesPatchPacketExploits.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ztones/MixinZtonesPatchPacketExploits.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.late.ztones;
+
+import com.riciJak.Ztones.item.block.ItemBlockZTMetadata;
+import com.riciJak.Ztones.item.block.ItemDecoBlocks2;
+import com.riciJak.Ztones.network.ToggleMetaData;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/*
+ * Merged from ModMixins under the MIT License
+ *    Copyright bartimaeusnek & GTNewHorizons
+ */
+@Mixin(ToggleMetaData.class)
+public class MixinZtonesPatchPacketExploits {
+    @Redirect(
+            method = "processData",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/entity/player/EntityPlayer;getHeldItem()Lnet/minecraft/item/ItemStack;"))
+    public ItemStack getPlayerHeldZtonesItem(EntityPlayer entityPlayer) {
+        final ItemStack heldItemStack = entityPlayer.getHeldItem();
+        if (heldItemStack == null) return null;
+
+        final Item heldItem = heldItemStack.getItem();
+        if (!(heldItem instanceof ItemBlockZTMetadata || heldItem instanceof ItemDecoBlocks2)) return null;
+
+        return heldItemStack;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/PollutionHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PollutionHelper.java
@@ -1,0 +1,13 @@
+package com.mitchej123.hodgepodge.util;
+
+import gregtech.common.GT_Pollution;
+import net.minecraft.world.chunk.Chunk;
+
+public class PollutionHelper {
+    /*
+     * GT might not loaded when the pollution mixins run, so use this shim
+     */
+    public static void addPollution(Chunk ch, int aPollution) {
+        GT_Pollution.addPollution(ch, aPollution);
+    }
+}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,8 +7,9 @@
         "mcversion": "${minecraftVersion}",
         "url": "",
         "updateUrl": "",
-        "authorList": ["mitchej123"],
-        "credits": "",
+        "authorList": ["mitchej123", "GTNewHorizons Team"],
+        "license": "LGPL v3",
+        "credits": "bartimaeusnek for ModMixins",
         "logoFile": "",
         "screenshots": [],
         "dependencies": []


### PR DESCRIPTION
Adaption of https://github.com/MinecraftForge/MinecraftForge/commit/638a54b04ab896fd18bdc5da48269f5465e5b61c

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9147 when fastcraft is not in use

Note: Targeting 2.0 branch, will rebase to master if merged after 2.0 branch