### PR TITLE
Fix Witchery's Mirror Reflections

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -25,6 +25,7 @@ public class LoadingConfig {
     public boolean deduplicateForestryCompatInBOP;
     public boolean dimensionManagerDebug;
     public boolean disableWitcheryPotionExtender;
+    public boolean fixWitcheryReflections;
     public boolean displayIc2FluidLocalizedName;
     public boolean dropPickedLootOnDespawn;
     public boolean enableDefaultLanPort;
@@ -214,6 +215,7 @@ public class LoadingConfig {
         defaultLanPort = config.get(Category.TWEAKS.toString(), "defaultLanPort", 25565, "Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port.").getInt();
         dimensionManagerDebug = config.get(Category.DEBUG.toString(), "dimensionManagerDebug", true, "Prints debug log if DimensionManager got crashed").getBoolean();
         disableWitcheryPotionExtender = config.get(Category.FIXES.toString(), "disableWitcheryPotionExtender", true, "Disable Witchery potion extender for Java 12 compat").getBoolean();
+        fixWitcheryReflections = config.get(Category.FIXES.toString(), "fixWitcheryReflections", true, "Fixes Witchery player skins reflections with inhabited mirrors").getBoolean();
         displayIc2FluidLocalizedName = config.get(Category.TWEAKS.toString(), "displayIc2FluidLocalizedName", true, "Display fluid localized name in IC2 fluid cell tooltip").getBoolean();
         dropPickedLootOnDespawn = config.get(Category.TWEAKS.toString(), "dropPickedLootOnDespawn", true, "Drop picked loot on entity despawn").getBoolean();
         enableDefaultLanPort = config.get(Category.TWEAKS.toString(), "enableDefaultLanPort", true, "Open an integrated server on a static port.").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -493,6 +493,10 @@ public enum Mixins {
             .addMixinClasses("witchery.MixinPotionArrayExtender").setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.disableWitcheryPotionExtender).addTargetedMod(TargetedMod.WITCHERY)),
 
+    Fix_WitcheryReflectionSkin(new Builder("Fixes Witchery player skins reflections")
+            .addMixinClasses("witchery.MixinExtendedPlayer", "witchery.MixinEntityReflection").setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.fixWitcheryReflections).addTargetedMod(TargetedMod.WITCHERY)),
+
     // Various Exploits/Fixes
     GC_TIME_COMMAND_FIX(new Builder("GC Time Fix").addMixinClasses("minecraft.MixinTimeCommandGalacticraftFix")
             .setPhase(Phase.EARLY).setSide(Side.BOTH).setApplyIf(() -> Common.config.fixTimeCommandWithGC)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityReflection.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityReflection.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import static net.minecraft.client.entity.AbstractClientPlayer.getDownloadImageSkin;
+
+import net.minecraft.client.renderer.ThreadDownloadImageData;
+import net.minecraft.util.ResourceLocation;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.emoniph.witchery.entity.EntityReflection;
+
+@Mixin(EntityReflection.class)
+public class MixinEntityReflection {
+
+    @Redirect(
+            method = "setupCustomSkin",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/emoniph/witchery/entity/EntityReflection;getDownloadImageSkin(Lnet/minecraft/util/ResourceLocation;Ljava/lang/String;)Lnet/minecraft/client/renderer/ThreadDownloadImageData;"),
+            remap = false)
+    private ThreadDownloadImageData hodgepodge$getDownloadImageSkin(ResourceLocation location, String name) {
+        return getDownloadImageSkin(location, name);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinExtendedPlayer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinExtendedPlayer.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import static net.minecraft.client.entity.AbstractClientPlayer.getDownloadImageSkin;
+
+import net.minecraft.client.renderer.ThreadDownloadImageData;
+import net.minecraft.util.ResourceLocation;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.emoniph.witchery.common.ExtendedPlayer;
+
+@Mixin(ExtendedPlayer.class)
+public class MixinExtendedPlayer {
+
+    @Redirect(
+            method = "setupCustomSkin",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/emoniph/witchery/common/ExtendedPlayer;getDownloadImageSkin(Lnet/minecraft/util/ResourceLocation;Ljava/lang/String;)Lnet/minecraft/client/renderer/ThreadDownloadImageData;"),
+            remap = false)
+    private ThreadDownloadImageData hodgepodge$getDownloadImageSkin(ResourceLocation location, String name) {
+        return getDownloadImageSkin(location, name);
+    }
+}


### PR DESCRIPTION
Allow `getDownloadImageSkin()` fixes to apply to Witchery's Mirror content (demon reflections, player camouflage and sleeping bodies).

See issue in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13903

This wasn't fixed before by solutions such as https://github.com/GTNewHorizons/Hodgepodge/pull/237 primarily due to Witchery's decision to duplicate the vanilla method rather than referencing it.