### PR TITLE
Prevents journeymap from using illegal character in file paths

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -50,6 +50,7 @@ public class LoadingConfig {
     public boolean fixIgnisFruitAABB;
     public boolean fixImmobileFireballs;
     public boolean fixJourneymapKeybinds;
+    public boolean fixJourneymapFilePath;
     public boolean fixNetherLeavesFaceRendering;
     public boolean fixNorthWestBias;
     public boolean fixOptifineChunkLoadingCrash;
@@ -190,6 +191,7 @@ public class LoadingConfig {
         fixIgnisFruitAABB = config.get(Category.FIXES.toString(), "fixIgnisFruitAABB", true, "Fix Axis aligned Bounding Box of Ignis Fruit").getBoolean();
         fixImmobileFireballs = config.get(Category.FIXES.toString(), "fixImmobileFireballs", true, "Fix the bug that makes fireballs stop moving when chunk unloads").getBoolean();
         fixJourneymapKeybinds = config.get(Category.FIXES.toString(), "fixJourneymapKeybinds", true, "Prevent unbinded keybinds from triggering when pressing certain keys").getBoolean();
+        fixJourneymapFilePath = config.get(Category.FIXES.toString(), "fixJourneymapFilePath", true, "Prevents journeymap from using illegal character in file paths").getBoolean();
         fixNetherLeavesFaceRendering = config.get(Category.FIXES.toString(), "fixNetherLeavesFaceRendering", true, "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too").getBoolean();
         fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
         fixOptifineChunkLoadingCrash = config.get(Category.FIXES.toString(), "fixOptifineChunkLoadingCrash", true, "Forces the chunk loading option from optifine to default since other values can crash the game").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -426,6 +426,11 @@ public enum Mixins {
             .addMixinClasses("journeymap.MixinConstants")
             .setApplyIf(() -> Common.config.fixJourneymapKeybinds)
             .addTargetedMod(TargetedMod.JOURNEYMAP)),
+    FIX_JOURNEYMAP_ILLEGAL_FILE_PATH_CHARACTER(new Builder("Fix Journeymap Illegal File Path Character")
+            .setSide(Side.CLIENT)
+            .addMixinClasses("journeymap.MixinWorldData")
+            .setApplyIf(() -> Common.config.fixJourneymapFilePath)
+            .addTargetedMod(TargetedMod.JOURNEYMAP)),
 
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(new Builder("Ignis Fruit")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWorldData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWorldData.java
@@ -1,0 +1,15 @@
+package com.mitchej123.hodgepodge.mixins.late.journeymap;
+
+import com.gtnewhorizon.mixinextras.injector.ModifyReturnValue;
+import journeymap.client.data.WorldData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(WorldData.class)
+public class MixinWorldData {
+
+    @ModifyReturnValue(method = "getServerName", at = @At("RETURN"), remap = false)
+    private static String hodgepodge$fixIllegalFilePathCharacter(String worldname) {
+        return worldname == null ? null : worldname.replace(':', '_');
+    }
+}


### PR DESCRIPTION
should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11876

I didn't test it since I don't have any servers to join but it injects properly and should fix the link issue