### PR TITLE
Don't invert crosshair colors

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -281,7 +281,7 @@ public class LoadingConfig {
         validatePacketEncodingBeforeSendingShouldCrash = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSendingShouldCrash", false, "Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)").getBoolean();
 
         compactChat = config.get(Category.TWEAKS.toString(), "Compact chat", true, "Compacts identical consecutive chat messages together").getBoolean();
-        dontInvertCrosshairColor = config.get(Category.TWEAKS.toString(), "dontInvertCrosshairColor", true, "Stop inverting colors of crosshair").getBoolean();
+        dontInvertCrosshairColor = config.get(Category.TWEAKS.toString(), "dontInvertCrosshairColor", false, "Stop inverting colors of crosshair").getBoolean();
         enhanceNightVision = config.get(Category.TWEAKS.toString(), "enhanceNightVision", false, "Remove the blueish sky tint from night vision").getBoolean();
         hideCrosshairInThirdPerson = config.get(Category.TWEAKS.toString(), "hideCrosshairInThirdPerson", true, "Stops rendering the crosshair when you are playing in third person").getBoolean();
         hideIc2ReactorSlots = config.get(Category.TWEAKS.toString(), "hideIc2ReactorSlots", true, "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -115,6 +115,7 @@ public class LoadingConfig {
     public boolean removeCreativeSearchTab;
 
     public boolean compactChat;
+    public boolean dontInvertCrosshairColor;
     public boolean enhanceNightVision;
     public boolean enableMacosCmdShortcuts;
     public boolean fixFontRendererLinewrapRecursion;
@@ -280,6 +281,7 @@ public class LoadingConfig {
         validatePacketEncodingBeforeSendingShouldCrash = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSendingShouldCrash", false, "Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)").getBoolean();
 
         compactChat = config.get(Category.TWEAKS.toString(), "Compact chat", true, "Compacts identical consecutive chat messages together").getBoolean();
+        dontInvertCrosshairColor = config.get(Category.TWEAKS.toString(), "dontInvertCrosshairColor", true, "Stop inverting colors of crosshair").getBoolean();
         enhanceNightVision = config.get(Category.TWEAKS.toString(), "enhanceNightVision", false, "Remove the blueish sky tint from night vision").getBoolean();
         hideCrosshairInThirdPerson = config.get(Category.TWEAKS.toString(), "hideCrosshairInThirdPerson", true, "Stops rendering the crosshair when you are playing in third person").getBoolean();
         hideIc2ReactorSlots = config.get(Category.TWEAKS.toString(), "hideIc2ReactorSlots", true, "Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -213,9 +213,12 @@ public enum Mixins {
     STATIC_LAN_PORT(new Builder("Static Lan Port").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.server.MixinHttpUtil").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.enableDefaultLanPort).addTargetedMod(TargetedMod.VANILLA)),
-    CROSSHAIR_THIRDPERSON(new Builder("Crosshairs Thirdperson").setPhase(Phase.EARLY)
-            .addMixinClasses("forge.MixinGuiIngameForge").setSide(Side.CLIENT)
+    CROSSHAIR_THIRDPERSON(new Builder("Crosshairs thirdperson").setPhase(Phase.EARLY)
+            .addMixinClasses("forge.MixinGuiIngameForge_CrosshairThirdPerson").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.hideCrosshairInThirdPerson).addTargetedMod(TargetedMod.VANILLA)),
+    DONT_INVERT_CROSSHAIR_COLORS(new Builder("Don't invert crosshair colors").setPhase(Phase.EARLY)
+            .addMixinClasses("forge.MixinGuiIngameForge_CrosshairInvertColors").setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.dontInvertCrosshairColor).addTargetedMod(TargetedMod.VANILLA)),
     FIX_OPENGUIHANDLER_WINDOWID(new Builder("Fix OpenGuiHandler").setPhase(Phase.EARLY)
             .addMixinClasses("forge.MixinOpenGuiHandler").setApplyIf(() -> Common.config.fixForgeOpenGuiHandlerWindowId)
             .addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairInvertColors.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairInvertColors.java
@@ -1,0 +1,20 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraftforge.client.GuiIngameForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+
+@Mixin(GuiIngameForge.class)
+public class MixinGuiIngameForge_CrosshairInvertColors {
+
+    @WrapWithCondition(
+            method = "renderCrosshairs",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OpenGlHelper;glBlendFunc(IIII)V"))
+    private boolean hodgepodge$dontInvertColors(int i1, int i2, int i3, int i4) {
+        return false;
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairThirdPerson.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairThirdPerson.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GuiIngameForge.class)
-public class MixinGuiIngameForge extends GuiIngame {
+public class MixinGuiIngameForge_CrosshairThirdPerson extends GuiIngame {
 
     @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
     public void hodgepodge$hideCrosshairThirdPerson(int width, int height, CallbackInfo ci) {
@@ -19,7 +19,7 @@ public class MixinGuiIngameForge extends GuiIngame {
         }
     }
 
-    private MixinGuiIngameForge(Minecraft mc) {
+    private MixinGuiIngameForge_CrosshairThirdPerson(Minecraft mc) {
         super(mc);
     }
 }


### PR DESCRIPTION
Stop inverting the colors of the crosshair

default : 
![Default](https://github.com/GTNewHorizons/Hodgepodge/assets/57050655/30b7efb1-bf16-402e-aaa1-b88eb9fd476e)

Not inverted :
![Not inverted](https://github.com/GTNewHorizons/Hodgepodge/assets/57050655/4400a59d-e7c2-491c-b51e-25724cdb0e2e)


This will conflict with https://github.com/GTNewHorizons/Hodgepodge/pull/247 without saying that is has merge conflicts