### PR TITLE
Fix journeymap scrolling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1675110695
+//version: 1675173326
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -66,7 +66,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.7.2' apply false
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.2'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.1.3'
 }
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
@@ -743,6 +743,7 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        inheritOutputDirs = true
     }
     project {
         settings {

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ apiPackage =
 
 # Specify the configuration file for Forge's access transformers here. I must be placed into /src/main/resources/META-INF/
 # Example value: mymodid_at.cfg
-accessTransformersFile =
+accessTransformersFile = hodgepodge_at.cfg
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true
@@ -60,6 +60,9 @@ containsMixinsAndOrCoreModOnly = false
 # If enabled, you may use 'shadowImplementation' for dependencies. They will be integrated in your jar. It is your
 # responsibility check the licence and request permission for distribution, if required.
 usesShadowedDependencies = false
+
+# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories
+includeWellKnownRepositories = true
 
 # Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
 # projects. New projects should not use this parameter.

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,27 +1,2 @@
 repositories {
-    maven {
-        name = "GTNH Maven"
-        url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-    }
-    maven {
-        // IC2
-        name = "ic2"
-        url = "https://maven.ic2.player.to/"
-        metadataSources {
-            mavenPom()
-            artifact()
-        }
-    }
-    maven {
-        // IC2
-        name = "ic2"
-        url = "https://maven2.ic2.player.to/"
-        metadataSources {
-            mavenPom()
-            artifact()
-        }
-    }
-    maven {
-        url "https://cursemaven.com"
-    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -57,6 +57,7 @@ public class LoadingConfig {
     public boolean fixIgnisFruitAABB;
     public boolean fixImmobileFireballs;
     public boolean fixJourneymapKeybinds;
+    public boolean fixJourneymapJumpyScrolling;
     public boolean fixJourneymapFilePath;
     public boolean fixNetherLeavesFaceRendering;
     public boolean fixNorthWestBias;
@@ -207,6 +208,7 @@ public class LoadingConfig {
         fixIgnisFruitAABB = config.get(Category.FIXES.toString(), "fixIgnisFruitAABB", true, "Fix Axis aligned Bounding Box of Ignis Fruit").getBoolean();
         fixImmobileFireballs = config.get(Category.FIXES.toString(), "fixImmobileFireballs", true, "Fix the bug that makes fireballs stop moving when chunk unloads").getBoolean();
         fixJourneymapKeybinds = config.get(Category.FIXES.toString(), "fixJourneymapKeybinds", true, "Prevent unbinded keybinds from triggering when pressing certain keys").getBoolean();
+        fixJourneymapJumpyScrolling = config.get(Category.FIXES.toString(), "fixJourneymapJumpyScrolling", true, "Fix jumpy scrolling in the waypoint manager screen").getBoolean();
         fixJourneymapFilePath = config.get(Category.FIXES.toString(), "fixJourneymapFilePath", true, "Prevents journeymap from using illegal character in file paths").getBoolean();
         fixNetherLeavesFaceRendering = config.get(Category.FIXES.toString(), "fixNetherLeavesFaceRendering", true, "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too").getBoolean();
         fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -290,6 +290,10 @@ public enum Mixins {
             .setSide(Side.CLIENT).addMixinClasses("journeymap.MixinWorldData")
             .setApplyIf(() -> Common.config.fixJourneymapFilePath).addTargetedMod(TargetedMod.JOURNEYMAP)),
 
+    FIX_JOURNEYMAP_JUMPY_SCROLLING(new Builder("Fix Journeymap jumpy scrolling in the waypoint manager")
+            .setSide(Side.CLIENT).addMixinClasses("journeymap.MixinWaypointManager")
+            .setApplyIf(() -> Common.config.fixJourneymapJumpyScrolling).addTargetedMod(TargetedMod.JOURNEYMAP)),
+
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(new Builder("Ignis Fruit").addMixinClasses("harvestthenether.MixinBlockPamFruit")
             .setApplyIf(() -> Common.config.fixIgnisFruitAABB).addTargetedMod(TargetedMod.HARVESTTHENETHER)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -4,6 +4,7 @@ public enum TargetedMod {
 
     VANILLA("Minecraft", null),
     GTNHLIB("GTNHLib", "com.gtnewhorizon.gtnhlib.core.GTNHLibCore", "gtnhlib"),
+    LWJGL3IFY("lwjgl3ify", "me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod", "lwjgl3ify"),
     IC2("IC2", "ic2.core.coremod.IC2core", "IC2"),
     FASTCRAFT("FastCraft", "fastcraft.Tweaker"),
     COFH_CORE("CoFHCore", "cofh.asm.LoadingPlugin", "CoFHCore"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWaypointManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWaypointManager.java
@@ -18,10 +18,10 @@ import cpw.mods.fml.common.Loader;
 @Mixin(WaypointManager.class)
 public abstract class MixinWaypointManager extends JmUI {
 
-    @Shadow
+    @Shadow(remap = false)
     protected ScrollListPane itemScrollPane;
 
-    @Shadow
+    @Shadow(remap = false)
     protected int rowHeight;
 
     @Unique

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWaypointManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWaypointManager.java
@@ -40,7 +40,7 @@ public abstract class MixinWaypointManager extends JmUI {
                 // LWJGL 2's reported scroll amounts are not uniformly scaled across operating systems
                 delta = MathHelper.clamp_int(delta, -1, 1);
             }
-            this.itemScrollPane.scrollBy(delta * this.rowHeight);
+            this.itemScrollPane.scrollBy(-delta * this.rowHeight);
         }
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWaypointManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/journeymap/MixinWaypointManager.java
@@ -1,0 +1,51 @@
+package com.mitchej123.hodgepodge.mixins.late.journeymap;
+
+import journeymap.client.ui.component.JmUI;
+import journeymap.client.ui.component.ScrollListPane;
+import journeymap.client.ui.waypoint.WaypointManager;
+
+import net.minecraft.util.MathHelper;
+
+import org.lwjgl.input.Mouse;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import com.mitchej123.hodgepodge.mixins.TargetedMod;
+import cpw.mods.fml.common.Loader;
+
+@Mixin(WaypointManager.class)
+public abstract class MixinWaypointManager extends JmUI {
+
+    @Shadow
+    protected ScrollListPane itemScrollPane;
+
+    @Shadow
+    protected int rowHeight;
+
+    @Unique
+    private final boolean hasLwjgl3 = Loader.isModLoaded(TargetedMod.LWJGL3IFY.modId);
+
+    /**
+     * @author eigenraven
+     * @reason Reversed clamping (was: {@code if(delta > 1) delta = -1;} and vice versa)
+     */
+    @Overwrite(remap = false)
+    public void handleMouseInput() {
+        super.handleMouseInput();
+        int delta = Mouse.getEventDWheel();
+        if (delta != 0) {
+            if (!hasLwjgl3) {
+                // LWJGL 2's reported scroll amounts are not uniformly scaled across operating systems
+                delta = MathHelper.clamp_int(delta, -1, 1);
+            }
+            this.itemScrollPane.scrollBy(delta * this.rowHeight);
+        }
+    }
+
+    /* Forced to have constructor matching super */
+    private MixinWaypointManager(String title) {
+        super(title);
+    }
+}


### PR DESCRIPTION
Under LWJGL3 the bug in the original code was triggered because the scroll amounts can reach low values like 1/-1, lwjgl2 reports huge numbers (>120 on Windows, >10 on Linux) so the reversed clamping seemingly always worked. LWJGL3 reports properly scaled scroll amounts, so I disable the clamping if it's detected for a better user experience.