### PR TITLE
Fix path handling of bibliocraft saved books to replace invalid characters with dashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1689409577
+//version: 1690104383
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.19'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -575,11 +575,26 @@ repositories {
         }
     }
     if (includeWellKnownRepositories.toBoolean()) {
-        maven {
-            name "CurseMaven"
-            url "https://cursemaven.com"
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name "CurseMaven"
+                    url "https://cursemaven.com"
+                }
+            }
+            filter {
                 includeGroup "curse.maven"
+            }
+        }
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
+                includeGroup "maven.modrinth"
             }
         }
         maven {
@@ -623,7 +638,7 @@ dependencies {
         }
     }
     if (usesMixins.toBoolean()) {
-        implementation(mixinProviderSpec)
+        implementation(modUtils.enableMixins(mixinProviderSpec))
     } else if (forceEnableMixins.toBoolean()) {
         runtimeOnlyNonPublishable(mixinProviderSpec)
     }
@@ -677,9 +692,6 @@ if (file('dependencies.gradle.kts').exists()) {
 }
 
 def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
-def mixinTmpDir = buildDir.path + File.separator + 'tmp' + File.separator + 'mixins'
-def refMap = "${mixinTmpDir}" + File.separator + mixingConfigRefMap
-def mixinSrg = "${mixinTmpDir}" + File.separator + "mixins.srg"
 
 tasks.register('generateAssets') {
     group = "GTNH Buildscript"
@@ -711,46 +723,17 @@ tasks.register('generateAssets') {
 }
 
 if (usesMixins.toBoolean()) {
-    tasks.named("reobfJar", ReobfuscatedJar).configure {
-        extraSrgFiles.from(mixinSrg)
-    }
-
     tasks.named("processResources").configure {
         dependsOn("generateAssets")
     }
 
     tasks.named("compileJava", JavaCompile).configure {
-        doFirst {
-            new File(mixinTmpDir).mkdirs()
-        }
         options.compilerArgs += [
-            "-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}",
-            "-AoutSrgFile=${mixinSrg}",
-            "-AoutRefMapFile=${refMap}",
             // Elan: from what I understand they are just some linter configs so you get some warning on how to properly code
             "-XDenableSunApiLintControl",
             "-XDignore.symbol.file"
         ]
     }
-
-    pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
-        kapt {
-            correctErrorTypes = true
-            javacOptions {
-                option("-AreobfSrgFile=${tasks.reobfJar.srg.get().asFile}")
-                option("-AoutSrgFile=$mixinSrg")
-                option("-AoutRefMapFile=$refMap")
-            }
-        }
-        tasks.configureEach { task ->
-            if (task.name == "kaptKotlin") {
-                task.doFirst {
-                    new File(mixinTmpDir).mkdirs()
-                }
-            }
-        }
-    }
-
 }
 
 tasks.named("processResources", ProcessResources).configure {
@@ -768,7 +751,6 @@ tasks.named("processResources", ProcessResources).configure {
     }
 
     if (usesMixins.toBoolean()) {
-        from refMap
         dependsOn("compileJava", "compileScala")
     }
 }
