### PR TITLE
Add a priority to the TextureMap mixin

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,12 +17,13 @@ dependencies {
 
     transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.3.35-GTNH:dev") // force a more up-to-date NEI version
     transformedMod("com.github.GTNewHorizons:Baubles:1.0.1.14:dev")
+    transformedMod("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-195-GTNH")
     transformedMod("com.github.GTNewHorizons:Galacticraft:3.0.63-GTNH:dev")
     transformedMod("com.github.GTNewHorizons:GT5-Unofficial:5.09.42.36:dev")
     transformedMod("com.github.GTNewHorizons:HungerOverhaul:1.0.4-GTNH:dev")
     transformedMod("com.github.GTNewHorizons:MrTJPCore:1.1.1:dev") // Do not update, fixed afterwards
     transformedMod("com.github.GTNewHorizons:Railcraft:9.13.15:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
-    transformedMod("com.github.GTNewHorizons:TinkersConstruct:1.9.12-GTNH:dev")
+    transformedMod("com.github.GTNewHorizons:TinkersConstruct:1.9.27-GTNH:dev")
     transformedMod("curse.maven:biomes-o-plenty-220318:2499612")
     transformedMod("curse.maven:cofh-core-69162:2388751")
     transformedMod("curse.maven:extra-utilities-225561:2264384")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/textures/client/MixinTextureMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/textures/client/MixinTextureMap.java
@@ -18,7 +18,7 @@ import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.client.HodgepodgeClient.AnimationMode;
 import com.mitchej123.hodgepodge.textures.IPatchedTextureAtlasSprite;
 
-@Mixin(TextureMap.class)
+@Mixin(value = TextureMap.class, priority = 999)
 public abstract class MixinTextureMap extends AbstractTexture {
 
     @Shadow


### PR DESCRIPTION
Add a priority to the TextureMap mixin to fix crash on startup with TEXTURE_OPTIMIZATIONS from falsetweaks.

I don't know if its a proper fix.But its work on my 800+ mods modpack.