### PR TITLE
Add offline mode UUID mapping

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -31,6 +31,11 @@ public enum Mixins {
                     .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinNetHandlerPlayClient_FixHandleSetSlot")
                     .setSide(Side.CLIENT).setApplyIf(() -> Common.config.fixNetHandlerPlayClientHandleSetSlot)
                     .addTargetedMod(TargetedMod.VANILLA)),
+    FIX_NETHANDLERLOGINSERVER_OFFLINEMODE(
+            new Builder("Allows the server to assign the logged in UUID to the same username when online_mode is false")
+                    .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinNetHandlerLoginServer_OfflineMode")
+                    .setSide(Side.SERVER).setApplyIf(() -> true) /* no config option for this */
+                    .addTargetedMod(TargetedMod.VANILLA)),
     FIX_INVENTORY_POTION_EFFECT_NUMERALS(
             new Builder("Fix potion effects level not displaying properly above a certain value").setPhase(Phase.EARLY)
                     .addMixinClasses(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerLoginServer_OfflineMode.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerLoginServer_OfflineMode.java
@@ -1,0 +1,57 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraft.server.network.NetHandlerLoginServer;
+import net.minecraftforge.common.UsernameCache;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mojang.authlib.GameProfile;
+
+@Mixin(NetHandlerLoginServer.class)
+public abstract class MixinNetHandlerLoginServer_OfflineMode {
+
+    @Shadow
+    private GameProfile field_147337_i;
+
+    @Shadow
+    public abstract void func_147322_a(String reason);
+
+    /**
+     * @author Caedis
+     * @reason Allows a server to run offline but only allow players who have logged in while it was online (and they
+     *         get their UUID so stuff works as expected).
+     */
+    @Overwrite
+    protected GameProfile func_152506_a(GameProfile original) {
+        Map<UUID, String> usernameCache = UsernameCache.getMap();
+        for (Map.Entry<UUID, String> entry : usernameCache.entrySet()) {
+            if (entry.getValue().equals(original.getName())) {
+                return new GameProfile(entry.getKey(), original.getName());
+            }
+        }
+        return null;
+    }
+
+    @Inject(
+            method = "func_147326_c()V",
+            at = @At(
+                    value = "INVOKE_ASSIGN",
+                    target = "Lnet/minecraft/server/network/NetHandlerLoginServer;func_152506_a(Lcom/mojang/authlib/GameProfile;)Lcom/mojang/authlib/GameProfile;",
+                    shift = At.Shift.AFTER),
+            cancellable = true)
+    private void hodgepodge$func_147326_c(CallbackInfo ci) {
+        if (this.field_147337_i == null) {
+            // Disconnect null profiles from func_152506_a
+            this.func_147322_a("You were not found in the cache!");
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
[Discord Discussion](https://discord.com/channels/181078474394566657/401118216228831252/1118794386432589834)

The error message could be better and more vague.

Test results:
tested with GTNH 2.3.3 server (docker container) with online_mode set to false

With no fix:
* Online client -> offline server: Not whitelisted error
* Offline client (same name as online) -> offline server: Not whitelisted error
* Offline client (different name as online) -> offline server: Not whitelisted error

With fix:
* Online client -> offline server: Connected (uuid mapped)
* Offline client (same name as online) -> offline server: Connected (uuid mapped)
* Offline client (different name as online) -> offline server: Not in cache error


whitelist errors were due to uuid not being mapped