### PR TITLE
Basic patch for Realms screen NPE

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -79,6 +79,7 @@ public class LoadingConfig {
     public boolean fixNetherLeavesFaceRendering;
     public boolean fixNorthWestBias;
     public boolean fixNettyNPE;
+    public boolean fixRealmsGuiNPE;
     public boolean fixOptifineChunkLoadingCrash;
     public boolean fixPerspectiveCamera;
     public boolean fixPlayerSkinFetching;
@@ -273,6 +274,7 @@ public class LoadingConfig {
         fixNetherLeavesFaceRendering = config.get(Category.FIXES.toString(), "fixNetherLeavesFaceRendering", true, "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too").getBoolean();
         fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
         fixNettyNPE = config.get(Category.FIXES.toString(), "fixNettyNPE", true, "Fix NPE in Netty's Bootstrap class").getBoolean();
+        fixNettyNPE = config.get(Category.FIXES.toString(), "fixNettyNPE", true, "Fix NPE in GuiScreen tripped by the Realms GUI").getBoolean();
         fixOptifineChunkLoadingCrash = config.get(Category.FIXES.toString(), "fixOptifineChunkLoadingCrash", true, "Forces the chunk loading option from optifine to default since other values can crash the game").getBoolean();
         fixPerspectiveCamera = config.get(Category.FIXES.toString(), "fixPerspectiveCamera", true, "Prevent tall grass and such to affect the perspective camera").getBoolean();
         fixPlayerSkinFetching = config.get(Category.FIXES.toString(), "fixPlayerSkinFetching", true, "Allow some mods to properly fetch the player skin").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -274,7 +274,7 @@ public class LoadingConfig {
         fixNetherLeavesFaceRendering = config.get(Category.FIXES.toString(), "fixNetherLeavesFaceRendering", true, "If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too").getBoolean();
         fixNorthWestBias = config.get(Category.FIXES.toString(), "fixNorthWestBias", true, "Fix northwest bias on RandomPositionGenerator").getBoolean();
         fixNettyNPE = config.get(Category.FIXES.toString(), "fixNettyNPE", true, "Fix NPE in Netty's Bootstrap class").getBoolean();
-        fixNettyNPE = config.get(Category.FIXES.toString(), "fixNettyNPE", true, "Fix NPE in GuiScreen tripped by the Realms GUI").getBoolean();
+        fixRealmsGuiNPE = config.get(Category.FIXES.toString(), "fixRealmsGuiNPE", true, "Fix NPE in GuiScreen tripped by the Realms GUI").getBoolean();
         fixOptifineChunkLoadingCrash = config.get(Category.FIXES.toString(), "fixOptifineChunkLoadingCrash", true, "Forces the chunk loading option from optifine to default since other values can crash the game").getBoolean();
         fixPerspectiveCamera = config.get(Category.FIXES.toString(), "fixPerspectiveCamera", true, "Prevent tall grass and such to affect the perspective camera").getBoolean();
         fixPlayerSkinFetching = config.get(Category.FIXES.toString(), "fixPlayerSkinFetching", true, "Allow some mods to properly fetch the player skin").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -272,6 +272,9 @@ public enum Mixins {
     NETTY_PATCH(new Builder("Fix NPE in Netty's Bootstrap class").addMixinClasses("netty.MixinBootstrap")
             .setPhase(Phase.EARLY).setSide(Side.CLIENT).setApplyIf(() -> Common.config.fixNettyNPE)
             .addTargetedMod(TargetedMod.VANILLA)),
+    REALMS_GUI_PATCH(new Builder("Fix NPE in GuiScreen tripped by the Realms GUI")
+            .addMixinClasses("minecraft.MixinGuiScreen").setPhase(Phase.EARLY).setSide(Side.CLIENT)
+            .setApplyIf(() -> Common.config.fixRealmsGuiNPE).addTargetedMod(TargetedMod.VANILLA)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiScreen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiScreen.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(GuiScreen.class)
+public abstract class MixinGuiScreen {
+
+    @Shadow
+    public Minecraft mc;
+
+    @Shadow
+    public abstract void drawBackground(int tint);
+
+    @Inject(
+            method = "drawWorldBackground",
+            at = @At(value = "HEAD"),
+            locals = LocalCapture.CAPTURE_FAILSOFT,
+            cancellable = true)
+    private void hodgepodge$fixRealmsScreenCrash(int tint, CallbackInfo ci) {
+        if (this.mc == null) {
+            this.drawBackground(tint);
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
Opening the Realms screen, clicking "Buy Realm", and then hitting Esc to exit and entering a world will eventually cause an NPE+crash when the HTTP request returns and it tries to display a realms GUI. This adds a simple null check to avert that. It still kicks you out of the world, but you can just log back in instead of restarting the client.

Technically the proper fix would be to stop whatever Realms screen is trying to appear from showing in the first place, but that's much harder and would still leave an NPE for someone else to footgun on.

Tested in full pack and it launched, although the actual functionality couldn't be tested as GTNH removes the realms button.