### PR TITLE
fix resource pack folder sometimes not opening on windows

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -61,6 +61,7 @@ public class LoadingConfig {
     public boolean fixPotionLimit;
     public boolean fixPotionRenderOffset;
     public boolean fixResizableFullscreen;
+    public boolean fixResourcePackOpening;
     public boolean fixTimeCommandWithGC;
     public boolean fixUnfocusedFullscreen;
     public boolean fixUrlDetection;
@@ -205,6 +206,7 @@ public class LoadingConfig {
         fixPotionLimit = config.get(Category.FIXES.toString(), "fixPotionLimit", true, "Fix potions >= 128").getBoolean();
         fixPotionRenderOffset = config.get(Category.TWEAKS.toString(), "fixPotionRenderOffset", true, "Prevents the inventory from shifting when the player has active potion effects").getBoolean();
         fixResizableFullscreen = config.get(Category.FIXES.toString(), "fixResizableFullscreen", true, "Fix game window becoming not resizable after toggling fullscrean in any way").getBoolean();
+        fixResourcePackOpening = config.get(Category.FIXES.toString(), "fixResourcePackOpening", true, "Fix resource pack folder not opening on Windows if file path has a space").getBoolean();
         fixUnfocusedFullscreen = config.get(Category.FIXES.toString(), "fixUnfocusedFullscreen", true, "Fix exiting fullscreen when you tab out of the game").getBoolean();
         fixUrlDetection = config.get(Category.FIXES.toString(), "fixUrlDetection", true, "Fix URISyntaxException in forge.").getBoolean();
         fixVanillaUnprotectedGetBlock = config.get(Category.FIXES.toString(), "fixVanillaUnprotectedGetBlock", true, "Fixes various unchecked vanilla getBlock() methods").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -10,6 +10,12 @@ import java.util.function.Supplier;
 
 public enum Mixins {
     // Vanilla Fixes
+    FIX_RESOURCEPACK_FOLDER_OPENING(new Builder("Fix resource pack folder sometimes not opening on windows")
+            .setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinGuiScreenResourcePacks")
+            .setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.fixResourcePackOpening)
+            .addTargetedMod(TargetedMod.VANILLA)),
     FIX_ENCHANTMENT_LEVEL_NUMERALS(new Builder("Fix enchantment levels not displaying properly above a certain value")
             .setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEnchantment_FixRomanNumerals")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -475,12 +475,18 @@ public enum Mixins {
             .setApplyIf(() -> Common.config.fixPotionRenderOffset)
             .addTargetedMod(TargetedMod.TRAVELLERSGEAR)),
 
-    // Exu Unenchanting fix
+    // Extra Utilities
     FIX_EXTRA_UTILITIES_UNENCHANTING(new Builder("Fix Exu Unenchanting")
             .addMixinClasses("extrautilities.MixinRecipeUnEnchanting")
             .setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.fixExtraUtilitiesUnEnchanting)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    DISABLE_AID_SPAWN_XU_SPIKES(
+            new Builder("Fixes the vanilla zombie aid spawn triggering when killed by Extra Utilities Spikes")
+                    .addMixinClasses("extrautilities.MixinBlockSpike")
+                    .setSide(Side.BOTH)
+                    .setApplyIf(() -> Common.config.disableAidSpawnByXUSpikes)
+                    .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Various Exploits/Fixes
     GC_TIME_COMMAND_FIX(new Builder("GC Time Fix")
@@ -531,13 +537,7 @@ public enum Mixins {
             .addMixinClasses("galacticraftcore.MixinGalacticraftRocketPollution")
             .setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.rocketsPollute)
-            .addTargetedMod(TargetedMod.GALACTICRAFT_CORE)),
-    DISABLE_AID_SPAWN_XU_SPIKES(
-            new Builder("Fixes the vanilla zombie aid spawn triggering when killed by Extra Utilities Spikes")
-                    .addMixinClasses("extrautilities.MixinBlockSpike")
-                    .setSide(Side.BOTH)
-                    .setApplyIf(() -> Common.config.disableAidSpawnByXUSpikes)
-                    .addTargetedMod(TargetedMod.EXTRA_UTILITIES));
+            .addTargetedMod(TargetedMod.GALACTICRAFT_CORE));
 
     public final String name;
     public final List<String> mixinClasses;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiScreenResourcePacks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiScreenResourcePacks.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import java.awt.*;
+import java.awt.Desktop;
 import java.io.IOException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreenResourcePacks;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiScreenResourcePacks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiScreenResourcePacks.java
@@ -1,0 +1,29 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.awt.*;
+import java.io.IOException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreenResourcePacks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiScreenResourcePacks.class)
+public class MixinGuiScreenResourcePacks {
+
+    @Inject(
+            method = "actionPerformed",
+            at =
+                    @At(
+                            value = "INVOKE",
+                            target = "Ljava/lang/Runtime;getRuntime()Ljava/lang/Runtime;",
+                            ordinal = 1,
+                            shift = At.Shift.BEFORE),
+            cancellable = true)
+    private void hodgepodge$fixFolderOpening(CallbackInfo ci) throws IOException {
+        Desktop.getDesktop()
+                .open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
+        ci.cancel();
+    }
+}


### PR DESCRIPTION
there is a forge bug where if you have a space character on your folder path with Windows, when you click the "open resource pack folder" button it will not work. This PR fixes it