@@ -1311,7 +1293,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.1.1"
+def buildscriptGradleVersion = "8.2.1"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -32,6 +32,7 @@ public class LoadingConfig {
     public boolean changeSprintCategory;
     public boolean enlargePotionArray;
     public boolean fixBibliocraftPackets;
+    public boolean fixBibliocraftPathSanitization;
     public boolean fixComponentsPoppingOff;
     public boolean fixContainerPutStacksInSlots;
     public boolean fixDebugBoundingBox;
@@ -224,7 +225,8 @@ public class LoadingConfig {
         fixGuiGameOver = config.get(Category.FIXES.toString(), "fixGuiGameOver", true, "Fix Game Over GUI buttons disabled if switching fullscreen").getBoolean();
         fixHasteArmSwing = config.get(Category.FIXES.toString(), "fixHasteArmSwing", true, "Fix arm not swinging when having too much haste").getBoolean();
         fixTimeCommandWithGC = config.get(Category.FIXES.toString(), "fixTimeCommandWithGC", true, "Fix time commands with GC").getBoolean();
-        fixBibliocraftPackets = config.get(Category.FIXES.toString(), "fixBibliocraftPackets", true, "Fix Biblocraft packet exploits").getBoolean();
+        fixBibliocraftPackets = config.get(Category.FIXES.toString(), "fixBibliocraftPackets", true, "Fix Bibliocraft packet exploits").getBoolean();
+        fixBibliocraftPathSanitization = config.get(Category.FIXES.toString(), "fixBibliocraftPathSanitization", true, "Fix Bibliocraft path sanitization").getBoolean();
         fixZTonesPackets = config.get(Category.FIXES.toString(), "fixZTonesPackets", true, "Fix ZTones packet exploits").getBoolean();
         fixHopperHitBox = config.get(Category.FIXES.toString(), "fixHopperHitBox", true, "Fix vanilla hopper hit box").getBoolean();
         fixHopperVoidingItems = config.get(Category.FIXES.toString(), "fixHopperVoidingItems", true, "Fix Drawer + Hopper voiding items").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -448,6 +448,9 @@ public enum Mixins {
     BIBLIOCRAFT_PACKET_FIX(new Builder("Packet Fix").addMixinClasses("bibliocraft.MixinBibliocraftPatchPacketExploits")
             .setSide((Side.BOTH)).setApplyIf(() -> Common.config.fixBibliocraftPackets)
             .addTargetedMod(TargetedMod.BIBLIOCRAFT)),
+    BIBLIOCRAFT_PATH_SANITIZATION_FIX(new Builder("Path sanitization fix")
+            .addMixinClasses("bibliocraft.MixinPathSanitization").setSide((Side.BOTH))
+            .setApplyIf(() -> Common.config.fixBibliocraftPackets).addTargetedMod(TargetedMod.BIBLIOCRAFT)),
     ZTONES_PACKET_FIX(new Builder("Packet Fix").addMixinClasses("ztones.MixinZtonesPatchPacketExploits")
             .setSide((Side.BOTH)).setApplyIf(() -> Common.config.fixZTonesPackets).addTargetedMod(TargetedMod.ZTONES)),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinPathSanitization.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinPathSanitization.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.mitchej123.hodgepodge.util.PathSanitizer;
+
+import jds.bibliocraft.FileUtil;
+
+@Mixin(FileUtil.class)
+public class MixinPathSanitization {
+
+    @ModifyArg(
+            method = { "isBookSaved", "saveBook", "loadBook", "getAuthorList", "getPublistList",
+                    "addPublicPrivateFieldToBook", "deleteBook", "updatePublicFlag", "saveNBTtoFile", "saveBookMeta",
+                    "getBookType(Lnet/minecraft/world/World;I)I", "getBookType(ZI)I", "loadBookNBT" },
+            at = @At(value = "INVOKE", target = "Ljava/io/File;<init>(Ljava/io/File;Ljava/lang/String;)V"),
+            index = 1,
+            remap = false)
+    private String hodgepodge$sanitizeBookPath(String v) {
+        return PathSanitizer.sanitizeFileName(v);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/PathSanitizer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PathSanitizer.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utilities for sanitizing file paths generated with user input
+ */
+public final class PathSanitizer {
+
+    // This class just has some static utilities
+    private PathSanitizer() {}
+
+    // On Linux it's just /, macOS forbids / and :
+    // On Windows it's <>:"/\|?*
+    private static final Pattern ILLEGAL_FILE_NAME_CHARS = Pattern.compile("[/\\\\<>:\\\"|?*]");
+
+    /**
+     * Replaces all illegal characters (including directory separators) for a file name from input with dashes.
+     * 
+     * @param input The untrusted file name
+     * @return A name that can be trusted to be safe for file reading/creation
+     */
+    public static String sanitizeFileName(String input) {
+        return ILLEGAL_FILE_NAME_CHARS.matcher(input).replaceAll("-").replace('\0', '-');
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/PathSanitizer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PathSanitizer.java
@@ -12,7 +12,7 @@ public final class PathSanitizer {
 
     // On Linux it's just /, macOS forbids / and :
     // On Windows it's <>:"/\|?*
-    private static final Pattern ILLEGAL_FILE_NAME_CHARS = Pattern.compile("[/\\\\<>:\\\"|?*]");
+    private static final Pattern ILLEGAL_FILE_NAME_CHARS = Pattern.compile("[/\\\\<>:\"|?*]");
 
     /**
      * Replaces all illegal characters (including directory separators) for a file name from input with dashes.


### PR DESCRIPTION
Creating books with slashes in the title and saving them via the typesetting table could cause exceptions and crashes.