### PR TITLE
Stop saying twice in log which ASM transformers it's loading

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
@@ -26,6 +26,8 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
     private static final Logger log = LogManager.getLogger("Hodgepodge");
     public static final SortingIndex index = HodgepodgeCore.class.getAnnotation(IFMLLoadingPlugin.SortingIndex.class);
 
+    private String[] transformerClasses;
+
     public static int getSortingIndex() {
         return index != null ? index.value() : 0;
     }
@@ -86,15 +88,17 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     @Override
     public String[] getASMTransformerClass() {
-
-        return Arrays.stream(AsmTransformers.values()).map(asmTransformer -> {
-            if (asmTransformer.shouldBeLoaded()) {
-                log.info("Loading hodgepodge transformers {}", asmTransformer.name);
-                return asmTransformer.asmTransformers;
-            } else {
-                return null;
-            }
-        }).filter(Objects::nonNull).flatMap(List::stream).toArray(String[]::new);
+        if (transformerClasses == null) {
+            transformerClasses = Arrays.stream(AsmTransformers.values()).map(asmTransformer -> {
+                if (asmTransformer.shouldBeLoaded()) {
+                    log.info("Loading hodgepodge transformers {}", asmTransformer.name);
+                    return asmTransformer.asmTransformers;
+                } else {
+                    return null;
+                }
+            }).filter(Objects::nonNull).flatMap(List::stream).toArray(String[]::new);
+        }
+        return transformerClasses;
     }
 
     @Override


### PR DESCRIPTION
because the method public String[] getASMTransformerClass() gets called twice by FML