### PR TITLE
Check for >0 instead of !=0

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinKeyBinding.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinKeyBinding.java
@@ -37,7 +37,7 @@ public class MixinKeyBinding implements KeyBindingExt {
      */
     @Overwrite
     public static void onTick(int keyCode) {
-        if (keyCode != 0) {
+        if (keyCode > 0) {
             for (KeyBinding bind : hodgepodge$keybindMultiMap.get(keyCode)) {
                 if (bind != null) {
                     ++((MixinKeyBinding) (Object) bind).pressTime;
@@ -52,7 +52,7 @@ public class MixinKeyBinding implements KeyBindingExt {
      */
     @Overwrite
     public static void setKeyBindState(int keyCode, boolean pressed) {
-        if (keyCode != 0) {
+        if (keyCode > 0) {
             for (KeyBinding bind : hodgepodge$keybindMultiMap.get(keyCode)) {
                 if (bind != null) {
                     ((MixinKeyBinding) (Object) bind).pressed = pressed;
@@ -68,7 +68,7 @@ public class MixinKeyBinding implements KeyBindingExt {
     private static void hodgepodge$populateKeybindMatcherArray(CallbackInfo ci) {
         hodgepodge$keybindMultiMap.clear();
         for (KeyBinding binding : (List<KeyBinding>) keybindArray) {
-            if (binding != null && binding.getKeyCode() != 0) {
+            if (binding != null && binding.getKeyCode() > 0) {
                 hodgepodge$keybindMultiMap.put(binding.getKeyCode(), binding);
             }
         }
@@ -87,7 +87,7 @@ public class MixinKeyBinding implements KeyBindingExt {
         for (KeyBinding keyBinding : hodgepodge$keybindMultiMap.values()) {
             try {
                 final int keyCode = keyBinding.getKeyCode();
-                KeyBinding.setKeyBindState(keyCode, keyCode < 256 && Keyboard.isKeyDown(keyCode));
+                KeyBinding.setKeyBindState(keyCode, keyCode > 0 && keyCode < 256 && Keyboard.isKeyDown(keyCode));
             } catch (IndexOutOfBoundsException ignored) {}
         }
     }


### PR DESCRIPTION
Fixes the error I was seeing with lwjglxdebug

```
    Description : Invalid key -1
    Stacktrace  :
org.lwjgl.glfw.GLFWErrorCallbackI.callback(GLFWErrorCallbackI.java:43)
org.lwjgl.system.JNI.invokePI(Native Method)
org.lwjgl.glfw.GLFW.glfwGetKey(GLFW.java:3746)
org.lwjglx.debug.$Proxy$4840.glfwGetKey577(Unknown Source)
org.lwjglx.input.Keyboard.isKeyDown(Keyboard.java:263)
net.minecraft.client.settings.KeyBinding.hodgepodge$updateKeyStates(KeyBinding.java:590)
net.minecraft.client.Minecraft.handler$zeb000$hodgepodge$updateKeysStates(Minecraft.java:6596)
net.minecraft.client.Minecraft.setIngameFocus(Minecraft.java:1386)
net.minecraft.client.Minecraft.displayGuiScreen(Minecraft.java:871)
net.minecraft.client.gui.GuiChat.keyTyped(GuiChat.java:119)
```