### PR TITLE
Update Packet Exploit Patch for Bibliocraft

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBibliocraftPatchPacketExploits.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBibliocraftPatchPacketExploits.java
@@ -1,6 +1,8 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
 
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemEmptyMap;
 import net.minecraft.item.ItemMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -67,9 +69,14 @@ public class MixinBibliocraftPatchPacketExploits {
 
         NBTTagList inventoryTagList = tags.getTagList("Inventory", 10);
         if (inventoryTagList == null) return;
-        for (int i = 0; i < inventoryTagList.tagCount(); i++) {
-            if (!(ItemStack.loadItemStackFromNBT(inventoryTagList.getCompoundTagAt(i)).getItem() instanceof ItemMap)) {
-                kickAndWarn(player, c, "BiblioFrameGive");
+        if (!player.worldObj.isRemote) {
+
+            for (int i = 0; i < inventoryTagList.tagCount(); i++) {
+                Item itemChecks = ItemStack.loadItemStackFromNBT(inventoryTagList.getCompoundTagAt(i)).getItem();
+
+                if (!(itemChecks instanceof ItemMap || itemChecks instanceof ItemEmptyMap)) {
+                    kickAndWarn(player, c, "BiblioFrameGive");
+                }
             }
         }
     }


### PR DESCRIPTION
Changes:
- Don't kick players from their singleplayer world
- Make exceptions for empty maps in addition to the original filled maps

Fixes https://github.com/GTNewHorizons/Hodgepodge/issues/225 for real