### PR TITLE
Fix Quantumsuit hover mode slowly losing altitude

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -54,6 +54,7 @@ public class LoadingConfig {
     public boolean fixHungerOverhaulRestore0Hunger;
     public boolean fixIc2DirectInventoryAccess;
     public boolean fixIc2Hazmat;
+    public boolean fixIc2HoverMode;
     public boolean fixIc2Nightvision;
     public boolean fixIc2ReactorDupe;
     public boolean fixIc2UnprotectedGetBlock;
@@ -221,6 +222,7 @@ public class LoadingConfig {
         fixHungerOverhaulRestore0Hunger = config.get(Category.FIXES.toString(), "fixHungerOverhaulRestore0Hunger", true, "Fix some items restore 0 hunger").getBoolean();
         fixIc2DirectInventoryAccess = config.get(Category.FIXES.toString(), "fixIc2DirectInventoryAccess", true, "Fix IC2's direct inventory access").getBoolean();
         fixIc2Hazmat = config.get(Category.FIXES.toString(), "fixIc2Hazmat", true, "Fix IC2 armors to avoid giving poison").getBoolean();
+        fixIc2HoverMode = config.get(Category.FIXES.toString(), "fixIc2HoverMode", true, "Fix IC2's armor hover mode").getBoolean();
         fixIc2Nightvision = config.get(Category.FIXES.toString(), "fixIc2Nightvision", true, "Prevent IC2's nightvision from blinding you").getBoolean();
         fixIc2ReactorDupe = config.get(Category.FIXES.toString(), "fixIc2ReactorDupe", true, "Fix IC2's reactor dupe").getBoolean();
         fixIc2UnprotectedGetBlock = config.get(Category.FIXES.toString(), "fixIc2UnprotectedGetBlock", true, "Fixes various unchecked IC2 getBlock() methods").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -248,6 +248,9 @@ public enum Mixins {
     IC2_FLUID_RENDER_FIX(new Builder("IC2 Fluid Render Fix").setPhase(Phase.EARLY)
             .addMixinClasses("ic2.textures.MixinRenderLiquidCell").setApplyIf(() -> Common.config.speedupAnimations)
             .addTargetedMod(TargetedMod.IC2)),
+    IC2_HOVER_MODE_FIX(
+            new Builder("IC2 Hover Mode Fix").setPhase(Phase.LATE).addMixinClasses("ic2.MixinIc2QuantumSuitHoverMode")
+                    .setApplyIf(() -> Common.config.fixIc2HoverMode).addTargetedMod(TargetedMod.IC2)),
 
     // Disable update checkers
     BIBLIOCRAFT_UPDATE_CHECK(new Builder("Yeet Bibliocraft Update Check").setPhase(Phase.LATE).setSide(Side.CLIENT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIc2QuantumSuitHoverMode.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIc2QuantumSuitHoverMode.java
@@ -1,0 +1,16 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import ic2.core.item.armor.ItemArmorQuantumSuit;
+
+@Mixin(ItemArmorQuantumSuit.class)
+public class MixinIc2QuantumSuitHoverMode {
+
+    @ModifyConstant(method = "useJetpack", constant = @Constant(floatValue = -0.025F), remap = false)
+    private float hodgepodge$fixHoverMode(float original) {
+        return 0.0F;
+    }
+}


### PR DESCRIPTION
I don't think there's any issues open for this or anything, but I made a quantum chestplate today and the hover mode on it makes you slowly float down, which sucks ass compared to the advanced nano chestplate. Given the latter is used in the recipe for the former, to me it seems like that should mean it can at least do everything the old one can. I don't know if this is officially considered a bug but it seems like some ic2 "balance" that nobody would miss, in the same vein as the stock ic2 night vision blinding you in the sun. 


Also if I have to go back to the advanced nano chestplate until gravisuit at ZPM my outfit will no longer match