### PR TITLE
Minechem Java 12 compat: Stop potion array expansion and add config for potion ID

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,6 +31,7 @@ dependencies {
     transformedMod(deobf("https://edge.forgecdn.net/files/2234/410/witchery-1.7.10-0.24.1.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2423/369/BiblioCraft%5bv1.11.7%5d%5bMC1.7.10%5d.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2367/915/journeymap-1.7.10-5.1.4p2-unlimited.jar"))
+    transformedMod("curse.maven:minechem-368422:2905830")
     transformedModCompileOnly(deobf('https://media.forgecdn.net/files/4127/328/XaerosWorldMap_1.14.1.22_Forge_1.7.10.jar'))
     transformedModCompileOnly("curse.maven:immersive-engineering-231951:2299019")
     transformedMod("com.github.GTNewHorizons:harvestcraft:1.0.19-GTNH:dev")

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -89,6 +89,7 @@ public class LoadingConfig {
     public boolean installAnchorAlarm;
     public boolean java12BopCompat;
     public boolean java12ImmersiveEngineeringCompat;
+    public boolean java12MineChemCompat;
     public boolean logHugeChat;
     public boolean longerChat;
     public boolean makeBigFirsPlantable;
@@ -255,6 +256,7 @@ public class LoadingConfig {
         itemStacksPickedUpPerTick = Math.max(1, config.get(Category.FIXES.toString(), "itemStacksPickedUpPerTick", 36, "Stacks picked up per tick").getInt());
         java12BopCompat = config.get(Category.FIXES.toString(), "java12BopCompat", true, "BiomesOPlenty Java 12 compatibility patches.").getBoolean();
         java12ImmersiveEngineeringCompat = config.get(Category.FIXES.toString(), "java12ImmersiveEngineeringCompat", true, "Immersive Engineering Java 12 compatibility patch").getBoolean();
+        java12MineChemCompat = config.get(Category.FIXES.toString(), "java12MineChemCompat", true, "Minechem Java 12 compatibility patch").getBoolean();
         logHugeChat = config.get(Category.FIXES.toString(), "logHugeChat", true, "Log oversized chat message to console. WARNING: might create huge log files if this happens very often.").getBoolean();
         longerChat = config.get(Category.TWEAKS.toString(), "longerChat", true, "Makes the chat history longer instead of 100 lines").getBoolean();
         makeBigFirsPlantable = config.get(Category.TWEAKS.toString(), "makeBigFirsPlantable", true, "Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -14,6 +14,7 @@ public class LoadingConfig {
     public boolean arabicNumbersForEnchantsPotions;
     public int chatLength;
     public int ic2SeedMaxStackSize;
+    public int atropineHighID;
     public int itemStacksPickedUpPerTick;
     public int particleLimit;
 
@@ -251,6 +252,7 @@ public class LoadingConfig {
         hideIc2ReactorSlots = config.get(Category.TWEAKS.toString(), "hideIc2ReactorSlots", true, "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor").getBoolean();
         hidePotionParticlesFromSelf = config.get(Category.TWEAKS.toString(), "hidePotionParticlesFromSelf", true, "Stops rendering potion particles from yourself").getBoolean();
         ic2SeedMaxStackSize = config.get(Category.TWEAKS.toString(), "ic2SeedMaxStackSize", 64, "IC2 seed max stack size", 1, 64).getInt();
+        atropineHighID = config.get(Category.TWEAKS.toString(), "atropineHighID", 255, "Minechem Atropine High (Delirium) effect ID", 1, 255).getInt();
         increaseParticleLimit = config.get(Category.TWEAKS.toString(), "increaseParticleLimit", true, "Increase particle limit").getBoolean();
         installAnchorAlarm = config.get(Category.TWEAKS.toString(), "installAnchorAlarm", true, "Wake up passive & personal anchors on player login").getBoolean();
         itemStacksPickedUpPerTick = Math.max(1, config.get(Category.FIXES.toString(), "itemStacksPickedUpPerTick", 36, "Stacks picked up per tick").getInt());

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -305,6 +305,10 @@ public enum Mixins {
             .addMixinClasses("immersiveengineering.MixinIEPotions")
             .setApplyIf(() -> Common.config.java12ImmersiveEngineeringCompat)
             .addTargetedMod(TargetedMod.IMMERSIVE_ENGINENEERING)),
+    JAVA12_MINE_CHEM(new Builder("Minechem Java-12 safe potion array resizing")
+            .addMixinClasses("minechem.MixinPotionInjector")
+            .setApplyIf(() -> Common.config.java12MineChemCompat)
+            .addTargetedMod(TargetedMod.MINECHEM)),
 
     // MrTJPCore (Project Red)
     FIX_HUD_LIGHTING_GLITCH(new Builder("HUD Lighting glitch").addMixinClasses("mrtjpcore.MixinFXEngine")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -305,10 +305,9 @@ public enum Mixins {
             .addMixinClasses("immersiveengineering.MixinIEPotions")
             .setApplyIf(() -> Common.config.java12ImmersiveEngineeringCompat)
             .addTargetedMod(TargetedMod.IMMERSIVE_ENGINENEERING)),
-    JAVA12_MINE_CHEM(new Builder("Minechem Java-12 safe potion array resizing")
-            .addMixinClasses("minechem.MixinPotionInjector")
-            .setApplyIf(() -> Common.config.java12MineChemCompat)
-            .addTargetedMod(TargetedMod.MINECHEM)),
+    JAVA12_MINE_CHEM(
+            new Builder("Minechem Java-12 safe potion array resizing").addMixinClasses("minechem.MixinPotionInjector")
+                    .setApplyIf(() -> Common.config.java12MineChemCompat).addTargetedMod(TargetedMod.MINECHEM)),
 
     // MrTJPCore (Project Red)
     FIX_HUD_LIGHTING_GLITCH(new Builder("HUD Lighting glitch").addMixinClasses("mrtjpcore.MixinFXEngine")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -20,6 +20,7 @@ public enum TargetedMod {
     IC2("IC2", "ic2.core.coremod.IC2core", "IC2"),
     JOURNEYMAP("JourneyMap", null, "journeymap"),
     LWJGL3IFY("lwjgl3ify", "me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod", "lwjgl3ify"),
+    MINECHEM("Minechem", null, "minechem"),
     MRTJPCORE("MrTJPCore", null, "MrTJPCoreMod"),
     OPTIFINE("Optifine", "optifine.OptiFineForgeTweaker", "Optifine"),
     PROJECTE("ProjectE", null, "ProjectE"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minechem/MixinPotionInjector.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minechem/MixinPotionInjector.java
@@ -2,12 +2,16 @@ package com.mitchej123.hodgepodge.mixins.late.minechem;
 
 import minechem.potion.PotionInjector;
 import minechem.potion.PotionProvider;
+
 import net.minecraft.potion.Potion;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.Common;
 
 @Mixin(value = PotionInjector.class, remap = false)
 public class MixinPotionInjector {
@@ -20,6 +24,6 @@ public class MixinPotionInjector {
         if (Potion.potionTypes.length > 255) {
             ci.cancel();
         }
-        atropineHigh = new PotionProvider(255, true, 0x00FF6E).setPotionName("Delirium");
+        atropineHigh = new PotionProvider(Common.config.atropineHighID, true, 0x00FF6E).setPotionName("Delirium");
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minechem/MixinPotionInjector.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minechem/MixinPotionInjector.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.late.minechem;
+
+import minechem.potion.PotionInjector;
+import minechem.potion.PotionProvider;
+import net.minecraft.potion.Potion;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = PotionInjector.class, remap = false)
+public class MixinPotionInjector {
+
+    @Shadow
+    public static Potion atropineHigh;
+
+    @Inject(method = "inject", at = @At("HEAD"), cancellable = true)
+    private static void hodgepodge$inject(CallbackInfo ci) {
+        if (Potion.potionTypes.length > 255) {
+            ci.cancel();
+        }
+        atropineHigh = new PotionProvider(255, true, 0x00FF6E).setPotionName("Delirium");
+    }
+}


### PR DESCRIPTION
Similar fix to #192

Includes a config option as well to set the ID since that wasn't possible originally