### PR TITLE
Vanilla Fix: Player Sound Registered as Friendly Creatures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
-//version: 1666118075
+//version: 1667597057
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
- Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
+ Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/master/build.gradle for updates.
  */
 
 
@@ -45,7 +45,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.9'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.11'
     }
 }
 plugins {

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -32,6 +32,7 @@ public class LoadingConfig {
     public boolean fixExtraUtilitiesUnEnchanting;
     public boolean fixFenceConnections;
     public boolean fixFireSpread;
+    public boolean fixFriendlyCreatureSounds;
     public boolean fixGetBlockLightValue;
     public boolean fixGlStateBugs;
     public boolean fixGuiGameOver;
@@ -164,6 +165,7 @@ public class LoadingConfig {
         fixExtraUtilitiesUnEnchanting = config.get(Category.FIXES.toString(), "fixExtraUtilitiesUnEnchanting", true, "Fix dupe bug with division sigil removing enchantment").getBoolean();
         fixFenceConnections = config.get(Category.FIXES.toString(), "fixFenceConnections", true, "Fix fence connections with other types of fence").getBoolean();
         fixFireSpread = config.get(Category.FIXES.toString(), "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();
+        fixFriendlyCreatureSounds = config.get(Category.FIXES.toString(), "fixFriendlyCreatureSounds", true, "Fix vanilla issue where player sounds register as animal sounds").getBoolean();
         fixGetBlockLightValue = config.get(Category.FIXES.toString(), "fixGetBlockLightValue", true, "Fix vanilla light calculation sometimes cause NPE on thermos").getBoolean();
         fixGlStateBugs = config.get(Category.FIXES.toString(), "fixGlStateBugs", true, "Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).").getBoolean();
         fixGuiGameOver = config.get(Category.FIXES.toString(), "fixGuiGameOver", true, "Fix Game Over GUI buttons disabled if switching fullscreen").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -10,6 +10,12 @@ import java.util.function.Supplier;
 
 public enum Mixins {
     // Vanilla Fixes
+    FIX_FRIENDLY_CREATURE_SOUNDS(new Builder("Fix Friendly Creature Sounds")
+            .setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinSoundHandler")
+            .setSide(Side.CLIENT)
+            .addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> Common.config.fixFriendlyCreatureSounds)),
     THROTTLE_ITEMPICKUPEVENT(new Builder("Throttle Item Pickup Event")
             .setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityPlayer")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundHandler.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.audio.SoundCategory;
+import net.minecraft.client.audio.SoundHandler;
+import net.minecraft.client.audio.SoundList;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(value = SoundHandler.class)
+public class MixinSoundHandler {
+
+    @Inject(method = "loadSoundResource", at = @At("HEAD"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
+    private void loadSoundResource(ResourceLocation resourceLocation, SoundList soundList, CallbackInfo callbackInfo) {
+        String name = resourceLocation.toString();
+
+        if (name.startsWith("minecraft:step")
+                || name.startsWith("minecraft:random.bow")
+                || name.equals("minecraft:game.potion.smash")) {
+            soundList.setSoundCategory(SoundCategory.PLAYERS);
+        }
+    }
+}


### PR DESCRIPTION
This fixes a bug in vanilla Minecraft where certain player sounds were registered as animal(AKA friendly creatures) sounds. This caused them to not be played when the friendly creatures sounds were muted.

GTNH Issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11752

Here's a link to the Mojang bug report: https://bugs.mojang.com/browse/MC-36360

The issue has since been fixed in Vanilla minecraft so this is a backport of sorts. The problem is that in the vanilla `sounds.json` file these sounds are registered incorrectly, however you are unable to override this setting via resourcepacks, so a mixin is needed to intercept the sounds loading in, and dynamically change the SoundCategory depending on the name of the sound.