### PR TITLE
Fix one of the memory leaks on dimension change

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -28,6 +28,7 @@ public class LoadingConfig {
     public boolean fixComponentsPoppingOff;
     public boolean fixDebugBoundingBox;
     public boolean fixDimensionChangeHearts;
+    public boolean fixDimensionChangeMemoryLeak;
     public boolean fixExtraUtilitiesUnEnchanting;
     public boolean fixFenceConnections;
     public boolean fixFireSpread;
@@ -159,6 +160,7 @@ public class LoadingConfig {
         fixComponentsPoppingOff = config.get(Category.TWEAKS.toString(), "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();
         fixDebugBoundingBox = config.get(Category.FIXES.toString(), "fixDebugBoundingBox", true, "Fixes the debug hitbox of the player beeing offset").getBoolean();
         fixDimensionChangeHearts = config.get(Category.FIXES.toString(), "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();
+        fixDimensionChangeMemoryLeak = config.get(Category.FIXES.toString(), "fixDimensionChangeMemoryLeak", true, "Fix memory leak on dimension change").getBoolean();
         fixExtraUtilitiesUnEnchanting = config.get(Category.FIXES.toString(), "fixExtraUtilitiesUnEnchanting", true, "Fix dupe bug with division sigil removing enchantment").getBoolean();
         fixFenceConnections = config.get(Category.FIXES.toString(), "fixFenceConnections", true, "Fix fence connections with other types of fence").getBoolean();
         fixFireSpread = config.get(Category.FIXES.toString(), "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/client/biomesoplenty/BOPFogHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/biomesoplenty/BOPFogHandler.java
@@ -6,6 +6,7 @@ import com.mitchej123.hodgepodge.mixins.late.biomesoplenty.AccessorFogHandler;
 import java.util.concurrent.atomic.AtomicInteger;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -66,9 +67,9 @@ public class BOPFogHandler {
                                 int playerX = MathHelper.floor_double(player.posX);
                                 int playerY = MathHelper.floor_double(player.posY);
                                 int playerZ = MathHelper.floor_double(player.posZ);
-                                BiomeGenBase biome = Minecraft.getMinecraft()
-                                        .theWorld
-                                        .getBiomeGenForCoords(playerX + x, playerZ + z);
+                                final WorldClient worldClient = Minecraft.getMinecraft().theWorld;
+                                if (worldClient == null) continue;
+                                final BiomeGenBase biome = worldClient.getBiomeGenForCoords(playerX + x, playerZ + z);
 
                                 if (biome instanceof IBiomeFog) {
                                     float distancePart =

--- a/src/main/java/com/mitchej123/hodgepodge/interfaces/IMixinCleanup.java
+++ b/src/main/java/com/mitchej123/hodgepodge/interfaces/IMixinCleanup.java
@@ -1,0 +1,5 @@
+package com.mitchej123.hodgepodge.interfaces;
+
+public interface IMixinCleanup {
+    void cleanup();
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -136,6 +136,14 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinServerConfigurationManager", "minecraft.MixinEntityPlayerMP")
             .setApplyIf(() -> Common.config.fixDimensionChangeHearts)
             .addTargetedMod(TargetedMod.VANILLA)),
+    DIMENSION_MEMORY_LEAK_FIX(new Builder("Dimension Change Memory Leak Fix")
+            .setPhase(Phase.EARLY)
+            .addMixinClasses(
+                    "minecraft.MixinNetHandlerPlayClient",
+                    "minecraft.MixinWorldClient",
+                    "minecraft.MixinChunkProviderClient")
+            .setApplyIf(() -> Common.config.fixDimensionChangeMemoryLeak)
+            .addTargetedMod(TargetedMod.VANILLA)),
     INCREASE_PARTICLE_LIMIT(new Builder("Increase Particle Limit")
             .setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEffectRenderer")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderClient.java
@@ -1,0 +1,34 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.interfaces.IMixinCleanup;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.client.multiplayer.ChunkProviderClient;
+import net.minecraft.util.LongHashMap;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ChunkProviderClient.class)
+public class MixinChunkProviderClient implements IMixinCleanup {
+
+    @Shadow
+    private List<Chunk> chunkListing;
+
+    @Shadow
+    private LongHashMap chunkMapping;
+
+    @Shadow
+    private World worldObj;
+
+    @Override
+    public void cleanup() {
+        Common.log.info("ChunkProviderClient::Cleanup");
+        // Make sure we don't have any dangling objects that have a reference to the worldObj
+        this.chunkListing = new ArrayList<>();
+        this.chunkMapping = new LongHashMap();
+        this.worldObj = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.interfaces.IMixinCleanup;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.network.play.server.S07PacketRespawn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(NetHandlerPlayClient.class)
+public class MixinNetHandlerPlayClient {
+    @Shadow
+    private WorldClient clientWorldController;
+
+    @Inject(method = "cleanup", at = @At("HEAD"))
+    private void betterCleanup(CallbackInfo ci) {
+        Common.log.info("MixinNetHandlerPlayClient::BetterCleanup");
+        // Do a better job at cleaning up
+        if (this.clientWorldController != null) {
+            ((IMixinCleanup) this.clientWorldController).cleanup();
+        }
+    }
+
+    @Inject(
+            method = "handleRespawn",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target =
+                                    "Lnet/minecraft/client/multiplayer/WorldClient;getScoreboard()Lnet/minecraft/scoreboard/Scoreboard;"))
+    private void handleRespawnClearWorldClient(S07PacketRespawn packetRespawn, CallbackInfo ci) {
+        Common.log.info("MixinNetHandlerPlayClient::handleRespawnClearWorldClient");
+        if (this.clientWorldController != null) {
+            ((IMixinCleanup) this.clientWorldController).cleanup();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldClient.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.interfaces.IMixinCleanup;
+import net.minecraft.client.multiplayer.ChunkProviderClient;
+import net.minecraft.client.multiplayer.WorldClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(WorldClient.class)
+public class MixinWorldClient implements IMixinCleanup {
+    @Shadow
+    private ChunkProviderClient clientChunkProvider;
+
+    public void cleanup() {
+        // This keeps a reference to the WorldClient, which keeps a reference to the ClientChunkProvider...
+        // which.....<explodes>
+        Common.log.info("WorldClient::Cleanup");
+        if (this.clientChunkProvider != null) {
+            ((IMixinCleanup) this.clientChunkProvider).cleanup();
+        }
+        this.clientChunkProvider = null;
+    }
+}


### PR DESCRIPTION
* WorldClient keeps a reference to ChunkProviderClient which keeps a reference to WorldClient, as well as Chunks which keep a reference to WorldClient
* Add various cleanup methods to clean up the various cyclical references