### PR TITLE
Thermal Dynamics NASE Prevention

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,6 +40,7 @@ dependencies {
     transformedModCompileOnly(deobfCurse("automagy-222153:2285272"))
     transformedModCompileOnly("com.github.GTNewHorizons:Galacticraft:3.1.2-GTNH:dev")
     transformedModCompileOnly("curse.maven:minechem-368422:2905830")
+    transformedModCompileOnly("curse.maven:thermal-dynamics-227443:2388756")
     transformedModCompileOnly(deobfCurse("projecte-226410:2340786"))
     transformedModCompileOnly(deobfCurse("better-hud-286066:2523840"))
     transformedModCompileOnly("curse.maven:immersive-engineering-231951:2299019")

--- a/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoadingConfig.java
@@ -165,6 +165,7 @@ public class LoadingConfig {
     public boolean fixVoxelMapYCoord;
     public boolean fixVoxelMapChunkNPE;
     public boolean fixRedstoneTorchWorldLeak;
+    public boolean preventThermalDynamicsNASE;
 
     // render debug
     public boolean renderDebug;
@@ -368,7 +369,7 @@ public class LoadingConfig {
         fixVoxelMapYCoord = config.get(Category.FIXES.toString(), "fixVoxelMapYCoord", true, "Fix Y coordinate being off by one").getBoolean();
         fixVoxelMapChunkNPE = config.get(Category.FIXES.toString(), "fixVoxelMapChunkNPE", true, "Fix some NullPointerExceptions").getBoolean();
         fixRedstoneTorchWorldLeak = config.get(Category.FIXES.toString(), "fixRedstoneTorchWorldLeak", true, "Fix redstone torch leaking world").getBoolean();
-
+        preventThermalDynamicsNASE = config.get(Category.FIXES.toString(), "preventThermalDynamicsNASE", true, "Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers").getBoolean();
 
         // Pollution :nauseous:
         pollutionBlockRecolor = config.get(Category.POLLUTION_RECOLOR.toString(), "pollutionRecolor", true, "Changes colors of certain blocks based on pollution levels").getBoolean();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -647,7 +647,11 @@ public enum Mixins {
                     .addTargetedMod(TargetedMod.GALACTICRAFT_CORE)),
     IC2_CELL(new Builder("No IC2 Cell Consumption in tanks").addMixinClasses("ic2.MixinIC2ItemCell")
             .setPhase(Phase.LATE).setSide(Side.BOTH).setApplyIf(() -> Common.config.ic2CellWithContainer)
-            .addTargetedMod(TargetedMod.IC2));
+            .addTargetedMod(TargetedMod.IC2)),
+    TD_NASE_PREVENTION(new Builder("Prevent NegativeArraySizeException on itemduct transfers")
+            .addMixinClasses("thermaldynamics.MixinSimulatedInv").setSide(Side.BOTH)
+            .setApplyIf(() -> Common.config.preventThermalDynamicsNASE).addTargetedMod(TargetedMod.THERMALDYNAMICS)
+            .setPhase(Phase.LATE));
 
     private final List<String> mixinClasses;
     private final List<TargetedMod> targetedMods;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -35,6 +35,7 @@ public enum TargetedMod {
     PROJECTE("ProjectE", null, "ProjectE"),
     RAILCRAFT("Railcraft", null, "Railcraft"),
     THAUMCRAFT("Thaumcraft", null, "Thaumcraft"), // "thaumcraft.codechicken.core.launch.DepLoader"
+    THERMALDYNAMICS("Thermal Dynamics", null, "ThermalDynamics"),
     TINKERSCONSTRUCT("TConstruct", null, "TConstruct"),
     EXTRATIC("ExtraTiC", null, "ExtraTiC"),
     TRAVELLERSGEAR("TravellersGear", null, "TravellersGear"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thermaldynamics/MixinSimulatedInv.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thermaldynamics/MixinSimulatedInv.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.late.thermaldynamics;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import cofh.thermaldynamics.duct.item.SimulatedInv;
+
+@Mixin(SimulatedInv.class)
+public class MixinSimulatedInv {
+
+    @Shadow(remap = false)
+    ItemStack[] items;
+
+    @Inject(method = "func_70301_a", at = @At("HEAD"), remap = false, cancellable = true)
+    public void func_70301_a(int par1, CallbackInfoReturnable<ItemStack> cir) {
+        if (this.items.length <= par1) {
+            cir.setReturnValue(null);
+        }
+    }
+
+    @Inject(method = "func_70304_b", at = @At("HEAD"), remap = false, cancellable = true)
+    public void func_70304_b(int par1, CallbackInfoReturnable<ItemStack> cir) {
+        if (this.items.length <= par1) {
+            cir.setReturnValue(null);
+        }
+    }
+}


### PR DESCRIPTION
Adds checks to prevent `NegativeArraySizeException` with Thermal Dynamics upon transferring items into invalid inventories.

Where it would previously be stuck on a crashing loop with mods like Nuclearcraft, now it will simply cancels that operation.