### PR TITLE
Fix LLibrary incompatibility

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
@@ -25,7 +25,7 @@ public abstract class MixinFontRenderer {
      * @author eigenraven
      */
     @Overwrite
-    String wrapFormattedStringToWidth(String str, int wrapWidth) {
+    public String wrapFormattedStringToWidth(String str, int wrapWidth) {
         // Always have at least one character per line
         final int firstLineWidth = Math.max(1, this.sizeStringToWidth(str, wrapWidth));
         if (str.length() <= firstLineWidth) {


### PR DESCRIPTION
LLibrary uses an [access transformer](https://github.com/iLexiconn/LLibrary/blob/1.7.10/src/main/resources/META-INF/llibrary_at.cfg) which increases the visibility of `FontRenderer` methods to `public` which clashes with the package-private visibility of `MixinFontRenderer.wrapFormattedStringToWidth`:

```
Mixin Errors in Stacktrace: 
	net.minecraft.client.gui.FontRenderer:
		org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException: PACKAGE @Overwrite method func_78280_d in mixins.hodgepodge.early.json:minecraft.MixinFontRenderer from mod hodgepodge cannot reduce visibiliy of PUBLIC target method
Mixins in Stacktrace: 
	net.minecraft.client.Minecraft:
		mixins.hodgepodge.early.json:minecraft.MixinMinecraft_UnfocusedFullscreen from mod hodgepodge
		mixins.hodgepodge.early.json:minecraft.MixinMinecraft_ToggleDebugMessage from mod hodgepodge
		mixins.hodgepodge.early.json:minecraft.MixinMinecraft_ResizableFullscreen from mod hodgepodge
		mixins.hodgepodge.early.json:minecraft.profiler.MinecraftMixin from mod hodgepodge
	net.minecraft.client.gui.FontRenderer:
		mixins.hodgepodge.early.json:minecraft.MixinFontRenderer from mod hodgepodge
```

The PR changes the visibility of `MixinFontRenderer.wrapFormattedStringToWidth` to `public` to avoid the crash. Even though LLibrary is the issue here, I figured it would be easier to fix the single line in Hodgepodge instead of forking LLibrary.