### PR TITLE
ExtraTiC Patch p.2

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -498,8 +498,9 @@ public enum Mixins {
     // Extra Tinkers
     Fix_EXTRATIC_TECONFLICT(new Builder(
             "Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: [Brass, Silver, Electrum & Platinum]")
-                    .addMixinClasses("extratic.MixinPartsHandler").setPhase(Phase.LATE).setSide(Side.BOTH)
-                    .setApplyIf(() -> Common.config.fixExtraTiCTEConflict).addTargetedMod(TargetedMod.EXTRATIC)),
+                    .addMixinClasses("extratic.MixinPartsHandler", "extratic.MixinRecipeHandler").setPhase(Phase.LATE)
+                    .setSide(Side.BOTH).setApplyIf(() -> Common.config.fixExtraTiCTEConflict)
+                    .addTargetedMod(TargetedMod.EXTRATIC)),
     // Extra Utilities
     FIX_EXTRA_UTILITIES_UNENCHANTING(new Builder("Fix Exu Unenchanting")
             .addMixinClasses("extrautilities.MixinRecipeUnEnchanting").setPhase(Phase.LATE).setSide(Side.BOTH)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extratic/MixinRecipeHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extratic/MixinRecipeHandler.java
@@ -1,0 +1,38 @@
+package com.mitchej123.hodgepodge.mixins.late.extratic;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import cpw.mods.fml.common.FMLLog;
+import glassmaker.extratic.common.RecipeHandler;
+
+@Mixin(RecipeHandler.class)
+public class MixinRecipeHandler {
+
+    /**
+     * @author DrParadox
+     * @reason Breaks Thermal Foundation's TConstruct material integration
+     */
+    @Redirect(
+            method = "addPartsRecipes",
+            at = @At(value = "INVOKE", target = "Lglassmaker/extratic/common/RecipeHandler;_addM3PreciousRecipes()V"),
+            remap = false)
+    private static void hodgepodge$disableM3PreciousRecipes() {
+        FMLLog.info("Disabled ExtraTiC Recipe integration with Metallurgy 3 Precious Materials");
+    }
+
+    /**
+     * @author DrParadox
+     * @reason Breaks Thermal Foundation's TConstruct parts integration
+     */
+    @Redirect(
+            method = "addPartsRecipes",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lglassmaker/extratic/common/RecipeHandler;_addM3PreciousAlloyMixing()V"),
+            remap = false)
+    private static void hodgepodge$disableM3PreciousAlloyMixing() {
+        FMLLog.info("Disabled ExtraTiC Alloy integration with Metallurgy 3 Precious Materials");
+    }
+}


### PR DESCRIPTION
Disabled additional ExtraTiC's Metallurgy 3 Precious Module that were still creating conflicts.
Specifically M3Precious recipes and alloy mixing,