### PR TITLE
Moves the sprint keybind to the movement category

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -28,6 +28,7 @@ public class LoadingConfig {
     public boolean dropPickedLootOnDespawn;
     public boolean enableDefaultLanPort;
 
+    public boolean changeSprintCategory;
     public boolean enlargePotionArray;
     public boolean fixBibliocraftPackets;
     public boolean fixComponentsPoppingOff;
@@ -178,6 +179,7 @@ public class LoadingConfig {
         enableDefaultLanPort = config.get(Category.TWEAKS.toString(), "enableDefaultLanPort", true, "Open an integrated server on a static port.").getBoolean();
         enableTileRendererProfiler = config.get(Category.TWEAKS.toString(), "enableTileRendererProfiler", true, "Shows renderer's impact on FPS in vanilla lagometer").getBoolean();
 
+        changeSprintCategory = config.get(Category.TWEAKS.toString(), "changeSprintCategory", true, "Moves the sprint keybind to the movement category").getBoolean();
         fixComponentsPoppingOff = config.get(Category.TWEAKS.toString(), "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();
         fixDebugBoundingBox = config.get(Category.FIXES.toString(), "fixDebugBoundingBox", true, "Fixes the debug hitbox of the player beeing offset").getBoolean();
         fixDimensionChangeHearts = config.get(Category.FIXES.toString(), "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -12,6 +12,9 @@ import cpw.mods.fml.relauncher.FMLLaunchHandler;
 public enum Mixins {
 
     // Vanilla Fixes
+    CHANGE_CATEGORY_SPRINT_KEY(new Builder("Moves the sprint keybind to the movement category")
+            .addTargetedMod(TargetedMod.VANILLA).setSide(Side.CLIENT).setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinGameSetttings").setApplyIf(() -> Common.config.changeSprintCategory)),
     FIX_RESOURCEPACK_FOLDER_OPENING(new Builder("Fix resource pack folder sometimes not opening on windows")
             .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinGuiScreenResourcePacks").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.fixResourcePackOpening).addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSetttings.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSetttings.java
@@ -1,0 +1,28 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.settings.GameSettings;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(GameSettings.class)
+public class MixinGameSetttings {
+
+    @ModifyConstant(
+            method = { "<init>()V", "<init>(Lnet/minecraft/client/Minecraft;Ljava/io/File;)V" },
+            constant = @Constant(stringValue = "key.categories.gameplay"),
+            slice = @Slice(
+                    from = @At(
+                            value = "FIELD",
+                            target = "Lnet/minecraft/client/settings/GameSettings;keyBindPickBlock:Lnet/minecraft/client/settings/KeyBinding;"),
+                    to = @At(
+                            value = "FIELD",
+                            target = "Lnet/minecraft/client/settings/GameSettings;keyBindSprint:Lnet/minecraft/client/settings/KeyBinding;")))
+    private String hodgepodge$ChangeSprintCategory(String original) {
+        return "key.categories.movement";
+    }
+
+}


### PR DESCRIPTION
by default in vanilla minecraft it is under the gameplay category instead of movement