### PR TITLE
Fix Minecraft Not Supporting MacOS CMD Shortcuts in Text Fields

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -95,6 +95,8 @@ public class LoadingConfig {
     public boolean optimizeWorldUpdateLight;
     public boolean preventPickupLoot;
     public boolean removeSpawningMinecartSound;
+
+    public boolean enableMacosCmdShortcuts;
     public boolean removeUpdateChecks;
     public boolean speedupAnimations;
     public boolean speedupBOPFogHandling;
@@ -252,6 +254,7 @@ public class LoadingConfig {
         optimizeWorldUpdateLight = config.get(Category.FIXES.toString(), "optimizeWorldUpdateLight", true, "Fix too early light initialization").getBoolean();
         particleLimit = Math.max(Math.min(config.get(Category.TWEAKS.toString(), "particleLimit", 8000, "Particle limit [4000-16000]").getInt(), 16000), 4000);
         preventPickupLoot = config.get(Category.TWEAKS.toString(), "preventPickupLoot", true, "Prevent monsters from picking up loot.").getBoolean();
+        enableMacosCmdShortcuts = config.get(Category.TWEAKS.toString(), "enableMacosCmdShortcuts", true, "Use CMD key on MacOS to COPY / INSERT / SELECT in text fields (Chat, NEI, Server IP etc.)").getBoolean();
         removeSpawningMinecartSound = config.get(Category.TWEAKS.toString(), "removeSpawningMinecartSound", true, "Stop playing a sound when spawning a minecart in the world").getBoolean();
         removeUpdateChecks = config.get(Category.FIXES.toString(), "removeUpdateChecks", true, "Remove old/stale/outdated update checks.").getBoolean();
         renderDebug = config.get(Category.DEBUG.toString(), "renderDebug", true, "Enable GL state debug hooks. Will not do anything useful unless mode is changed to nonzero.").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -197,7 +197,9 @@ public enum Mixins {
     REMOVE_SPAWN_MINECART_SOUND(new Builder("Remove sound when spawning a minecart")
             .addMixinClasses("minecraft.MixinWorldClient").addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> Common.config.removeSpawningMinecartSound).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
-
+    MACOS_KEYS_TEXTFIELD_SHORTCUTS(new Builder("Macos use CMD to copy/select/delete text")
+            .addMixinClasses("minecraft.MixinGuiTextField").addTargetedMod(TargetedMod.VANILLA)
+                    .setApplyIf(() -> Common.config.enableMacosCmdShortcuts).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(
             new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).addMixinClasses("ic2.MixinIc2WaterKinetic")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -199,7 +199,10 @@ public enum Mixins {
             .setApplyIf(() -> Common.config.removeSpawningMinecartSound).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
     MACOS_KEYS_TEXTFIELD_SHORTCUTS(new Builder("Macos use CMD to copy/select/delete text")
             .addMixinClasses("minecraft.MixinGuiTextField").addTargetedMod(TargetedMod.VANILLA)
-                    .setApplyIf(() -> Common.config.enableMacosCmdShortcuts).setPhase(Phase.EARLY).setSide(Side.CLIENT)),
+            .setApplyIf(
+                    () -> System.getProperty("os.name").toLowerCase().contains("mac")
+                            && Common.config.enableMacosCmdShortcuts)
+            .setPhase(Phase.EARLY).setSide(Side.CLIENT)),
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(
             new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).addMixinClasses("ic2.MixinIc2WaterKinetic")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -33,10 +33,12 @@ public abstract class MixinGuiTextField {
 
     @Inject(method = "textboxKeyTyped", at = @At(value = "HEAD"), cancellable = true)
     public void provideMacOsKeys(char typedChar, int eventKey, CallbackInfoReturnable<Boolean> cir) {
-        if (this.isFocused && this.isEnabled && GuiScreen.isCtrlKeyDown()) {
+        if (this.isFocused && GuiScreen.isCtrlKeyDown()) {
             if (eventKey == Keyboard.KEY_V) {
-                this.writeText(GuiScreen.getClipboardString());
-                cir.setReturnValue(true);
+                if (this.isEnabled) {
+                    this.writeText(GuiScreen.getClipboardString());
+                    cir.setReturnValue(true);
+                }
             } else if (eventKey == Keyboard.KEY_C) {
                 GuiScreen.setClipboardString(this.getSelectedText());
                 cir.setReturnValue(true);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -1,8 +1,8 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
+
 import org.lwjgl.input.Keyboard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -17,6 +17,9 @@ public abstract class MixinGuiTextField {
     private boolean isEnabled;
 
     @Shadow
+    private boolean isFocused;
+
+    @Shadow
     public abstract void writeText(String p_146191_1_);
 
     @Shadow
@@ -28,25 +31,20 @@ public abstract class MixinGuiTextField {
     @Shadow
     public abstract String getSelectedText();
 
-    @Inject(method="textboxKeyTyped",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/util/ChatAllowedCharacters;isAllowedCharacter(C)Z"
-            ),
-            cancellable = true)
-    public void provideMacOsKeys(char typedChar, int eventKey, CallbackInfoReturnable cir) {
-       if (Minecraft.isRunningOnMac && this.isEnabled && GuiScreen.isCtrlKeyDown())  {
-           if (eventKey == Keyboard.KEY_V) {
-               this.writeText(GuiScreen.getClipboardString());
-               cir.setReturnValue(true);
-           } else if (eventKey == Keyboard.KEY_C) {
-               GuiScreen.setClipboardString(this.getSelectedText());
-               cir.setReturnValue(true);
-           } else if (eventKey == Keyboard.KEY_A) {
-               this.setCursorPositionEnd();
-               this.setSelectionPos(0);
-               cir.setReturnValue(true);
-           }
-       }
+    @Inject(method = "textboxKeyTyped", at = @At(value = "HEAD"), cancellable = true)
+    public void provideMacOsKeys(char typedChar, int eventKey, CallbackInfoReturnable<Boolean> cir) {
+        if (this.isFocused && this.isEnabled && GuiScreen.isCtrlKeyDown()) {
+            if (eventKey == Keyboard.KEY_V) {
+                this.writeText(GuiScreen.getClipboardString());
+                cir.setReturnValue(true);
+            } else if (eventKey == Keyboard.KEY_C) {
+                GuiScreen.setClipboardString(this.getSelectedText());
+                cir.setReturnValue(true);
+            } else if (eventKey == Keyboard.KEY_A) {
+                this.setCursorPositionEnd();
+                this.setSelectionPos(0);
+                cir.setReturnValue(true);
+            }
+        }
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -48,8 +48,7 @@ public abstract class MixinGuiTextField {
                 cir.setReturnValue(true);
             } else if (eventKey == Keyboard.KEY_X) {
                 GuiScreen.setClipboardString(this.getSelectedText());
-                if (this.isEnabled)
-                {
+                if (this.isEnabled) {
                     this.writeText("");
                 }
                 cir.setReturnValue(true);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -1,0 +1,52 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
+import org.lwjgl.input.Keyboard;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(GuiTextField.class)
+public abstract class MixinGuiTextField {
+
+    @Shadow
+    private boolean isEnabled;
+
+    @Shadow
+    public abstract void writeText(String p_146191_1_);
+
+    @Shadow
+    public abstract void setCursorPositionEnd();
+
+    @Shadow
+    public abstract void setSelectionPos(int p_146199_1_);
+
+    @Shadow
+    public abstract String getSelectedText();
+
+    @Inject(method="textboxKeyTyped",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/util/ChatAllowedCharacters;isAllowedCharacter(C)Z"
+            ),
+            cancellable = true)
+    public void provideMacOsKeys(char typedChar, int eventKey, CallbackInfoReturnable cir) {
+       if (Minecraft.isRunningOnMac && this.isEnabled && GuiScreen.isCtrlKeyDown())  {
+           if (eventKey == Keyboard.KEY_V) {
+               this.writeText(GuiScreen.getClipboardString());
+               cir.setReturnValue(true);
+           } else if (eventKey == Keyboard.KEY_C) {
+               GuiScreen.setClipboardString(this.getSelectedText());
+               cir.setReturnValue(true);
+           } else if (eventKey == Keyboard.KEY_A) {
+               this.setCursorPositionEnd();
+               this.setSelectionPos(0);
+               cir.setReturnValue(true);
+           }
+       }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -46,6 +46,13 @@ public abstract class MixinGuiTextField {
                 this.setCursorPositionEnd();
                 this.setSelectionPos(0);
                 cir.setReturnValue(true);
+            } else if (eventKey == Keyboard.KEY_X) {
+                GuiScreen.setClipboardString(this.getSelectedText());
+                if (this.isEnabled)
+                {
+                    this.writeText("");
+                }
+                cir.setReturnValue(true);
             }
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -32,7 +32,8 @@ public abstract class MixinGuiTextField {
     public abstract String getSelectedText();
 
     @Inject(method = "textboxKeyTyped", at = @At(value = "HEAD"), cancellable = true)
-    public void provideMacOsKeys(char typedChar, int eventKey, CallbackInfoReturnable<Boolean> cir) {
+    private void hodgepodge$addMacCommandKeyShortcuts(char typedChar, int eventKey,
+            CallbackInfoReturnable<Boolean> cir) {
         if (this.isFocused && GuiScreen.isCtrlKeyDown()) {
             if (eventKey == Keyboard.KEY_V) {
                 if (this.isEnabled) {


### PR DESCRIPTION
Added mixin that allows Copy / Select / Insert text using Command key on MacOS.
This works in pretty much inputs that using GuiTextField component (NEI, Chat, Server IP insertion and many others)

It's very awful to me and i think other mac users to use control.
It works on command only i think in 1.8+ minecraft, but i didn't remove control shortcut for now and i don't think it needs.

Works in GTNH too.
<img width="299" alt="Screenshot 2023-03-01 at 01 30 53" src="https://user-images.githubusercontent.com/64744993/222006999-cb5b0991-682b-4765-a73e-1433fb845e3e.png">



