### PR TITLE
Check for GT5's presence before using GT_Pollution

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -13,6 +13,8 @@ public class Compat {
     private static boolean isNeiPresent;
     private static boolean doesNeiHaveBookmarkAPI;
 
+    private static boolean isGT5Present;
+
     static void init(Side side) {
         isClient = side == Side.CLIENT;
 
@@ -28,6 +30,8 @@ public class Compat {
             } catch (Exception e) {
             }
         }
+
+        isGT5Present = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
     }
 
     public static boolean isNeiLeftPanelVisible() {
@@ -36,5 +40,12 @@ public class Compat {
                 && NEIClientConfig.isEnabled()
                 && !NEIClientConfig.isHidden()
                 && (!doesNeiHaveBookmarkAPI || !NEIClientConfig.isBookmarkPanelHidden());
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isGT5Present() {
+        return isGT5Present;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/PollutionHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PollutionHelper.java
@@ -1,5 +1,6 @@
 package com.mitchej123.hodgepodge.util;
 
+import com.mitchej123.hodgepodge.Compat;
 import gregtech.common.GT_Pollution;
 import net.minecraft.world.chunk.Chunk;
 
@@ -8,6 +9,8 @@ public class PollutionHelper {
      * GT might not loaded when the pollution mixins run, so use this shim
      */
     public static void addPollution(Chunk ch, int aPollution) {
-        GT_Pollution.addPollution(ch, aPollution);
+        if (Compat.isGT5Present()) {
+            GT_Pollution.addPollution(ch, aPollution);
+        }
     }
 }


### PR DESCRIPTION
Using a furnace causes a crash when pollution is enabled in the config (which it is by default!) while GT5 is not present.

This PR fixes this by adding a check that GT5 is present before using GT's pollution API.