### PR TITLE
Fix lotr error with speedupVanillaFurnace

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,6 +36,7 @@ dependencies {
     transformedModCompileOnly(deobf('https://media.forgecdn.net/files/4127/328/XaerosWorldMap_1.14.1.22_Forge_1.7.10.jar'))
     transformedModCompileOnly("curse.maven:immersive-engineering-231951:2299019")
     transformedMod("com.github.GTNewHorizons:harvestcraft:1.0.19-GTNH:dev")
+    transformedModCompileOnly deobf('https://media.forgecdn.net/files/4091/561/LOTRMod+v36.15.jar')
     // Contains an outdated copy of thaumcraft api that breaks class loading at runtime
     transformedModCompileOnly(deobf("https://mediafiles.forgecdn.net/files/2241/397/Pam%27s+Harvest+the+Nether+1.7.10a.jar"))
     transformedMod(deobf("https://mediafiles.forgecdn.net/files/2340/786/ProjectE-1.7.10-PE1.10.1.jar"))

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -356,6 +356,11 @@ public enum Mixins {
     FIX_FURNACE_ITERATION(new Builder("Speedup Furnaces").addMixinClasses("projecte.MixinObjHandler")
             .setApplyIf(() -> Common.config.speedupVanillaFurnace).addTargetedMod(TargetedMod.PROJECTE)),
 
+    // LOTR
+    FIX_LOTR_FURNACE_ERROR(new Builder("Patches lotr to work with the vanilla furnace speedup")
+            .addMixinClasses("lotr.MixinLOTRRecipes").setApplyIf(() -> Common.config.speedupVanillaFurnace)
+            .addTargetedMod(TargetedMod.VANILLA).addTargetedMod(TargetedMod.GTNHLIB).addTargetedMod(TargetedMod.LOTR)),
+
     // Journeymap
     FIX_JOURNEYMAP_KEYBINDS(
             new Builder("Fix Journeymap Keybinds").setSide(Side.CLIENT).addMixinClasses("journeymap.MixinConstants")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -20,6 +20,7 @@ public enum TargetedMod {
     HUNGER_OVERHAUL("HungerOverhaul", null, "HungerOverhaul"),
     IC2("IC2", "ic2.core.coremod.IC2core", "IC2"),
     JOURNEYMAP("JourneyMap", null, "journeymap"),
+    LOTR("The Lord of the rings mod", "lotr.common.coremod.LOTRLoadingPlugin", "lotr"),
     LWJGL3IFY("lwjgl3ify", "me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod", "lwjgl3ify"),
     MINECHEM("Minechem", null, "minechem"),
     MRTJPCORE("MrTJPCore", null, "MrTJPCoreMod"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/lotr/MixinLOTRRecipes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/lotr/MixinLOTRRecipes.java
@@ -1,0 +1,34 @@
+package com.mitchej123.hodgepodge.mixins.late.lotr;
+
+import java.util.Map;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import lotr.common.recipe.LOTRRecipes;
+
+@Mixin(value = LOTRRecipes.class, remap = false)
+public class MixinLOTRRecipes {
+
+    /**
+     * @author Mist475
+     * @reason The speedupVanillaFurnace feature replaces the FurnaceRecipes {@link java.util.HashMap} with gtnhlib's
+     *         {@link com.gtnewhorizon.gtnhlib.util.map.ItemStackMap}, lotr casts the map to a hashmap causing errors
+     */
+    @Overwrite(remap = false)
+    private static void addSmeltingXPForItem(Item item, float xp) {
+        try {
+            //Get experienceList
+            Map<ItemStack, Float> map = ObfuscationReflectionHelper
+                    .getPrivateValue(FurnaceRecipes.class, FurnaceRecipes.smelting(), 2);
+            map.put(new ItemStack(item, 1, 32767), xp);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/lotr/MixinLOTRRecipes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/lotr/MixinLOTRRecipes.java
@@ -23,7 +23,7 @@ public class MixinLOTRRecipes {
     @Overwrite(remap = false)
     private static void addSmeltingXPForItem(Item item, float xp) {
         try {
-            //Get experienceList
+            // Get experienceList
             Map<ItemStack, Float> map = ObfuscationReflectionHelper
                     .getPrivateValue(FurnaceRecipes.class, FurnaceRecipes.smelting(), 2);
             map.put(new ItemStack(item, 1, 32767), xp);


### PR DESCRIPTION
Atm lotr itself doesn't have j12+ support so I left it at transformedModCompileOnly for now. I have patches ready in [my own mod](https://github.com/mist475/MistLotrTweaks) that I will pr some time later.