### PR TITLE
Add config option to manually configure autosave interval

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -170,6 +170,10 @@ public class TweaksConfig {
     @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean fastBlockPlacing;
+    @Config.Comment("Sets the interval for auto saves in ticks (20 ticks = 1 second)")
+    @Config.RangeInt(min = 1)
+    @Config.DefaultInt(900)
+    public static int autoSaveInterval;
 
     @Config.Comment("Stops rendering potion particles from yourself")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -345,6 +345,10 @@ public enum Mixins {
             .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinRegionFile")
             .setApplyIf(() -> FixesConfig.remove2MBChunkLimit)),
 
+    AUTOSAVE_INTERVAL(new Builder("Sets the auto save interval in ticks").setPhase(Phase.EARLY).setSide(Side.BOTH)
+            .addTargetedMod(TargetedMod.VANILLA)
+            .addMixinClasses("minecraft.MixinMinecraftServer").setApplyIf(() -> TweaksConfig.autoSaveInterval != 900)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraftServer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraftServer.java
@@ -1,0 +1,17 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+
+    @ModifyConstant(method = "tick", constant = @Constant(intValue = 900))
+    private int modifyAutoSaveInterval(int constant) {
+        return TweaksConfig.autoSaveInterval;
+    }
+
+}


### PR DESCRIPTION
This adds a config option to be able to configure the autosave interval. The default for this is 900 ticks or 45 seconds. This itself is quite arbitrary and its useless that its configurable because the autosave itself can take quite long especially in large bases. 
Here is an example of how long a tick with an autosave takes on our server:

![image](https://github.com/GTNewHorizons/Hodgepodge/assets/45769595/270c6602-fd1b-47c7-81e2-371464bc0bdf)
 