### PR TITLE
make all debug keybinds require simultaneous ctrl and shift instead of just shift

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -20,7 +20,9 @@ public class ClientKeyListener {
     public void keyUp(InputEvent.KeyInputEvent event) {
         int key = Keyboard.getEventKey();
         boolean released = !Keyboard.getEventKeyState();
-        if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown() && GuiScreen.isCtrlKeyDown() && released) {
+        if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown()
+                && GuiScreen.isCtrlKeyDown()
+                && released) {
             if (key == Keyboard.KEY_N) {
                 HodgepodgeClient.animationsMode.next();
             } else if (key == Keyboard.KEY_D && Common.config.renderDebug) {

--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -20,7 +20,7 @@ public class ClientKeyListener {
     public void keyUp(InputEvent.KeyInputEvent event) {
         int key = Keyboard.getEventKey();
         boolean released = !Keyboard.getEventKeyState();
-        if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown() && released) {
+        if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown() && GuiScreen.isCtrlKeyDown() && released) {
             if (key == Keyboard.KEY_N) {
                 HodgepodgeClient.animationsMode.next();
             } else if (key == Keyboard.KEY_D && Common.config.renderDebug) {


### PR DESCRIPTION
So many people mistype shift+d given it's sneak move right. Not so many people would press ctrl+shift+d though.