### PR TITLE
Add pollution tooltips

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -18,6 +18,14 @@ public class Compat {
 
     private static boolean isIC2CropPluginPresent;
 
+    private static boolean isThaumcraftPresent;
+
+    private static boolean isThaumicBasesPresent;
+
+    private static boolean isRailcraftPresent;
+
+    private static boolean isGalacticraftPresent;
+
     static void init(Side side) {
         isClient = side == Side.CLIENT;
 
@@ -36,6 +44,14 @@ public class Compat {
         isGT5Present = Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi");
 
         isIC2CropPluginPresent = Loader.isModLoaded("Ic2Nei");
+
+        isThaumcraftPresent = Loader.isModLoaded("Thaumcraft");
+
+        isThaumicBasesPresent = Loader.isModLoaded("thaumicbases");
+
+        isRailcraftPresent = Loader.isModLoaded("Railcraft");
+
+        isGalacticraftPresent = Loader.isModLoaded("GalacticraftCore");
     }
 
     /**
@@ -60,5 +76,33 @@ public class Compat {
      */
     public static boolean isIC2CropPluginPresent() {
         return isIC2CropPluginPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isThaumcraftPresent() {
+        return isThaumcraftPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isThaumicBasesPresent() {
+        return isThaumicBasesPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isRailcraftPresent() {
+        return isRailcraftPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isGalacticraftPresent() {
+        return isGalacticraftPresent;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -33,6 +33,10 @@ public class Hodgepodge {
     public void preinit(FMLPreInitializationEvent event) {
         Compat.init(event.getSide());
         MinecraftForge.EVENT_BUS.register(EVENT_HANDLER);
+
+        if (event.getSide() == Side.CLIENT) {
+            HodgepodgeClient.preInit();
+        }
     }
 
     @EventHandler

--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -25,6 +25,12 @@ public class HodgepodgeClient {
     public static final ManagedEnum<AnimationMode> animationsMode = new ManagedEnum<>(AnimationMode.VISIBLE_ONLY);
     public static final ManagedEnum<RenderDebugMode> renderDebugMode = new ManagedEnum<>(RenderDebugMode.REDUCED);
 
+    public static void preInit() {
+        if (Compat.isGT5Present()) {
+            MinecraftForge.EVENT_BUS.register(PollutionTooltip.INSTANCE);
+        }
+    }
+
     public static void postInit() {
         colorGrass = References.gt_PollutionRenderer.getMethod("colorGrass").resolve();
         colorLiquid = References.gt_PollutionRenderer.getMethod("colorLiquid").resolve();

--- a/src/main/java/com/mitchej123/hodgepodge/client/PollutionTooltip.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/PollutionTooltip.java
@@ -1,0 +1,113 @@
+package com.mitchej123.hodgepodge.client;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.Compat;
+
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_Utility;
+
+public class PollutionTooltip {
+
+    public static final PollutionTooltip INSTANCE = new PollutionTooltip();
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void getTooltip(ItemTooltipEvent event) {
+        if (event.itemStack == null) return;
+
+        String producesPollutionFormat = "Produces %d Pollution/Second";
+
+        if (Common.config.furnacesPollute) {
+            String furnacePollution = String.format(producesPollutionFormat, Common.config.furnacePollutionAmount);
+
+            // Furnace and Iron Furnace
+            if (GT_Utility.areStacksEqual(event.itemStack, new ItemStack(Blocks.furnace)) || GT_Utility
+                    .areStacksEqual(event.itemStack, GT_ModHandler.getModItem("IC2", "blockMachine", 1, 1))) {
+                event.toolTip.add(furnacePollution);
+            }
+
+            // Alchemical Furnace
+            if (Compat.isThaumcraftPresent()) {
+                if (GT_Utility.areStacksEqual(
+                        event.itemStack,
+                        GT_ModHandler.getModItem("Thaumcraft", "blockStoneDevice", 1, 0))) {
+                    event.toolTip.add(furnacePollution);
+                }
+            }
+
+            // Advanced Alchemical Furnace
+            if (Compat.isThaumicBasesPresent()) {
+                if (GT_Utility.areStacksEqual(
+                        event.itemStack,
+                        GT_ModHandler.getModItem("thaumicbases", "advAlchFurnace", 1, 0))) {
+                    event.toolTip.add(furnacePollution);
+                }
+            }
+        }
+
+        if (Compat.isRailcraftPresent() && Common.config.railcraftPollutes) {
+            String multiProducesPollutionFormat = "A complete Multiblock produces %d Pollution/Second";
+
+            // Solid and Liquid Boiler Firebox
+            if (GT_Utility.areStacksEqual(event.itemStack, GT_ModHandler.getModItem("Railcraft", "machine.beta", 1, 5))
+                    || GT_Utility.areStacksEqual(
+                            event.itemStack,
+                            GT_ModHandler.getModItem("Railcraft", "machine.beta", 1, 6))) {
+                event.toolTip.add(
+                        String.format(
+                                "Produces %d Pollution/Second per firebox",
+                                Common.config.fireboxPollutionAmount));
+            }
+
+            // Tunnel Bore
+            if (GT_Utility.areStacksEqual(event.itemStack, GT_ModHandler.getModItem("Railcraft", "cart.bore", 1, 0))) {
+                event.toolTip.add(String.format(producesPollutionFormat, Common.config.tunnelBorePollutionAmount));
+            }
+
+            // Coke Oven Brick
+            if (GT_Utility
+                    .areStacksEqual(event.itemStack, GT_ModHandler.getModItem("Railcraft", "machine.alpha", 1, 7))) {
+                event.toolTip.add(String.format(multiProducesPollutionFormat, Common.config.cokeOvenPollutionAmount));
+            }
+
+            // Advanced Coke Oven Brick
+            if (GT_Utility
+                    .areStacksEqual(event.itemStack, GT_ModHandler.getModItem("Railcraft", "machine.alpha", 1, 12))) {
+                event.toolTip.add(
+                        String.format(multiProducesPollutionFormat, Common.config.advancedCokeOvenPollutionAmount));
+            }
+
+            // Hobbyist's Steam Engine
+            if (GT_Utility
+                    .areStacksEqual(event.itemStack, GT_ModHandler.getModItem("Railcraft", "machine.beta", 1, 7))) {
+                event.toolTip.add(String.format(producesPollutionFormat, Common.config.hobbyistEnginePollutionAmount));
+            }
+        }
+
+        // Galacticraft (and Galaxy Space) rockets
+        if (Compat.isGalacticraftPresent() && Common.config.rocketsPollute && event.itemStack.getItem() != null) {
+            String simpleName = event.itemStack.getItem().getClass().getSimpleName();
+            if (simpleName.contains("Rocket")) {
+                for (char d : simpleName.toCharArray()) {
+                    if (Character.isDigit(d)) {
+                        int tier = Character.getNumericValue(d);
+                        event.toolTip.add(
+                                String.format(
+                                        "Produces %d Pollution/Second when ignited",
+                                        Common.config.rocketPollutionAmount * tier / 100));
+                        event.toolTip.add(
+                                String.format(
+                                        "Produces %d Pollution/Second when flying",
+                                        Common.config.rocketPollutionAmount * tier));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/client/PollutionTooltip.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/PollutionTooltip.java
@@ -6,6 +6,7 @@ import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 
 import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.Compat;
+import com.mitchej123.hodgepodge.util.PollutionHelper;
 
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -99,11 +100,11 @@ public class PollutionTooltip {
                         event.toolTip.add(
                                 String.format(
                                         "Produces %d Pollution/Second when ignited",
-                                        Common.config.rocketPollutionAmount * tier / 100));
+                                        PollutionHelper.rocketIgnitionPollutionAmount(tier)));
                         event.toolTip.add(
                                 String.format(
                                         "Produces %d Pollution/Second when flying",
-                                        Common.config.rocketPollutionAmount * tier));
+                                        PollutionHelper.flyingRocketPollutionAmount(tier)));
                         break;
                     }
                 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/galacticraftcore/MixinGalacticraftRocketPollution.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/galacticraftcore/MixinGalacticraftRocketPollution.java
@@ -7,7 +7,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.util.PollutionHelper;
 
 import micdoodle8.mods.galacticraft.api.entity.IRocketType;
@@ -29,14 +28,12 @@ public abstract class MixinGalacticraftRocketPollution extends EntityAutoRocket 
         if (this.worldObj.isRemote || !(launchPhase == EnumLaunchPhase.LAUNCHED.ordinal()
                 || launchPhase == EnumLaunchPhase.IGNITED.ordinal()))
             return;
-        int pollutionAmount = Common.config.rocketPollutionAmount;
 
-        // Note: Linear instead of growing by powers of 2
+        int pollutionAmount = 0;
         if (launchPhase == EnumLaunchPhase.LAUNCHED.ordinal())
-            pollutionAmount = (pollutionAmount * this.getRocketTier());
+            pollutionAmount = PollutionHelper.flyingRocketPollutionAmount(this.getRocketTier());
         else if (launchPhase == EnumLaunchPhase.IGNITED.ordinal())
-            pollutionAmount = (pollutionAmount * (this.getRocketTier())) / 100;
-        else pollutionAmount = 0;
+            pollutionAmount = PollutionHelper.rocketIgnitionPollutionAmount(this.getRocketTier());
 
         PollutionHelper.addPollution(worldObj.getChunkFromBlockCoords((int) posX, (int) posZ), pollutionAmount);
     }

--- a/src/main/java/com/mitchej123/hodgepodge/util/PollutionHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PollutionHelper.java
@@ -2,6 +2,7 @@ package com.mitchej123.hodgepodge.util;
 
 import net.minecraft.world.chunk.Chunk;
 
+import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.Compat;
 
 import gregtech.common.GT_Pollution;
@@ -15,5 +16,15 @@ public class PollutionHelper {
         if (Compat.isGT5Present()) {
             GT_Pollution.addPollution(ch, aPollution);
         }
+    }
+
+    // Note: Linear instead of growing by powers of 2
+    public static int rocketIgnitionPollutionAmount(int rocketTier) {
+        return Common.config.rocketPollutionAmount * rocketTier / 100;
+    }
+
+    // Note: Linear instead of growing by powers of 2
+    public static int flyingRocketPollutionAmount(int rocketTier) {
+        return Common.config.rocketPollutionAmount * rocketTier;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12957

Restore pollution tooltips that were previously added through ModMixins.