### PR TITLE
Fix player skin fetching method in AbstractClientPlayer

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -73,6 +73,7 @@ public class LoadingConfig {
     public boolean fixNorthWestBias;
     public boolean fixOptifineChunkLoadingCrash;
     public boolean fixPerspectiveCamera;
+    public boolean fixPlayerSkinFetching;
     public boolean fixPotionEffectNumerals;
     public boolean fixPotionEffectRender;
     public boolean fixPotionIterating;
@@ -252,6 +253,7 @@ public class LoadingConfig {
         fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
         fixOptifineChunkLoadingCrash = config.get(Category.FIXES.toString(), "fixOptifineChunkLoadingCrash", true, "Forces the chunk loading option from optifine to default since other values can crash the game").getBoolean();
         fixPerspectiveCamera = config.get(Category.FIXES.toString(), "fixPerspectiveCamera", true, "Prevent tall grass and such to affect the perspective camera").getBoolean();
+        fixPlayerSkinFetching = config.get(Category.FIXES.toString(), "fixPlayerSkinFetching", true, "Allow some mods to properly fetch the player skin").getBoolean();
         fixPotionEffectNumerals = config.get(Category.FIXES.toString(), "fixPotionEffectNumerals", true, "Properly display level of potion effects in the inventory and on tooltips").getBoolean();
         fixPotionEffectRender = config.get(Category.TWEAKS.toString(), "fixPotionEffectRender", true, "Fix vanilla potion effects rendering above the NEI tooltips in the inventory").getBoolean();
         fixPotionIterating = config.get(Category.FIXES.toString(), "fixPotionIterating", true, "Fix crashes with ConcurrentModificationException because of incorrectly iterating over active potions").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -235,6 +235,9 @@ public enum Mixins {
     BED_MESSAGE_ABOVE_HOTBAR(new Builder("Bed Message Above Hotbar").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinBlockBed").setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.bedMessageAboveHotbar).addTargetedMod(TargetedMod.VANILLA)),
+    FIX_PLAYER_SKIN_FETCHING(new Builder("Fix player skin fetching").setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinAbstractClientPlayer").setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.fixPlayerSkinFetching).addTargetedMod(TargetedMod.VANILLA)),
 
     VALIDATE_PACKET_ENCODING_BEFORE_SENDING(new Builder("Validate packet encoding before sending").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.packets.MixinDataWatcher", "minecraft.packets.MixinS3FPacketCustomPayload")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAbstractClientPlayer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAbstractClientPlayer.java
@@ -1,13 +1,17 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
 import net.minecraft.client.entity.AbstractClientPlayer;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(AbstractClientPlayer.class)
 public class MixinAbstractClientPlayer {
-    @ModifyConstant(method = "getDownloadImageSkin", constant = @Constant(stringValue = "http://skins.minecraft.net/MinecraftSkins/%s.png"))
+
+    @ModifyConstant(
+            method = "getDownloadImageSkin",
+            constant = @Constant(stringValue = "http://skins.minecraft.net/MinecraftSkins/%s.png"))
     private static String hodgepodge$redirectSkinUrl(String url) {
         return "https://visage.surgeplay.com/skin/%s.png";
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAbstractClientPlayer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAbstractClientPlayer.java
@@ -1,0 +1,14 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.entity.AbstractClientPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(AbstractClientPlayer.class)
+public class MixinAbstractClientPlayer {
+    @ModifyConstant(method = "getDownloadImageSkin", constant = @Constant(stringValue = "http://skins.minecraft.net/MinecraftSkins/%s.png"))
+    private static String hodgepodge$redirectSkinUrl(String url) {
+        return "https://visage.surgeplay.com/skin/%s.png";
+    }
+}


### PR DESCRIPTION
`AbstractClientPlayer#getDownloadImageSkin` depends on the now-defunct skins.minecraft.net, breaking skin loading for (at least) FTBU and BQ.
This redirects it to a working public api that can accept usernames. Should this be changed to use a different api setup (currently it is not the fastest, due to performing uuid lookup), or is this good enough?