### PR TITLE
Fix crashes when opening forestry/adventure backpacks and quickly switching selected item

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -41,6 +41,7 @@ public class LoadingConfig {
     public boolean fixExtraUtilitiesUnEnchanting;
     public boolean fixFenceConnections;
     public boolean fixFireSpread;
+    public boolean fixForgeOpenGuiHandlerWindowId;
     public boolean fixFriendlyCreatureSounds;
     public boolean fixGetBlockLightValue;
     public boolean fixGlStateBugs;
@@ -207,6 +208,7 @@ public class LoadingConfig {
         fixFenceConnections = config.get(Category.FIXES.toString(), "fixFenceConnections", true, "Fix fence connections with other types of fence").getBoolean();
         fixFireSpread = config.get(Category.FIXES.toString(), "fixFireSpread", true, "Fix vanilla fire spread sometimes cause NPE on thermos").getBoolean();
         fixFontRendererLinewrapRecursion = config.get(Category.FIXES.toString(), "fixFontRendererLinewrapRecursion", true, "Replace recursion with iteration in FontRenderer line wrapping code").getBoolean();
+        fixForgeOpenGuiHandlerWindowId = config.get(Category.FIXES.toString(), "fixForgeOpenGuiHandlerWindowId", true, "Fix windowId being set on openContainer even if openGui failed").getBoolean();
         fixFriendlyCreatureSounds = config.get(Category.FIXES.toString(), "fixFriendlyCreatureSounds", true, "Fix vanilla issue where player sounds register as animal sounds").getBoolean();
         fixGetBlockLightValue = config.get(Category.FIXES.toString(), "fixGetBlockLightValue", true, "Fix vanilla light calculation sometimes cause NPE on thermos").getBoolean();
         fixGlStateBugs = config.get(Category.FIXES.toString(), "fixGlStateBugs", true, "Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -193,7 +193,7 @@ public enum Mixins {
             .addMixinClasses("forge.MixinGuiIngameForge").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.hideCrosshairInThirdPerson).addTargetedMod(TargetedMod.VANILLA)),
     FIX_OPENGUIHANDLER_WINDOWID(new Builder("Fix OpenGuiHandler").setPhase(Phase.EARLY)
-            .addMixinClasses("forge.OpenGuiHandler").setApplyIf(() -> Common.config.fixForgeOpenGuiHandlerWindowId)
+            .addMixinClasses("forge.MixinOpenGuiHandler").setApplyIf(() -> Common.config.fixForgeOpenGuiHandlerWindowId)
             .addTargetedMod(TargetedMod.VANILLA)),
     FIX_KEYBIND_CONFLICTS(new Builder("Trigger all conflicting keybinds").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinKeyBinding").setSide(Side.CLIENT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -192,6 +192,9 @@ public enum Mixins {
     CROSSHAIR_THIRDPERSON(new Builder("Crosshairs Thirdperson").setPhase(Phase.EARLY)
             .addMixinClasses("forge.MixinGuiIngameForge").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.hideCrosshairInThirdPerson).addTargetedMod(TargetedMod.VANILLA)),
+    FIX_OPENGUIHANDLER_WINDOWID(new Builder("Fix OpenGuiHandler").setPhase(Phase.EARLY)
+            .addMixinClasses("forge.OpenGuiHandler").setApplyIf(() -> Common.config.fixForgeOpenGuiHandlerWindowId)
+            .addTargetedMod(TargetedMod.VANILLA)),
     FIX_KEYBIND_CONFLICTS(new Builder("Trigger all conflicting keybinds").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinKeyBinding").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.triggerAllConflictingKeybindings).addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinOpenGuiHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinOpenGuiHandler.java
@@ -23,6 +23,9 @@ public abstract class MixinOpenGuiHandler extends SimpleChannelInboundHandler<FM
 
     boolean openGuiSuccess = false;
 
+    /*
+     * Copy the logic from player.openGui to explicitly check if the getLocalGuiContainer failed
+     */
     @Redirect(
             method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lcpw/mods/fml/common/network/internal/FMLMessage$OpenGui;)V",
             at = @At(
@@ -39,6 +42,9 @@ public abstract class MixinOpenGuiHandler extends SimpleChannelInboundHandler<FM
         }
     }
 
+    /*
+     * if openGui failed, we return from channelRead0 early to avoid setting windowId on the wrong openContainer
+     */
     @Inject(
             method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lcpw/mods/fml/common/network/internal/FMLMessage$OpenGui;)V",
             at = @At(value = "FIELD", target = "Lnet/minecraft/inventory/Container;windowId:I", opcode = PUTFIELD),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinOpenGuiHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinOpenGuiHandler.java
@@ -12,7 +12,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.internal.FMLMessage;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinOpenGuiHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinOpenGuiHandler.java
@@ -1,0 +1,30 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraft.inventory.Container;
+
+import org.spongepowered.asm.mixin.Intrinsic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.network.internal.FMLMessage;
+import cpw.mods.fml.common.network.internal.FMLMessage.OpenGui;
+import cpw.mods.fml.common.network.internal.OpenGuiHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+@Mixin(OpenGuiHandler.class)
+public abstract class MixinOpenGuiHandler extends SimpleChannelInboundHandler<FMLMessage.OpenGui> {
+
+    @Shadow(remap = false)
+    protected abstract void channelRead0(ChannelHandlerContext ctx, OpenGui msg) throws Exception;
+
+    @Intrinsic(displace = true)
+    protected void hodgepodge$channelRead0(ChannelHandlerContext ctx, OpenGui msg) throws Exception {
+        Container playerContainer = FMLClientHandler.instance().getClient().thePlayer.openContainer;
+        int playerContainerId = playerContainer.windowId;
+        this.channelRead0(ctx, msg);
+        if (playerContainer == FMLClientHandler.instance().getClient().thePlayer.openContainer)
+            playerContainer.windowId = playerContainerId;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13125
and possibly fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11950

before this fix, OpenGuiHandler would always set windowId on the player's openContainer after calling player.openGui.
This is a problem since many mods like Forestry, SpiceOfLife and AdventureBackpacks2 can possibly return null in their getLocalGuiContainer(). openGui and OpenGuiHandler don't check if the result of that was null, and so windowId gets set on the wrong openContainer. This bypasses the windowId validity check in S30WindowItems packet which can crash the client when assigning itemStacks to the wrong container.

After the fix, player.openGui() logic and getLocalGuiContainer() result check happen inside OpenGuiHandler itself, which now also returns before the windowId field is set if getLocalGuiContainer() returned null.