### PR TITLE
Fix `fixPotionEffectRender` crashing without NEI, and make it work as intended

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -2,16 +2,31 @@ package com.mitchej123.hodgepodge;
 
 import codechicken.nei.NEIClientConfig;
 import cpw.mods.fml.common.Loader;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /** This class cannot be used earlier than pre-init phase. */
 public class Compat {
     private static boolean isNeiPresent;
+    private static boolean doesNeiHaveBookmarkAPI;
 
     static void init() {
         isNeiPresent = Loader.isModLoaded("NotEnoughItems");
+        try {
+            Method isBookmarkPanelHiddenMethod =
+                    Class.forName("codechicken.nei.NEIClientConfig").getMethod("isBookmarkPanelHidden");
+            if (Modifier.isStatic(isBookmarkPanelHiddenMethod.getModifiers())
+                    && isBookmarkPanelHiddenMethod.getReturnType().equals(boolean.class)) {
+                doesNeiHaveBookmarkAPI = true;
+            }
+        } catch (Exception e) {
+        }
     }
 
-    public static boolean isNeiHidden() {
-        return !isNeiPresent || NEIClientConfig.isHidden();
+    public static boolean isNeiLeftPanelVisible() {
+        return isNeiPresent
+                && NEIClientConfig.isEnabled()
+                && !NEIClientConfig.isHidden()
+                && (!doesNeiHaveBookmarkAPI || !NEIClientConfig.isBookmarkPanelHidden());
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -1,0 +1,17 @@
+package com.mitchej123.hodgepodge;
+
+import codechicken.nei.NEIClientConfig;
+import cpw.mods.fml.common.Loader;
+
+/** This class cannot be used earlier than pre-init phase. */
+public class Compat {
+    private static boolean isNeiPresent;
+
+    static void init() {
+        isNeiPresent = Loader.isModLoaded("NotEnoughItems");
+    }
+
+    public static boolean isNeiHidden() {
+        return !isNeiPresent || NEIClientConfig.isHidden();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -8,6 +8,7 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.relauncher.Side;
 
@@ -22,6 +23,11 @@ public class Hodgepodge {
     public static final String MODID = "hodgepodge";
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static final String NAME = "A Hodgepodge of Patches";
+
+    @EventHandler
+    public void preinit(FMLPreInitializationEvent event) {
+        Compat.init();
+    }
 
     @EventHandler
     public void init(FMLInitializationEvent event) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -22,14 +22,14 @@ public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends
      */
     @Overwrite
     public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_) {
-        boolean bookmarkPanelHidden = Compat.isNeiHidden();
-        if (bookmarkPanelHidden) {
+        boolean leftPanelHidden = !Compat.isNeiLeftPanelVisible();
+        if (leftPanelHidden) {
             super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
         }
         if (!this.mc.thePlayer.getActivePotionEffects().isEmpty()) {
             this.func_147044_g();
         }
-        if (bookmarkPanelHidden) {
+        if (leftPanelHidden) {
             return;
         }
         super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import codechicken.nei.NEIClientConfig;
+import com.mitchej123.hodgepodge.Compat;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 import net.minecraft.inventory.Container;
@@ -22,7 +22,7 @@ public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends
      */
     @Overwrite
     public void drawScreen(int p_73863_1_, int p_73863_2_, float p_73863_3_) {
-        boolean bookmarkPanelHidden = NEIClientConfig.isHidden();
+        boolean bookmarkPanelHidden = Compat.isNeiHidden();
         if (bookmarkPanelHidden) {
             super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
         }


### PR DESCRIPTION
Removes dependency on NEI (and by extension, CCC and CCL).

Also makes the potion effects only get dimmed when there are actually widgets being drawn in the left panel. Previously they were dimmed even if the bookmark panel was hidden, or if NEI was disabled in the settings but not hidden. Now the fix works as intended both with NHEI and upstream NEI.