### PR TITLE
Only apply IC2 hazmat mixin if GT5 is present

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -2,11 +2,11 @@ package com.mitchej123.hodgepodge;
 
 import codechicken.nei.NEIClientConfig;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.relauncher.Side;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-/** This class cannot be used earlier than pre-init phase. */
 public class Compat {
     private static boolean isClient;
 
@@ -30,11 +30,22 @@ public class Compat {
         }
     }
 
+    /**
+     * Cannot be used before pre-init phase.
+     */
     public static boolean isNeiLeftPanelVisible() {
         return isNeiPresent
                 && isClient
                 && NEIClientConfig.isEnabled()
                 && !NEIClientConfig.isHidden()
                 && (!doesNeiHaveBookmarkAPI || !NEIClientConfig.isBookmarkPanelHidden());
+    }
+
+    /**
+     * Cannot be used before mod construction phase.
+     */
+    public static boolean isGT5Present() {
+        ModContainer gtModContainer = Loader.instance().getIndexedModList().get("gregtech");
+        return gtModContainer != null && gtModContainer.getVersion().equals("MC1710");
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -2,7 +2,6 @@ package com.mitchej123.hodgepodge;
 
 import codechicken.nei.NEIClientConfig;
 import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.relauncher.Side;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -39,13 +38,5 @@ public class Compat {
                 && NEIClientConfig.isEnabled()
                 && !NEIClientConfig.isHidden()
                 && (!doesNeiHaveBookmarkAPI || !NEIClientConfig.isBookmarkPanelHidden());
-    }
-
-    /**
-     * Cannot be used before mod construction phase.
-     */
-    public static boolean isGT5Present() {
-        ModContainer gtModContainer = Loader.instance().getIndexedModList().get("gregtech");
-        return gtModContainer != null && gtModContainer.getVersion().equals("MC1710");
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1,7 +1,6 @@
 package com.mitchej123.hodgepodge.mixins;
 
 import com.mitchej123.hodgepodge.Common;
-import com.mitchej123.hodgepodge.Compat;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -313,9 +312,10 @@ public enum Mixins {
     IC2_HAZMAT(new Builder("Hazmat")
             .setPhase(Phase.LATE)
             .addMixinClasses("ic2.MixinIc2Hazmat")
-            .setApplyIf(() -> Common.config.fixIc2Hazmat && Compat.isGT5Present())
+            .setApplyIf(() -> Common.config.fixIc2Hazmat)
             .addTargetedMod(TargetedMod.IC2)
-            .addTargetedMod(TargetedMod.GT5U)),
+            .addTargetedMod(TargetedMod.GT5U)
+            .addExcludedMod(TargetedMod.GT6API)),
     IC2_FLUID_CONTAINER_TOOLTIP(new Builder("IC2 Fluid Container Tooltip Fix")
             .setPhase(Phase.EARLY)
             .addMixinClasses("ic2.MixinItemIC2FluidContainer")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1,6 +1,7 @@
 package com.mitchej123.hodgepodge.mixins;
 
 import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.Compat;
 import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -310,9 +311,9 @@ public enum Mixins {
             .setApplyIf(() -> Common.config.hideIc2ReactorSlots)
             .addTargetedMod(TargetedMod.IC2)),
     IC2_HAZMAT(new Builder("Hazmat")
-            .setPhase(Phase.EARLY)
+            .setPhase(Phase.LATE)
             .addMixinClasses("ic2.MixinIc2Hazmat")
-            .setApplyIf(() -> Common.config.fixIc2Hazmat)
+            .setApplyIf(() -> Common.config.fixIc2Hazmat && Compat.isGT5Present())
             .addTargetedMod(TargetedMod.IC2)
             .addTargetedMod(TargetedMod.GT5U)),
     IC2_FLUID_CONTAINER_TOOLTIP(new Builder("IC2 Fluid Container Tooltip Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -315,7 +315,7 @@ public enum Mixins {
             .setApplyIf(() -> Common.config.fixIc2Hazmat)
             .addTargetedMod(TargetedMod.IC2)
             .addTargetedMod(TargetedMod.GT5U)
-            .addExcludedMod(TargetedMod.GT6API)),
+            .addExcludedMod(TargetedMod.GT6)),
     IC2_FLUID_CONTAINER_TOOLTIP(new Builder("IC2 Fluid Container Tooltip Fix")
             .setPhase(Phase.EARLY)
             .addMixinClasses("ic2.MixinItemIC2FluidContainer")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -8,7 +8,7 @@ public enum TargetedMod {
     COFH_CORE("CoFHCore", "cofh.asm.LoadingPlugin", "CoFHCore"),
     THAUMCRAFT("Thaumcraft", null, "Thaumcraft"), // "thaumcraft.codechicken.core.launch.DepLoader"
     GT5U("GregTech5u", null, "gregtech"), // Also matches GT6.
-    GT6API("GregTech6-API", null, "gregapi"), // Can be used to exclude GT6 from the GT5U target.
+    GT6("GregTech6", "gregtech.asm.GT_ASM", "gregapi"), // Can be used to exclude GT6 from the GT5U target.
     HUNGER_OVERHAUL("HungerOverhaul", null, "HungerOverhaul"),
     RAILCRAFT("Railcraft", null, "Railcraft"),
     BOP("BiomesOPlenty", null, "BiomesOPlenty"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -7,7 +7,8 @@ public enum TargetedMod {
     FASTCRAFT("FastCraft", "fastcraft.Tweaker"),
     COFH_CORE("CoFHCore", "cofh.asm.LoadingPlugin", "CoFHCore"),
     THAUMCRAFT("Thaumcraft", null, "Thaumcraft"), // "thaumcraft.codechicken.core.launch.DepLoader"
-    GT5U("GregTech5u", null, "gregtech"),
+    GT5U("GregTech5u", null, "gregtech"), // Also matches GT6.
+    GT6API("GregTech6-API", null, "gregapi"), // Can be used to exclude GT6 from the GT5U target.
     HUNGER_OVERHAUL("HungerOverhaul", null, "HungerOverhaul"),
     RAILCRAFT("Railcraft", null, "Railcraft"),
     BOP("BiomesOPlenty", null, "BiomesOPlenty"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIc2Hazmat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIc2Hazmat.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.ic2;
+package com.mitchej123.hodgepodge.mixins.late.ic2;
 
 import gregtech.api.util.GT_Utility;
 import ic2.core.item.armor.ItemArmorHazmat;


### PR DESCRIPTION
Currently the game crashes if `fixIc2Hazmat` is enabled while IC2 is present without GT5. This is because the mixin is initialized in the early phase before non-coremods have been discovered, causing the `TargetedMod.GT5U` check to always succeed.

This PR moves the mixin to the late phase as a solution. However, this alone would still cause the mod to crash when IC2 and GT6 are both present, since GT6 has the same modid as GT5. For this reason, I also added a check that the GT mod in question has GT5's version.