### PR TITLE
Vanilla fix: Don't delete whole stack when eating mushroom stew

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -28,6 +28,7 @@ public class LoadingConfig {
     public boolean fixComponentsPoppingOff;
     public boolean fixDebugBoundingBox;
     public boolean fixDimensionChangeHearts;
+    public boolean fixEatingStackedStew;
     public boolean fixExtraUtilitiesUnEnchanting;
     public boolean fixFenceConnections;
     public boolean fixFireSpread;
@@ -159,6 +160,7 @@ public class LoadingConfig {
         fixComponentsPoppingOff = config.get(Category.TWEAKS.toString(), "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();
         fixDebugBoundingBox = config.get(Category.FIXES.toString(), "fixDebugBoundingBox", true, "Fixes the debug hitbox of the player beeing offset").getBoolean();
         fixDimensionChangeHearts = config.get(Category.FIXES.toString(), "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();
+        fixEatingStackedStew = config.get(Category.FIXES.toString(), "fixEatingStackedStew", true, "Fix deleting stack when eating mushroom stew").getBoolean();
         fixExtraUtilitiesUnEnchanting = config.get(Category.FIXES.toString(), "fixExtraUtilitiesUnEnchanting", true, "Fix dupe bug with division sigil removing enchantment").getBoolean();
         fixFenceConnections = config.get(Category.FIXES.toString(), "fixFenceConnections", true, "Fix fence connections with other types of fence").getBoolean();
         fixFireSpread = config.get(Category.FIXES.toString(), "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -136,6 +136,11 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinServerConfigurationManager", "minecraft.MixinEntityPlayerMP")
             .setApplyIf(() -> Common.config.fixDimensionChangeHearts)
             .addTargetedMod(TargetedMod.VANILLA)),
+    FIX_EATING_STACKED_STEW(new Builder("Stacked Mushroom Stew Eating Fix")
+            .setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinItemSoup")
+            .setApplyIf(() -> Common.config.fixEatingStackedStew)
+            .addTargetedMod(TargetedMod.VANILLA)),
     INCREASE_PARTICLE_LIMIT(new Builder("Increase Particle Limit")
             .setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEffectRenderer")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemSoup.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemSoup.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemSoup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(ItemSoup.class)
+public class MixinItemSoup extends ItemFood {
+    // dummy constructor
+    public MixinItemSoup(int p_i45339_1_, float p_i45339_2_, boolean p_i45339_3_) {
+        super(p_i45339_1_, p_i45339_2_, p_i45339_3_);
+    }
+
+    /**
+     * @author rot13
+     * @reason Fix deleting stack (>1) when eating mushroom stew
+     */
+    @Overwrite()
+    public ItemStack onEaten(ItemStack p_77654_1_, World p_77654_2_, EntityPlayer p_77654_3_) {
+        ItemStack emptyBowl = new ItemStack(Items.bowl);
+
+        if (!p_77654_3_.inventory.addItemStackToInventory(emptyBowl)) {
+            p_77654_3_.dropPlayerItemWithRandomChoice(emptyBowl, true);
+        }
+
+        return super.onEaten(p_77654_1_, p_77654_2_, p_77654_3_);
+    }
+}


### PR DESCRIPTION
GTNH [increases](https://github.com/GTNewHorizons/GT5-Unofficial/pull/952) mushroom stew stack size, however the vanilla method for eating stew just throws the whole stack away.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9908

I know this is a minuscule fix in the grand scheme of things, though this is my first time using mixins and I prefer starting small.