### PR TITLE
Fix Class Name Typo in Forge

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -81,6 +81,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean fixForgeUpdateChecker;
+    @Config.Comment("Fix a class name typo in MinecraftForge's initialize method")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixEffectRendererClassTypo;
     @Config.Comment("Fix vanilla issue where player sounds register as animal sounds")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -140,6 +140,9 @@ public enum Mixins {
     FORGE_UPDATE_CHECK_FIX(new Builder("Fix the forge update checker").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("forge.MixinForgeVersion_FixUpdateCheck")
             .setApplyIf(() -> FixesConfig.fixForgeUpdateChecker).addTargetedMod(TargetedMod.VANILLA)),
+    FORGE_FIX_CLASS_TYPO(new Builder("Fix a class name typo in MinecraftForge's initialize method")
+            .setPhase(Phase.EARLY).setSide(Side.BOTH).addMixinClasses("forge.MixinMinecraftForge")
+            .setApplyIf(() -> FixesConfig.fixEffectRendererClassTypo).addTargetedMod(TargetedMod.VANILLA)),
     NORTHWEST_BIAS_FIX(new Builder("Fix Northwest Bias").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("minecraft.MixinRandomPositionGenerator").setApplyIf(() -> FixesConfig.fixNorthWestBias)
             .addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinMinecraftForge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinMinecraftForge.java
@@ -1,0 +1,44 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(MinecraftForge.class)
+public class MixinMinecraftForge {
+
+    @ModifyConstant(
+            constant = @Constant(stringValue = "net.minecraft.client.particle,EffectRenderer$1"),
+            method = "initialize",
+            remap = false)
+    private static String hodgepodge$EffectRenderer$1(String original) {
+        return "net.minecraft.client.particle.EffectRenderer$1";
+    }
+
+    @ModifyConstant(
+            constant = @Constant(stringValue = "net.minecraft.client.particle,EffectRenderer$2"),
+            method = "initialize",
+            remap = false)
+    private static String hodgepodge$EffectRenderer$2(String original) {
+        return "net.minecraft.client.particle.EffectRenderer$2";
+    }
+
+    @ModifyConstant(
+            constant = @Constant(stringValue = "net.minecraft.client.particle,EffectRenderer$3"),
+            method = "initialize",
+            remap = false)
+    private static String hodgepodge$EffectRenderer$3(String original) {
+        return "net.minecraft.client.particle.EffectRenderer$3";
+    }
+
+    @ModifyConstant(
+            constant = @Constant(stringValue = "net.minecraft.client.particle,EffectRenderer$4"),
+            method = "initialize",
+            remap = false)
+    private static String hodgepodge$EffectRenderer$4(String original) {
+        return "net.minecraft.client.particle.EffectRenderer$4";
+    }
+
+}


### PR DESCRIPTION
Fixes [these](https://github.com/MinecraftForge/MinecraftForge/blob/1.7.10/src/main/java/net/minecraftforge/common/MinecraftForge.java#L115-L118) class names, which contain `,` instead of `.`.