### PR TITLE
Fix broken tile entity lighting caused by Thaumcraft's advanced alchemical furnace

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -34,6 +34,7 @@ public class LoadingConfig {
 
     public boolean changeSprintCategory;
     public boolean enlargePotionArray;
+    public boolean fixAdvAlchemicalFurnaceLighting;
     public boolean fixBetterHUDArmorDisplay;
     public boolean fixBetterHUDHPDisplay;
     public int betterHUDHPRenderLimit;
@@ -232,6 +233,7 @@ public class LoadingConfig {
         enableTileRendererProfiler = config.get(Category.TWEAKS.toString(), "enableTileRendererProfiler", true, "Shows renderer's impact on FPS in vanilla lagometer").getBoolean();
 
         changeSprintCategory = config.get(Category.TWEAKS.toString(), "changeSprintCategory", true, "Moves the sprint keybind to the movement category").getBoolean();
+        fixAdvAlchemicalFurnaceLighting = config.get(Category.FIXES.toString(), "fixAdvAlchemicalFurnaceLighting", true, "Fix Advanced Alchemical Furnace causing other tile entities to be incorrectly lit when active and visible").getBoolean();
         fixContainerPutStacksInSlots = config.get(Category.FIXES.toString(), "fixContainerPutStacksInSlots", true, "Prevents crash if server sends container with wrong itemStack size").getBoolean();
         fixChatWrappedColors = config.get(Category.FIXES.toString(), "fixChatWrappedColors", true, "Fix wrapped chat lines missing colors").getBoolean();
         fixComponentsPoppingOff = config.get(Category.TWEAKS.toString(), "fixComponentsPoppingOff", true, "Fix Project Red components popping off on unloaded chunks").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -409,6 +409,10 @@ public enum Mixins {
             .setPhase(Phase.LATE).setSide(Side.BOTH)
             .addMixinClasses("thaumcraft.MixinEntityGolemBase", "thaumcraft.MixinItemGolemBell")
             .setApplyIf(() -> Common.config.fixThaumcraftGolemMarkerLoading).addTargetedMod(TargetedMod.THAUMCRAFT)),
+    FIX_ALCHEMY_FURNACE_ADVANCED_RENDERING(new Builder("Fix Advanced Alchemical Furnace breaking tile entity lighting")
+            .setPhase(Phase.LATE).setSide(Side.CLIENT)
+            .addMixinClasses("thaumcraft.MixinTileAlchemyFurnaceAdvancedRenderer")
+            .setApplyIf(() -> Common.config.fixAdvAlchemicalFurnaceLighting).addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // BOP
     FIX_QUICKSAND_XRAY(new Builder("Fix Xray through block without collision boundingBox").setPhase(Phase.LATE)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinTileAlchemyFurnaceAdvancedRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinTileAlchemyFurnaceAdvancedRenderer.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
+
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import thaumcraft.client.renderers.tile.TileAlchemyFurnaceAdvancedRenderer;
+
+@Mixin(value = TileAlchemyFurnaceAdvancedRenderer.class)
+public abstract class MixinTileAlchemyFurnaceAdvancedRenderer extends TileEntitySpecialRenderer {
+
+    @Redirect(
+            at = @At(
+                    target = "Lnet/minecraft/client/renderer/RenderHelper;disableStandardItemLighting()V",
+                    value = "INVOKE"),
+            method = "renderQuadCenteredFromIcon")
+    public void hodgepodge$disableStandardItemLighting() {
+        GL11.glDisable(GL11.GL_LIGHTING);
+    }
+
+    @Redirect(
+            at = @At(
+                    target = "Lnet/minecraft/client/renderer/RenderHelper;enableStandardItemLighting()V",
+                    value = "INVOKE"),
+            method = "renderQuadCenteredFromIcon")
+    public void hodgepodge$enableStandardItemLighting() {
+        GL11.glEnable(GL11.GL_LIGHTING);
+    }
+}


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#15066
This seemed to be caused by the way the fire effect on a powered advanced alchemical furnace is rendered, it disables lighting then reenables it, but also resets a bunch of lighting related parameters in the process, causing all tile entities after it to be rendered with incorrect lighting.

Here's a before/after for comparison:
![comparison](https://github.com/GTNewHorizons/Hodgepodge/assets/5514779/5edd7407-0bb2-424c-aaf2-9bd24cf0beb2)
