### PR TITLE
Add performance optimizations for grass block random ticking

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -123,6 +123,7 @@ public class LoadingConfig {
     public boolean removeUpdateChecks;
     public boolean speedupAnimations;
     public boolean speedupBOPFogHandling;
+    public boolean speedupGrassBlockRandomTicking;
     public boolean speedupChunkCoordinatesHashCode;
     public boolean speedupProgressBar;
     public boolean speedupVanillaFurnace;
@@ -315,6 +316,7 @@ public class LoadingConfig {
         renderDebugMode = config.get(Category.DEBUG.toString(), "renderDebugMode", 0, "Default GL state debug mode. 0 - off, 1 - reduced, 2 - full").setMinValue(0).setMaxValue(2).getInt();
         speedupAnimations = config.get(Category.FIXES.toString(), "speedupAnimations", true, "Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working)").getBoolean();
         speedupBOPFogHandling = config.get(Category.SPEEDUPS.toString(), "speedupBOPFogHandling", true, "Speedup biome fog rendering in BiomesOPlenty").getBoolean();
+        speedupGrassBlockRandomTicking = config.get(Category.SPEEDUPS.toString(), "speedupGrassBlockRandomTicking", true, "Speed up grass block random ticking").getBoolean();
         speedupChunkCoordinatesHashCode = config.get(Category.SPEEDUPS.toString(), "speedupChunkCoordinatesHashCode", true, "Speedup ChunkCoordinates hashCode").getBoolean();
         speedupProgressBar = config.get(Category.ASM.toString(), "speedupProgressBar", true, "Speedup progressbar").getBoolean();
         speedupVanillaFurnace = config.get(Category.SPEEDUPS.toString(), "speedupVanillaFurnace", true, "Speedup Vanilla Furnace recipe lookup").getBoolean();
@@ -330,14 +332,14 @@ public class LoadingConfig {
 
         // Disable for now as it is not compatible with anything modifying RenderBlocks
         pollutionAsm = config.get(Category.ASM.toString(), "pollutionAsm", false, "Enable pollution rendering ASM").getBoolean();
-        
+
         // Pollution :nauseous:
         furnacesPollute = config.get(Category.POLLUTION.toString(), "furnacesPollute", true, "Make furnaces Pollute").getBoolean();
         rocketsPollute = config.get(Category.POLLUTION.toString(), "rocketsPollute", true, "Make rockets Pollute").getBoolean();
         railcraftPollutes = config.get(Category.POLLUTION.toString(), "railcraftPollutes", true, "Make Railcraft Pollute").getBoolean();
 
         disableAidSpawnByXUSpikes = config.get(Category.TWEAKS.toString(), "disableAidSpawnByXUSpikes", true, "Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far.").getBoolean();
-        
+
         furnacePollutionAmount = config.get(Category.POLLUTION.toString(), "furnacePollution", 20, "Furnace pollution per second, min 1!", 1, Integer.MAX_VALUE).getInt();
         fireboxPollutionAmount = config.get(Category.POLLUTION.toString(), "fireboxPollution", 15, "Pollution Amount for RC Firebox", 1, Integer.MAX_VALUE).getInt();
         rocketPollutionAmount = config.get(Category.POLLUTION.toString(), "rocketPollution", 1000, "Pollution Amount for Rockets", 1, Integer.MAX_VALUE).getInt();
@@ -346,8 +348,8 @@ public class LoadingConfig {
         hobbyistEnginePollutionAmount = config.get(Category.POLLUTION.toString(), "hobbyistEnginePollution", 20, "Pollution Amount for hobbyist steam engine", 1, Integer.MAX_VALUE).getInt();
         tunnelBorePollutionAmount = config.get(Category.POLLUTION.toString(), "tunnelBorePollution", 2, "Pollution Amount for tunnel bore", 1, Integer.MAX_VALUE).getInt();
         explosionPollutionAmount = config.get(Category.POLLUTION.toString(), "explosionPollution", 33.34, "Explosion pollution").getDouble();
-        
-        
+
+
         // spotless:on
         if (config.hasChanged()) config.save();
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -82,6 +82,9 @@ public enum Mixins {
     TRANSPARENT_CHAT(new Builder("Transparent Chat").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinGuiNewChat_TransparentChat").setSide(Side.CLIENT)
             .setApplyIf(() -> Common.config.transparentChat).addTargetedMod(TargetedMod.VANILLA)),
+    SPEEDUP_GRASS_BLOCK_RANDOM_TICKING(new Builder("Speed up grass block random ticking").setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinBlockGrass").addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> Common.config.speedupGrassBlockRandomTicking)),
     CHUNK_COORDINATES_HASHCODE(new Builder("Optimize Chunk Coordinates Hashcode").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinChunkCoordinates").addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> Common.config.speedupChunkCoordinatesHashCode)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockGrass.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockGrass.java
@@ -1,0 +1,45 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Random;
+
+import net.minecraft.block.BlockGrass;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(BlockGrass.class)
+public class MixinBlockGrass {
+
+    /**
+     * @author tth05
+     * @reason Small performance improvements. Prevent chunk loading, avoid doing any work on blocks that can't turn to
+     *         grass, remove duplicate {@link World#getBlockLightValue(int, int, int)} call.
+     */
+    @Overwrite
+    public void updateTick(World worldIn, int x, int y, int z, Random random) {
+        if (worldIn.isRemote) return;
+
+        int blockLightValue = worldIn.getBlockLightValue(x, y + 1, z);
+        if (blockLightValue < 4 && worldIn.getBlockLightOpacity(x, y + 1, z) > 2) {
+            worldIn.setBlock(x, y, z, Blocks.dirt);
+        } else if (blockLightValue >= 9) {
+            for (int i = 0; i < 4; ++i) {
+                int targetX = x + random.nextInt(3) - 1;
+                int targetY = y + random.nextInt(5) - 3;
+                int targetZ = z + random.nextInt(3) - 1;
+
+                if (targetX == x && targetZ == z && (targetY == y || targetY == y - 1)) continue;
+                if (!worldIn.blockExists(targetX, targetY, targetZ)) continue;
+
+                if (worldIn.getBlock(targetX, targetY, targetZ) == Blocks.dirt
+                        && worldIn.getBlockMetadata(targetX, targetY, targetZ) == 0
+                        && worldIn.getBlockLightValue(targetX, targetY + 1, targetZ) >= 4
+                        && worldIn.getBlockLightOpacity(targetX, targetY + 1, targetZ) <= 2) {
+                    worldIn.setBlock(targetX, targetY, targetZ, Blocks.grass);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Prevent chunk loading
- Avoid doing any work on blocks that can't turn to grass, meaning the block itself and the block directly below
- Remove duplicate `World#getBlockLightValue` call
- Remove unused `World#getBlock` call with unused result