### PR TITLE
Adjustable network nbt and packet size limits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1702141377
+//version: 1704135167
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -31,8 +31,7 @@ buildscript {
         maven {
             // GTNH RetroFuturaGradle and ASM Fork
             name "GTNH Maven"
-            url "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-            allowInsecureProtocol = true
+            url "https://nexus.gtnewhorizons.com/repository/public/"
         }
         mavenLocal()
     }
@@ -49,7 +48,7 @@ plugins {
     id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id 'com.palantir.git-version' version '3.0.0' apply false
-    id 'de.undercouch.download' version '5.4.0'
+    id 'de.undercouch.download' version '5.5.0'
     id 'com.github.gmazzo.buildconfig' version '3.1.0' apply false // Unused, available for addon.gradle
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
@@ -118,7 +117,7 @@ propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnset("channel", "stable")
 propertyDefaultIfUnset("mappingsVersion", "12")
 propertyDefaultIfUnset("usesMavenPublishing", true)
-propertyDefaultIfUnset("mavenPublishUrl", "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases")
+propertyDefaultIfUnset("mavenPublishUrl", "https://nexus.gtnewhorizons.com/repository/releases/")
 propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
@@ -573,13 +572,15 @@ afterEvaluate {
 
 repositories {
     maven {
-        name 'Overmind forge repo mirror'
-        url 'https://gregtech.overminddl1.com/'
+        name = "GTNH Maven"
+        url = "https://nexus.gtnewhorizons.com/repository/public/"
+        // Links for convenience:
+        // Simple HTML browsing: https://nexus.gtnewhorizons.com/service/rest/repository/browse/releases/
+        // Rich web UI browsing: https://nexus.gtnewhorizons.com/#browse/browse:releases
     }
     maven {
-        name = "GTNH Maven"
-        url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
-        allowInsecureProtocol = true
+        name 'Overmind forge repo mirror'
+        url 'https://gregtech.overminddl1.com/'
     }
     maven {
         name 'sonatype'
@@ -960,8 +961,7 @@ if (usesShadowedDependencies.toBoolean()) {
     configurations.runtimeElements.outgoing.artifact(tasks.named("shadowJar", ShadowJar))
     configurations.apiElements.outgoing.artifact(tasks.named("shadowJar", ShadowJar))
     tasks.named("jar", Jar) {
-        enabled = false
-        finalizedBy(tasks.shadowJar)
+        archiveClassifier.set('dev-preshadow')
     }
     tasks.named("reobfJar", ReobfuscatedJar) {
         inputJar.set(tasks.named("shadowJar", ShadowJar).flatMap({it.archiveFile}))
@@ -969,11 +969,6 @@ if (usesShadowedDependencies.toBoolean()) {
     AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
     javaComponent.withVariantsFromConfiguration(configurations.shadowRuntimeElements) {
         skip()
-    }
-    for (runTask in ["runClient", "runServer", "runClient17", "runServer17"]) {
-        tasks.named(runTask).configure {
-            dependsOn("shadowJar")
-        }
     }
 }
 ext.publishableDevJar = usesShadowedDependencies.toBoolean() ? tasks.shadowJar : tasks.jar
@@ -1178,7 +1173,7 @@ publishing {
         if (usesMavenPublishing.toBoolean() && System.getenv("MAVEN_USER") != null) {
             maven {
                 url = mavenPublishUrl
-                allowInsecureProtocol = mavenPublishUrl.startsWith("http://") // Mostly for the GTNH maven
+                allowInsecureProtocol = mavenPublishUrl.startsWith("http://")
                 credentials {
                     username = System.getenv("MAVEN_USER") ?: "NONE"
                     password = System.getenv("MAVEN_PASSWORD") ?: "NONE"

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -153,6 +153,8 @@ public class LoadingConfig {
     public boolean validatePacketEncodingBeforeSending;
     public boolean validatePacketEncodingBeforeSendingShouldCrash;
     public boolean chunkSaveCMEDebug;
+    public boolean increasePacketSizeLimit;
+    public int packetSizeLimit;
     public boolean changeMaxNetworkNbtSizeLimit;
     public int maxNetworkNbtSizeLimit;
     public boolean ic2CellWithContainer;
@@ -305,6 +307,8 @@ public class LoadingConfig {
         fixXaerosWorldMapScroll = config.get(Category.FIXES.toString(), "fixXaerosWorldMapScrolling", true, "Fix scrolling in the world map screen").getBoolean();
         validatePacketEncodingBeforeSending = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSending", true, "Validate vanilla packet encodings before sending in addition to on reception").getBoolean();
         validatePacketEncodingBeforeSendingShouldCrash = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSendingShouldCrash", false, "Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)").getBoolean();
+        increasePacketSizeLimit = config.get(Category.FIXES.toString(), "increasePacketSizeLimit", true, "Increase the maximum network packet size from the default of 2MiB").getBoolean();
+        packetSizeLimit = config.getInt(Category.FIXES.toString(), "packetSizeLimit", 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum size limit in bytes of a network packet to accept, the vanilla value is 2097152 (2 MiB).");
         changeMaxNetworkNbtSizeLimit = config.get(Category.FIXES.toString(), "changeMaxNetworkNbtSizeLimit", true, "Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes").getBoolean();
         maxNetworkNbtSizeLimit = config.getInt(Category.FIXES.toString(), "maxNetworkNbtSizeLimit", 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB).");
 

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -308,9 +308,9 @@ public class LoadingConfig {
         validatePacketEncodingBeforeSending = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSending", true, "Validate vanilla packet encodings before sending in addition to on reception").getBoolean();
         validatePacketEncodingBeforeSendingShouldCrash = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSendingShouldCrash", false, "Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)").getBoolean();
         increasePacketSizeLimit = config.get(Category.FIXES.toString(), "increasePacketSizeLimit", true, "Increase the maximum network packet size from the default of 2MiB").getBoolean();
-        packetSizeLimit = config.getInt(Category.FIXES.toString(), "packetSizeLimit", 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum size limit in bytes of a network packet to accept, the vanilla value is 2097152 (2 MiB).");
+        packetSizeLimit = config.getInt("packetSizeLimit", Category.FIXES.toString(), 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum size limit in bytes of a network packet to accept, the vanilla value is 2097152 (2 MiB).");
         changeMaxNetworkNbtSizeLimit = config.get(Category.FIXES.toString(), "changeMaxNetworkNbtSizeLimit", true, "Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes").getBoolean();
-        maxNetworkNbtSizeLimit = config.getInt(Category.FIXES.toString(), "maxNetworkNbtSizeLimit", 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB).");
+        maxNetworkNbtSizeLimit = config.getInt("maxNetworkNbtSizeLimit", Category.FIXES.toString(), 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB).");
 
         disableRealmsButton = config.get(Category.TWEAKS.toString(), "disableRealmsButton", true, "Disable Minecraft Realms button on main menu").getBoolean();
         compactChat = config.get(Category.TWEAKS.toString(), "Compact chat", true, "Compacts identical consecutive chat messages together").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -153,6 +153,8 @@ public class LoadingConfig {
     public boolean validatePacketEncodingBeforeSending;
     public boolean validatePacketEncodingBeforeSendingShouldCrash;
     public boolean chunkSaveCMEDebug;
+    public boolean changeMaxNetworkNbtSizeLimit;
+    public int maxNetworkNbtSizeLimit;
     public boolean ic2CellWithContainer;
     public boolean cofhWorldTransformer;
     public boolean enableTileRendererProfiler;
@@ -303,6 +305,8 @@ public class LoadingConfig {
         fixXaerosWorldMapScroll = config.get(Category.FIXES.toString(), "fixXaerosWorldMapScrolling", true, "Fix scrolling in the world map screen").getBoolean();
         validatePacketEncodingBeforeSending = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSending", true, "Validate vanilla packet encodings before sending in addition to on reception").getBoolean();
         validatePacketEncodingBeforeSendingShouldCrash = config.get(Category.FIXES.toString(), "validatePacketEncodingBeforeSendingShouldCrash", false, "Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)").getBoolean();
+        changeMaxNetworkNbtSizeLimit = config.get(Category.FIXES.toString(), "changeMaxNetworkNbtSizeLimit", true, "Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes").getBoolean();
+        maxNetworkNbtSizeLimit = config.getInt(Category.FIXES.toString(), "maxNetworkNbtSizeLimit", 256 * 1024 * 1024, 1024, 1024 * 1024 * 1024, "The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB).");
 
         disableRealmsButton = config.get(Category.TWEAKS.toString(), "disableRealmsButton", true, "Disable Minecraft Realms button on main menu").getBoolean();
         compactChat = config.get(Category.TWEAKS.toString(), "Compact chat", true, "Compacts identical consecutive chat messages together").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -284,6 +284,9 @@ public enum Mixins {
     FIX_FLUID_CONTAINER_REGISTRY_KEY(new Builder("Fix Forge fluid container registry key").setPhase(Phase.EARLY)
             .addMixinClasses("forge.FluidContainerRegistryAccessor", "forge.MixinFluidRegistry").setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.fixFluidContainerRegistryKey).addTargetedMod(TargetedMod.VANILLA)),
+    CHANGE_MAX_NETWORK_NBT_SIZE_LIMIT(new Builder("Modify the maximum NBT size limit as received from network packets")
+            .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinPacketBuffer").setSide(Side.BOTH)
+            .setApplyIf(() -> Common.config.changeMaxNetworkNbtSizeLimit).addTargetedMod(TargetedMod.VANILLA)),
     FIX_XRAY_BLOCK_WITHOUT_COLLISION_AABB(new Builder("Fix Xray through block without collision boundingBox")
             .addMixinClasses("minecraft.MixinBlock_FixXray", "minecraft.MixinWorld_FixXray")
             .setApplyIf(() -> Common.config.fixPerspectiveCamera).addTargetedMod(TargetedMod.VANILLA)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -278,7 +278,9 @@ public enum Mixins {
             .setSide(Side.CLIENT).setApplyIf(() -> Common.config.fixPlayerSkinFetching)
             .addTargetedMod(TargetedMod.VANILLA)),
     VALIDATE_PACKET_ENCODING_BEFORE_SENDING(new Builder("Validate packet encoding before sending").setPhase(Phase.EARLY)
-            .addMixinClasses("minecraft.packets.MixinDataWatcher", "minecraft.packets.MixinS3FPacketCustomPayload")
+            .addMixinClasses(
+                    "minecraft.packets.MixinDataWatcher",
+                    "minecraft.packets.MixinS3FPacketCustomPayload_Validation")
             .setSide(Side.BOTH).setApplyIf(() -> Common.config.validatePacketEncodingBeforeSending)
             .addTargetedMod(TargetedMod.VANILLA)),
     FIX_FLUID_CONTAINER_REGISTRY_KEY(new Builder("Fix Forge fluid container registry key").setPhase(Phase.EARLY)
@@ -287,6 +289,15 @@ public enum Mixins {
     CHANGE_MAX_NETWORK_NBT_SIZE_LIMIT(new Builder("Modify the maximum NBT size limit as received from network packets")
             .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinPacketBuffer").setSide(Side.BOTH)
             .setApplyIf(() -> Common.config.changeMaxNetworkNbtSizeLimit).addTargetedMod(TargetedMod.VANILLA)),
+
+    INCREASE_PACKET_SIZE_LIMIT(new Builder("Increase the packet size limit from 2MiB to a theoretical maximum of 4GiB")
+            .setPhase(Phase.EARLY)
+            .addMixinClasses(
+                    "minecraft.MixinMessageSerializer2",
+                    "minecraft.MixinMessageDeserializer2",
+                    "minecraft.packets.MixinS3FPacketCustomPayload_LengthLimit")
+            .setSide(Side.BOTH).setApplyIf(() -> Common.config.increasePacketSizeLimit)
+            .addTargetedMod(TargetedMod.VANILLA)),
     FIX_XRAY_BLOCK_WITHOUT_COLLISION_AABB(new Builder("Fix Xray through block without collision boundingBox")
             .addMixinClasses("minecraft.MixinBlock_FixXray", "minecraft.MixinWorld_FixXray")
             .setApplyIf(() -> Common.config.fixPerspectiveCamera).addTargetedMod(TargetedMod.VANILLA)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMessageDeserializer2.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMessageDeserializer2.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.util.MessageDeserializer2;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(MessageDeserializer2.class)
+public class MixinMessageDeserializer2 {
+
+    /**
+     * @reason Remove the 21-bit (2MiB) limit of vanilla packet length. See {@link MixinMessageSerializer2}
+     */
+    @ModifyConstant(
+            method = "decode(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;Ljava/util/List;)V",
+            constant = @Constant(intValue = 3))
+    private int hodgepodge$increasePacketSizeLimit(int original) {
+        return 5;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMessageSerializer2.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMessageSerializer2.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.util.MessageSerializer2;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(MessageSerializer2.class)
+public class MixinMessageSerializer2 {
+
+    /**
+     * @reason Remove the 21-bit (2MiB) limit of vanilla packet length.
+     */
+    @ModifyConstant(
+            method = "encode(Lio/netty/channel/ChannelHandlerContext;Lio/netty/buffer/ByteBuf;Lio/netty/buffer/ByteBuf;)V",
+            constant = @Constant(intValue = 3))
+    private int hodgepodge$increasePacketSizeLimit(int original) {
+        // 32-bit length limit, which gets encoded as 5 7-bit varint bytes
+        return 5;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
@@ -1,20 +1,67 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import java.io.IOException;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTSizeTracker;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
 
 import com.mitchej123.hodgepodge.Common;
 
 @Mixin(PacketBuffer.class)
 public class MixinPacketBuffer {
 
-    @ModifyArg(
-            method = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTSizeTracker;<init>(J)V"))
-    private long hodgepodge$modifyMaxNetworkNBTSizeLimit(long original) {
-        return Common.config.maxNetworkNbtSizeLimit;
+    // A magic value that means the real length of the packet is encoded in a following int.
+    @Unique
+    private static final short MAGIC_LENGTH_IS_INT = Short.MAX_VALUE;
+
+    /**
+     * @author eigenraven
+     * @reason Change the length encoding to support values longer than a short, requires changing of local variable
+     *         types.
+     */
+    @Overwrite
+    public NBTTagCompound readNBTTagCompoundFromBuffer() throws IOException {
+        final PacketBuffer self = (PacketBuffer) (Object) this;
+        short shortLength = self.readShort();
+        final int realLength;
+        if (shortLength < 0) {
+            return null;
+        } else if (shortLength == MAGIC_LENGTH_IS_INT) {
+            realLength = self.readInt();
+        } else {
+            realLength = shortLength;
+        }
+        byte[] buffer = new byte[shortLength];
+        self.readBytes(buffer);
+        return CompressedStreamTools.func_152457_a(buffer, new NBTSizeTracker(Common.config.maxNetworkNbtSizeLimit));
     }
+
+    /**
+     * @author eigenraven
+     * @reason Change the length encoding to support values longer than a short, requires changing of local variable
+     *         types.
+     */
+    @Overwrite
+    public void writeNBTTagCompoundToBuffer(NBTTagCompound nbt) throws IOException {
+        final PacketBuffer self = (PacketBuffer) (Object) this;
+        if (nbt == null) {
+            self.writeShort(-1);
+        } else {
+            byte[] buffer = CompressedStreamTools.compress(nbt);
+            if (buffer.length >= MAGIC_LENGTH_IS_INT) {
+                self.writeShort(MAGIC_LENGTH_IS_INT);
+                self.writeInt(buffer.length);
+            } else {
+                self.writeShort(buffer.length);
+            }
+            self.writeBytes(buffer);
+        }
+    }
+
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
@@ -37,7 +37,7 @@ public class MixinPacketBuffer {
         } else {
             realLength = shortLength;
         }
-        byte[] buffer = new byte[shortLength];
+        byte[] buffer = new byte[realLength];
         self.readBytes(buffer);
         return CompressedStreamTools.func_152457_a(buffer, new NBTSizeTracker(Common.config.maxNetworkNbtSizeLimit));
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.PacketBuffer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.mitchej123.hodgepodge.Common;
+
+@Mixin(PacketBuffer.class)
+public class MixinPacketBuffer {
+    @ModifyArg(
+            method = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTSizeTracker;<init>(J)V"))
+    private long hodgepodge$modifyMaxNetworkNBTSizeLimit(long original) {
+        return Common.config.maxNetworkNbtSizeLimit;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPacketBuffer.java
@@ -10,6 +10,7 @@ import com.mitchej123.hodgepodge.Common;
 
 @Mixin(PacketBuffer.class)
 public class MixinPacketBuffer {
+
     @ModifyArg(
             method = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTSizeTracker;<init>(J)V"))

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS3FPacketCustomPayload_LengthLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS3FPacketCustomPayload_LengthLimit.java
@@ -1,0 +1,56 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.packets;
+
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S3FPacketCustomPayload;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.mixins.early.minecraft.MixinMessageSerializer2;
+import com.mitchej123.hodgepodge.util.PacketSerializationHelper;
+
+import io.netty.buffer.ByteBuf;
+
+@Mixin(S3FPacketCustomPayload.class)
+public abstract class MixinS3FPacketCustomPayload_LengthLimit extends Packet {
+
+    /**
+     * @reason Customizable packet length limit. Requires {@link MixinMessageSerializer2}.
+     */
+    @ModifyConstant(method = "<init>(Ljava/lang/String;[B)V", constant = @Constant(intValue = 0x1FFF9A))
+    private int hodgepodge$increasePacketSizeLimit(int original) {
+        return Common.config.packetSizeLimit;
+    }
+
+    @ModifyConstant(
+            method = "<init>(Ljava/lang/String;[B)V",
+            constant = @Constant(stringValue = "Payload may not be larger than 2097050 bytes"))
+    private String hodgepodge$increasePacketSizeLimitInErrorMsg(String original) {
+        return "Payload may not be larger than " + Common.config.packetSizeLimit
+                + " bytes (configurable in Hodgepodge)";
+    }
+
+    @Redirect(
+            method = "readPacketData(Lnet/minecraft/network/PacketBuffer;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/network/ByteBufUtils;readVarShort(Lio/netty/buffer/ByteBuf;)I"),
+            remap = false)
+    private static int hodgepodge$readLongerPacketData(ByteBuf buf) {
+        return PacketSerializationHelper.readExtendedVarShortOrInt(buf);
+    }
+
+    @Redirect(
+            method = "writePacketData(Lnet/minecraft/network/PacketBuffer;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/network/ByteBufUtils;writeVarShort(Lio/netty/buffer/ByteBuf;I)V"),
+            remap = false)
+    private static void hodgepodge$writeLongerPacketData(ByteBuf buf, int toWrite) {
+        PacketSerializationHelper.writeExtendedVarShortOrInt(buf, toWrite);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS3FPacketCustomPayload_LengthLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS3FPacketCustomPayload_LengthLimit.java
@@ -40,7 +40,7 @@ public abstract class MixinS3FPacketCustomPayload_LengthLimit extends Packet {
                     value = "INVOKE",
                     target = "Lcpw/mods/fml/common/network/ByteBufUtils;readVarShort(Lio/netty/buffer/ByteBuf;)I"),
             remap = false)
-    private static int hodgepodge$readLongerPacketData(ByteBuf buf) {
+    private int hodgepodge$readLongerPacketData(ByteBuf buf) {
         return PacketSerializationHelper.readExtendedVarShortOrInt(buf);
     }
 
@@ -50,7 +50,7 @@ public abstract class MixinS3FPacketCustomPayload_LengthLimit extends Packet {
                     value = "INVOKE",
                     target = "Lcpw/mods/fml/common/network/ByteBufUtils;writeVarShort(Lio/netty/buffer/ByteBuf;I)V"),
             remap = false)
-    private static void hodgepodge$writeLongerPacketData(ByteBuf buf, int toWrite) {
+    private void hodgepodge$writeLongerPacketData(ByteBuf buf, int toWrite) {
         PacketSerializationHelper.writeExtendedVarShortOrInt(buf, toWrite);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS3FPacketCustomPayload_Validation.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS3FPacketCustomPayload_Validation.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.mitchej123.hodgepodge.util.PacketPrevalidation;
 
 @Mixin(S3FPacketCustomPayload.class)
-public abstract class MixinS3FPacketCustomPayload extends Packet {
+public abstract class MixinS3FPacketCustomPayload_Validation extends Packet {
 
     /**
      * @author eigenraven

--- a/src/main/java/com/mitchej123/hodgepodge/util/PacketSerializationHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PacketSerializationHelper.java
@@ -33,7 +33,7 @@ public class PacketSerializationHelper {
     public static void writeExtendedVarShortOrInt(ByteBuf buf, int toWrite) {
         if (toWrite != (toWrite & 0x7F_FFFF) || toWrite == 0x7F_FFFF) {
             // too large to fit in the original representation
-            buf.writeShort(0xFFFFF);
+            buf.writeShort(0xFF_FFFF);
             buf.writeByte(0xFF);
             ByteBufUtils.writeVarInt(buf, toWrite, 5);
             return;

--- a/src/main/java/com/mitchej123/hodgepodge/util/PacketSerializationHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/PacketSerializationHelper.java
@@ -1,0 +1,88 @@
+package com.mitchej123.hodgepodge.util;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/** Utilities for extending the packet serialization format */
+public class PacketSerializationHelper {
+
+    /**
+     * Behaves like {@link cpw.mods.fml.common.network.ByteBufUtils#readVarShort(ByteBuf)} for values smaller than 21
+     * bits, or reads a full integer if larger.
+     */
+    public static int readExtendedVarShortOrInt(ByteBuf buf) {
+        int low = buf.readUnsignedShort();
+        int high = 0;
+        if ((low & 0x8000) != 0) {
+            low = low & 0x7FFF;
+            high = buf.readUnsignedByte();
+        }
+        final int shortValue = ((high & 0xFF) << 15) | low;
+        if (shortValue != 0x7F_FFFF) {
+            return shortValue;
+        } else {
+            return ByteBufUtils.readVarInt(buf, 5);
+        }
+    }
+
+    /**
+     * Behaves like {@link cpw.mods.fml.common.network.ByteBufUtils#writeVarShort(ByteBuf, int)} for values smaller than
+     * 21 bits, or reads a full integer if larger.
+     */
+    public static void writeExtendedVarShortOrInt(ByteBuf buf, int toWrite) {
+        if (toWrite != (toWrite & 0x7F_FFFF) || toWrite == 0x7F_FFFF) {
+            // too large to fit in the original representation
+            buf.writeShort(0xFFFFF);
+            buf.writeByte(0xFF);
+            ByteBufUtils.writeVarInt(buf, toWrite, 5);
+            return;
+        }
+        int low = toWrite & 0x7FFF;
+        int high = (toWrite & 0x7F8000) >> 15;
+        if (high != 0) {
+            low = low | 0x8000;
+        }
+        buf.writeShort(low);
+        if (high != 0) {
+            buf.writeByte(high);
+        }
+    }
+
+    private static void validateExtendedShort(ByteBuf scratch, int value) {
+        scratch.clear();
+        writeExtendedVarShortOrInt(scratch, value);
+        final int readback = readExtendedVarShortOrInt(scratch);
+        if (value != readback) {
+            System.err.printf("0x%08x != 0x%08x%n", value, readback);
+            throw new RuntimeException("mismatch");
+        }
+        if (scratch.isReadable()) {
+            System.err.printf("0x%08x overflow%n", value);
+            throw new RuntimeException("overflow");
+        }
+        if (value >= 0 && value < 0x7F_FFFF) {
+            scratch.resetReaderIndex();
+            final int fmlReadback = ByteBufUtils.readVarShort(scratch);
+            if (fmlReadback != value) {
+                System.err.printf("FML: 0x%08x != 0x%08x%n", value, fmlReadback);
+                throw new RuntimeException("FML mismatch");
+            }
+        }
+    }
+
+    // A simple test program to validate the implementation for all possible encodings
+    // This is quite slow to run through, so not automatically tested.
+    public static void main(String[] args) {
+        final ByteBuf scratchBuffer = Unpooled.buffer(16);
+        for (int value = 0; value < Integer.MAX_VALUE; value++) {
+            if (value % 0x1000_0000 == 0) {
+                System.out.printf("Checking 0x%08x%n", value);
+            }
+            validateExtendedShort(scratchBuffer, value);
+        }
+        validateExtendedShort(scratchBuffer, Integer.MAX_VALUE); // Can't iterate to MAX_VALUE without causing an
+                                                                 // integer overflow
+        System.out.println("All positive integers checked.");
+    }
+}


### PR DESCRIPTION
This adds configurable size limits for the network packet sizes and decoded NBT sizes, and bumps the vanilla limits from 2MB to 256MB.