### PR TITLE
Fix crashing due to server/client container size mismatch

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -66,6 +66,7 @@ public class LoadingConfig {
     public boolean fixJourneymapKeybinds;
     public boolean fixJourneymapJumpyScrolling;
     public boolean fixJourneymapFilePath;
+    public boolean fixNetHandlerPlayClientHandleSetSlot;
     public boolean fixNetherLeavesFaceRendering;
     public boolean fixNorthWestBias;
     public boolean fixOptifineChunkLoadingCrash;
@@ -238,6 +239,7 @@ public class LoadingConfig {
         fixJourneymapKeybinds = config.get(Category.FIXES.toString(), "fixJourneymapKeybinds", true, "Prevent unbinded keybinds from triggering when pressing certain keys").getBoolean();
         fixJourneymapJumpyScrolling = config.get(Category.FIXES.toString(), "fixJourneymapJumpyScrolling", true, "Fix jumpy scrolling in the waypoint manager screen").getBoolean();
         fixJourneymapFilePath = config.get(Category.FIXES.toString(), "fixJourneymapFilePath", true, "Prevents journeymap from using illegal character in file paths").getBoolean();
+        fixNetHandlerPlayClientHandleSetSlot = config.get(Category.FIXES.toString(), "fixNetHandlerPlayClientHandleSetSlot", true, "Prevents crash if server sends itemStack with index larger than client's container").getBoolean();
         fixNetherLeavesFaceRendering = config.get(Category.FIXES.toString(), "fixNetherLeavesFaceRendering", true, "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too").getBoolean();
         fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
         fixOptifineChunkLoadingCrash = config.get(Category.FIXES.toString(), "fixOptifineChunkLoadingCrash", true, "Forces the chunk loading option from optifine to default since other values can crash the game").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -33,6 +33,7 @@ public class LoadingConfig {
     public boolean enlargePotionArray;
     public boolean fixBibliocraftPackets;
     public boolean fixComponentsPoppingOff;
+    public boolean fixContainerPutStacksInSlots;
     public boolean fixDebugBoundingBox;
     public boolean fixDimensionChangeHearts;
     public boolean fixEatingStackedStew;
@@ -199,6 +200,7 @@ public class LoadingConfig {
         enableTileRendererProfiler = config.get(Category.TWEAKS.toString(), "enableTileRendererProfiler", true, "Shows renderer's impact on FPS in vanilla lagometer").getBoolean();
 
         changeSprintCategory = config.get(Category.TWEAKS.toString(), "changeSprintCategory", true, "Moves the sprint keybind to the movement category").getBoolean();
+        fixContainerPutStacksInSlots = config.get(Category.FIXES.toString(), "fixContainerPutStacksInSlots", true, "Prevents crash if server sends container with wrong itemStack size").getBoolean();
         fixComponentsPoppingOff = config.get(Category.TWEAKS.toString(), "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();
         fixDebugBoundingBox = config.get(Category.FIXES.toString(), "fixDebugBoundingBox", true, "Fixes the debug hitbox of the player beeing offset").getBoolean();
         fixDimensionChangeHearts = config.get(Category.FIXES.toString(), "fixDimensionChangeHearts", true, "Fix losing bonus hearts on dimension change").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -26,6 +26,11 @@ public enum Mixins {
     FIX_CONTAINER_PUT_STACKS_IN_SLOTS(new Builder("Prevents crash if server sends container with wrong itemStack size")
             .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinContainer").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.fixContainerPutStacksInSlots).addTargetedMod(TargetedMod.VANILLA)),
+    FIX_NETHANDLERPLAYCLIENT_HANDLE_SET_SLOT(
+            new Builder("Prevents crash if server sends itemStack with index larger than client's container")
+                    .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinNetHandlerPlayClient_FixHandleSetSlot")
+                    .setSide(Side.CLIENT).setApplyIf(() -> Common.config.fixNetHandlerPlayClientHandleSetSlot)
+                    .addTargetedMod(TargetedMod.VANILLA)),
     FIX_INVENTORY_POTION_EFFECT_NUMERALS(
             new Builder("Fix potion effects level not displaying properly above a certain value").setPhase(Phase.EARLY)
                     .addMixinClasses(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -23,6 +23,9 @@ public enum Mixins {
             .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinEnchantment_FixRomanNumerals").setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.fixEnchantmentNumerals || Common.config.arabicNumbersForEnchantsPotions)
             .addTargetedMod(TargetedMod.VANILLA)),
+    FIX_CONTAINER_PUT_STACKS_IN_SLOTS(new Builder("Prevents crash if server sends container with wrong itemStack size")
+            .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinContainer").setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.fixContainerPutStacksInSlots).addTargetedMod(TargetedMod.VANILLA)),
     FIX_INVENTORY_POTION_EFFECT_NUMERALS(
             new Builder("Fix potion effects level not displaying properly above a certain value").setPhase(Phase.EARLY)
                     .addMixinClasses(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.List;
+
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = Container.class)
+public class MixinContainer {
+
+    @Shadow
+    public List inventorySlots;
+
+    @Inject(method = "putStacksInSlots([Lnet/minecraft/item/ItemStack;)V", at = @At(value = "HEAD"), cancellable = true)
+    public void hodgepodge$checkStacksSize(ItemStack[] p_75131_1_, CallbackInfo ci) {
+        if (this.inventorySlots.size() < p_75131_1_.length) ci.cancel();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_FixHandleSetSlot.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_FixHandleSetSlot.java
@@ -1,0 +1,30 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.network.play.server.S2FPacketSetSlot;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = NetHandlerPlayClient.class)
+public class MixinNetHandlerPlayClient_FixHandleSetSlot {
+
+    @Shadow
+    private Minecraft gameController;
+
+    @Inject(
+            method = "handleSetSlot(Lnet/minecraft/network/play/server/S2FPacketSetSlot;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/inventory/Container;putStackInSlot(ILnet/minecraft/item/ItemStack;)V"),
+            cancellable = true)
+    public void hodgepodge$checkPacketItemStackSize(S2FPacketSetSlot packetIn, CallbackInfo ci) {
+        EntityClientPlayerMP entityclientplayermp = this.gameController.thePlayer;
+        if (packetIn.func_149173_d() >= entityclientplayermp.openContainer.inventorySlots.size()) ci.cancel();
+    }
+}


### PR DESCRIPTION
The exact same bug keeps popping up over and over again
Here's just some recent examples:
https://github.com/GTNewHorizons/NotEnoughItems/issues/388
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12658
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13125
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11950
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10933
And it's no wonder, since any time there's a mismatch between server/client open container size = potential crash
This is such an easy way for a mod to shoot itself in the foot especially when trying to deal with any sort of complex or dynamic gui container. The solution is a simple sanity check in handling the 2 offending server packets, so the problem is solved at its root
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12658
fixes https://github.com/GTNewHorizons/NotEnoughItems/issues/388