### PR TITLE
Fix scrolling Xaero's World Map with LWJGL 3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,7 +31,7 @@ dependencies {
     transformedMod(deobf("https://edge.forgecdn.net/files/2234/410/witchery-1.7.10-0.24.1.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2423/369/BiblioCraft%5bv1.11.7%5d%5bMC1.7.10%5d.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2367/915/journeymap-1.7.10-5.1.4p2-unlimited.jar"))
-    transformedMod(deobf('https://media.forgecdn.net/files/4127/328/XaerosWorldMap_1.14.1.22_Forge_1.7.10.jar'))
+    transformedModCompileOnly(deobf('https://media.forgecdn.net/files/4127/328/XaerosWorldMap_1.14.1.22_Forge_1.7.10.jar'))
     transformedMod("com.github.GTNewHorizons:harvestcraft:1.0.19-GTNH:dev")
     // Contains an outdated copy of thaumcraft api that breaks class loading at runtime
     transformedModCompileOnly(deobf("https://mediafiles.forgecdn.net/files/2241/397/Pam%27s+Harvest+the+Nether+1.7.10a.jar"))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,6 +31,7 @@ dependencies {
     transformedMod(deobf("https://edge.forgecdn.net/files/2234/410/witchery-1.7.10-0.24.1.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2423/369/BiblioCraft%5bv1.11.7%5d%5bMC1.7.10%5d.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2367/915/journeymap-1.7.10-5.1.4p2-unlimited.jar"))
+    transformedMod(deobf('https://media.forgecdn.net/files/4127/328/XaerosWorldMap_1.14.1.22_Forge_1.7.10.jar'))
     transformedMod("com.github.GTNewHorizons:harvestcraft:1.0.19-GTNH:dev")
     // Contains an outdated copy of thaumcraft api that breaks class loading at runtime
     transformedModCompileOnly(deobf("https://mediafiles.forgecdn.net/files/2241/397/Pam%27s+Harvest+the+Nether+1.7.10a.jar"))

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -79,6 +79,7 @@ public class LoadingConfig {
     public boolean fixVillageUncheckedGetBlock;
     public boolean fixWorldGetBlock;
     public boolean fixWorldServerLeakingUnloadedEntities;
+    public boolean fixXaerosWorldMapScroll;
     public boolean fixZTonesPackets;
     public boolean hideCrosshairInThirdPerson;
     public boolean hideIc2ReactorSlots;
@@ -234,6 +235,7 @@ public class LoadingConfig {
         fixVillageUncheckedGetBlock = config.get(Category.FIXES.toString(), "fixVillageUncheckedGetBlock", true, "Fixes village unchecked getBlock() calls").getBoolean();
         fixWorldGetBlock = config.get(Category.FIXES.toString(), "fixWorldGetBlock", true, "Fix unprotected getBlock() in World").getBoolean();
         fixWorldServerLeakingUnloadedEntities = config.get(Category.FIXES.toString(), "fixWorldServerLeakingUnloadedEntities", true, "Fix WorldServer leaking entities when no players are present in a dimension").getBoolean();
+        fixXaerosWorldMapScroll = config.get(Category.FIXES.toString(), "fixXaerosWorldMapScrolling", true, "Fix scrolling in the world map screen").getBoolean();
 
         hideCrosshairInThirdPerson = config.get(Category.TWEAKS.toString(), "hideCrosshairInThirdPerson", true, "Stops rendering the crosshair when you are playing in third person").getBoolean();
         hideIc2ReactorSlots = config.get(Category.TWEAKS.toString(), "hideIc2ReactorSlots", true, "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -308,6 +308,11 @@ public enum Mixins {
             .setSide(Side.CLIENT).addMixinClasses("journeymap.MixinWaypointManager")
             .setApplyIf(() -> Common.config.fixJourneymapJumpyScrolling).addTargetedMod(TargetedMod.JOURNEYMAP)),
 
+    // Xaero's Map
+    FIX_XAEROS_WORLDMAP_SCROLL(new Builder("Fix Xaero's World Map map screen scrolling")
+            .addMixinClasses("xaeroworldmap.MixinGuiMap").setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.fixXaerosWorldMapScroll).addTargetedMod(TargetedMod.XAEROWORLDMAP)),
+
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(new Builder("Ignis Fruit").addMixinClasses("harvestthenether.MixinBlockPamFruit")
             .setApplyIf(() -> Common.config.fixIgnisFruitAABB).addTargetedMod(TargetedMod.HARVESTTHENETHER)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -309,9 +309,10 @@ public enum Mixins {
             .setApplyIf(() -> Common.config.fixJourneymapJumpyScrolling).addTargetedMod(TargetedMod.JOURNEYMAP)),
 
     // Xaero's Map
-    FIX_XAEROS_WORLDMAP_SCROLL(new Builder("Fix Xaero's World Map map screen scrolling")
-            .addMixinClasses("xaeroworldmap.MixinGuiMap").setSide(Side.CLIENT)
-            .setApplyIf(() -> Common.config.fixXaerosWorldMapScroll).addTargetedMod(TargetedMod.XAEROWORLDMAP)),
+    FIX_XAEROS_WORLDMAP_SCROLL(
+            new Builder("Fix Xaero's World Map map screen scrolling").addMixinClasses("xaeroworldmap.MixinGuiMap")
+                    .setSide(Side.CLIENT).setApplyIf(() -> Common.config.fixXaerosWorldMapScroll)
+                    .addTargetedMod(TargetedMod.XAEROWORLDMAP).addTargetedMod(TargetedMod.LWJGL3IFY)),
 
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(new Builder("Ignis Fruit").addMixinClasses("harvestthenether.MixinBlockPamFruit")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -29,6 +29,7 @@ public enum TargetedMod {
     TRAVELLERSGEAR("TravellersGear", null, "TravellersGear"),
     VANILLA("Minecraft", null),
     WITCHERY("Witchery", null, "witchery"),
+    XAEROWORLDMAP("Xaero's World Map", null, "XaeroWorldMap"),
     ZTONES("ZTones", null, "Ztones");
 
     /** The "name" in the @Mod annotation */

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaeroworldmap/MixinGuiMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaeroworldmap/MixinGuiMap.java
@@ -1,17 +1,16 @@
 package com.mitchej123.hodgepodge.mixins.late.xaeroworldmap;
 
-import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 import xaero.map.gui.GuiMap;
 
 @Mixin(GuiMap.class)
 public class MixinGuiMap {
 
-    @ModifyVariable(method = "handleMouseInput", at = @At("STORE"), ordinal = 0)
+    @ModifyConstant(method = "handleMouseInput", constant = @Constant(intValue = 120, ordinal = 0))
     private int hodgepodge$fixScrolling(int original) {
-        return Mouse.getEventDWheel();
+        return 1;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaeroworldmap/MixinGuiMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaeroworldmap/MixinGuiMap.java
@@ -2,23 +2,16 @@ package com.mitchej123.hodgepodge.mixins.late.xaeroworldmap;
 
 import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import xaero.map.gui.GuiMap;
 
-import com.mitchej123.hodgepodge.mixins.TargetedMod;
-import cpw.mods.fml.common.Loader;
-
 @Mixin(GuiMap.class)
 public class MixinGuiMap {
 
-    @Unique
-    private final boolean hasLwjgl3 = Loader.isModLoaded(TargetedMod.LWJGL3IFY.modId);
-
     @ModifyVariable(method = "handleMouseInput", at = @At("STORE"), ordinal = 0)
     private int hodgepodge$fixScrolling(int original) {
-        return hasLwjgl3 ? Mouse.getEventDWheel() : original;
+        return Mouse.getEventDWheel();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaeroworldmap/MixinGuiMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaeroworldmap/MixinGuiMap.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.late.xaeroworldmap;
+
+import org.lwjgl.input.Mouse;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import xaero.map.gui.GuiMap;
+
+import com.mitchej123.hodgepodge.mixins.TargetedMod;
+import cpw.mods.fml.common.Loader;
+
+@Mixin(GuiMap.class)
+public class MixinGuiMap {
+
+    @Unique
+    private final boolean hasLwjgl3 = Loader.isModLoaded(TargetedMod.LWJGL3IFY.modId);
+
+    @ModifyVariable(method = "handleMouseInput", at = @At("STORE"), ordinal = 0)
+    private int hodgepodge$fixScrolling(int original) {
+        return hasLwjgl3 ? Mouse.getEventDWheel() : original;
+    }
+}


### PR DESCRIPTION
Xaero's World Map tries to clamp scroll wheel values by dividing by 120. This does not work with LWJGL 3 since it reports sane scroll wheel values, unlike LWJGL 2.
This makes it use the raw scroll wheel value instead if lwjgl3ify is detected, which makes scrolling work as expected.
Fixes the "unrelated note" in #172 