### PR TITLE
Player Skin Fetching Fix part 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1701530445
+//version: 1702141377
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -54,7 +54,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.24'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.26'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -613,7 +613,7 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            url = getURL("https://maven2.ic2.player.to/", "https://maven.ic2.player.to/")
             content {
                 includeGroup "net.industrial-craft"
             }
@@ -672,6 +672,8 @@ configurations.all {
         substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
+
+        substitute module('org.scala-lang:scala-library:2.11.1') using module('org.scala-lang:scala-library:2.11.5') because('To allow mixing with Java 8 targets')
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,11 +19,11 @@ dependencies {
     transformedMod("com.github.GTNewHorizons:Baubles:1.0.3:dev")
     // Transitive updates to make runClient17 work
     transformedMod("com.github.GTNewHorizons:ForgeMultipart:1.4.1:dev")
-    transformedMod("com.github.GTNewHorizons:GT5-Unofficial:5.09.44.96:dev")
-    transformedMod("com.github.GTNewHorizons:harvestcraft:1.1.3-GTNH:dev")
+    transformedMod("com.github.GTNewHorizons:GT5-Unofficial:5.09.44.106:dev")
+    transformedMod("com.github.GTNewHorizons:harvestcraft:1.1.4-GTNH:dev")
     transformedMod("com.github.GTNewHorizons:HungerOverhaul:1.0.4-GTNH:dev")
     transformedMod("com.github.GTNewHorizons:MrTJPCore:1.1.5:dev") // Do not update, fixed afterwards
-    transformedMod("com.github.GTNewHorizons:Railcraft:9.15.1:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
+    transformedMod("com.github.GTNewHorizons:Railcraft:9.15.3:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
     transformedMod("com.github.GTNewHorizons:TinkersConstruct:1.10.12-GTNH:dev")
     transformedMod(deobfCurse("bibliocraft-228027:2423369"))
     transformedMod("curse.maven:biomes-o-plenty-220318:2499612")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -268,8 +268,9 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinBlockBed").setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.bedMessageAboveHotbar).addTargetedMod(TargetedMod.VANILLA)),
     FIX_PLAYER_SKIN_FETCHING(new Builder("Fix player skin fetching").setPhase(Phase.EARLY)
-            .addMixinClasses("minecraft.MixinAbstractClientPlayer").setSide(Side.CLIENT)
-            .setApplyIf(() -> Common.config.fixPlayerSkinFetching).addTargetedMod(TargetedMod.VANILLA)),
+            .addMixinClasses("minecraft.MixinAbstractClientPlayer", "minecraft.MixinThreadDownloadImageData")
+            .setSide(Side.CLIENT).setApplyIf(() -> Common.config.fixPlayerSkinFetching)
+            .addTargetedMod(TargetedMod.VANILLA)),
     VALIDATE_PACKET_ENCODING_BEFORE_SENDING(new Builder("Validate packet encoding before sending").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.packets.MixinDataWatcher", "minecraft.packets.MixinS3FPacketCustomPayload")
             .setSide(Side.BOTH).setApplyIf(() -> Common.config.validatePacketEncodingBeforeSending)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinThreadDownloadImageData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinThreadDownloadImageData.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.net.HttpURLConnection;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import com.mitchej123.hodgepodge.Tags;
+
+@Mixin(targets = "net/minecraft/client/renderer/ThreadDownloadImageData$1")
+public class MixinThreadDownloadImageData {
+
+    @Inject(
+            method = "run()V",
+            at = @At(value = "INVOKE", target = "Ljava/net/HttpURLConnection;setDoInput(Z)V"),
+            locals = LocalCapture.CAPTURE_FAILSOFT,
+            remap = false)
+    private void hodgepodge$injectRun(CallbackInfo ci, HttpURLConnection httpURLConnection) {
+        httpURLConnection.setRequestProperty(
+                "User-Agent",
+                "Minecraft/1.7.10 Hodgepodge/" + Tags.VERSION + " (+https://github.com/GTNewHorizons/Hodgepodge)");
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinThreadDownloadImageData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinThreadDownloadImageData.java
@@ -13,6 +13,7 @@ import com.mitchej123.hodgepodge.Tags;
 @Mixin(targets = "net/minecraft/client/renderer/ThreadDownloadImageData$1")
 public class MixinThreadDownloadImageData {
 
+    @SuppressWarnings("UnresolvedMixinReference") // mcdev cannot find references in anonymous classes correctly
     @Inject(
             method = "run()V",
             at = @At(value = "INVOKE", target = "Ljava/net/HttpURLConnection;setDoInput(Z)V"),


### PR DESCRIPTION
Visage (the service used by the skin fetching fix) recently changed to require a non-generic user agent in API requests due to an influx of spam requests. (run eg. `curl https://visage.surgeplay.com/skin/Notch.png` to get a message describing this in more detail)
This sets a custom user agent for all requests made by `ThreadDownloadImageData` to satisfy this condition, currently formatted as `Minecraft/1.7.10 Hodgepodge/2.3.40 (+https://github.com/GTNewHorizons/Hodgepodge)`

(Bonus: As of a couple minutes ago at the time of this PR, Visage is now also geoblocking requests from Russia due to that being where all the spam requests are coming from and no other good way to keep them from eating bandwidth etc)