### PR TITLE
check all key states when you close an inventory to press the keybinds

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/common/KeyBindingDuck.java
+++ b/src/main/java/com/mitchej123/hodgepodge/common/KeyBindingDuck.java
@@ -1,0 +1,6 @@
+package com.mitchej123.hodgepodge.common;
+
+public interface KeyBindingDuck {
+
+    void hodgepodge$updateKeyStates();
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -216,7 +216,7 @@ public enum Mixins {
             .addMixinClasses("forge.MixinOpenGuiHandler").setApplyIf(() -> Common.config.fixForgeOpenGuiHandlerWindowId)
             .addTargetedMod(TargetedMod.VANILLA)),
     FIX_KEYBIND_CONFLICTS(new Builder("Trigger all conflicting keybinds").setPhase(Phase.EARLY)
-            .addMixinClasses("minecraft.MixinKeyBinding").setSide(Side.CLIENT)
+            .addMixinClasses("minecraft.MixinKeyBinding", "minecraft.MixinMinecraft_UpdateKeys").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.triggerAllConflictingKeybindings).addTargetedMod(TargetedMod.VANILLA)),
     REMOVE_SPAWN_MINECART_SOUND(new Builder("Remove sound when spawning a minecart")
             .addMixinClasses("minecraft.MixinWorldClient").addTargetedMod(TargetedMod.VANILLA)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_UpdateKeys.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_UpdateKeys.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.common.KeyBindingDuck;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft_UpdateKeys {
+
+    /**
+     * From Sk1er/Patcher
+     */
+    @Inject(
+            method = "setIngameFocus",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/util/MouseHelper;grabMouseCursor()V"))
+    private void hodgepodge$updateKeysStates(CallbackInfo ci) {
+        ((KeyBindingDuck) Minecraft.getMinecraft().gameSettings.keyBindAttack).hodgepodge$updateKeyStates();
+    }
+
+}


### PR DESCRIPTION
this way if you have your walk forward button pressed when you close your inventory, it directly starts walking, you don't have to unpress the key and press it again