### PR TITLE
Add server control for fast block placing

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -22,6 +22,7 @@ public class ClientKeyListener {
 
     private static String fastBlockPlacingEnabled = StatCollector.translateToLocal("key.fastBlockPlacing.enabled");
     private static String fastBlockPlacingDisabled = StatCollector.translateToLocal("key.fastBlockPlacing.disabled");
+    private static String fastBlockPlacingServerDisabled = StatCollector.translateToLocal("key.fastBlockPlacing.serverDisabled");
 
     public static KeyBinding FastBlockPlacingKey = new KeyBinding(
             "key.fastBlockPlacing.desc",
@@ -43,6 +44,15 @@ public class ClientKeyListener {
             }
         } else {
             if (FastBlockPlacingKey.isPressed()) {
+                if (!TweaksConfig.fastBlockPlacingServerControl){
+                    AboveHotbarHUD.renderTextAboveHotbar(
+                            fastBlockPlacingServerDisabled,
+                            40,
+                            false,
+                            false);
+                    return;
+                }
+
                 TweaksConfig.fastBlockPlacing = !TweaksConfig.fastBlockPlacing;
                 AboveHotbarHUD.renderTextAboveHotbar(
                         (TweaksConfig.fastBlockPlacing ? fastBlockPlacingEnabled : fastBlockPlacingDisabled),

--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -22,7 +22,8 @@ public class ClientKeyListener {
 
     private static String fastBlockPlacingEnabled = StatCollector.translateToLocal("key.fastBlockPlacing.enabled");
     private static String fastBlockPlacingDisabled = StatCollector.translateToLocal("key.fastBlockPlacing.disabled");
-    private static String fastBlockPlacingServerDisabled = StatCollector.translateToLocal("key.fastBlockPlacing.serverDisabled");
+    private static String fastBlockPlacingServerDisabled = StatCollector
+            .translateToLocal("key.fastBlockPlacing.serverDisabled");
 
     public static KeyBinding FastBlockPlacingKey = new KeyBinding(
             "key.fastBlockPlacing.desc",
@@ -44,12 +45,8 @@ public class ClientKeyListener {
             }
         } else {
             if (FastBlockPlacingKey.isPressed()) {
-                if (!TweaksConfig.fastBlockPlacingServerControl){
-                    AboveHotbarHUD.renderTextAboveHotbar(
-                            fastBlockPlacingServerDisabled,
-                            40,
-                            false,
-                            false);
+                if (!TweaksConfig.fastBlockPlacingServerControl) {
+                    AboveHotbarHUD.renderTextAboveHotbar(fastBlockPlacingServerDisabled, 40, false, false);
                     return;
                 }
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -168,8 +168,11 @@ public class TweaksConfig {
     public static boolean modernPickBlock;
     @Config.Comment("Allows blocks to be placed at a faster rate (toggleable via keybind)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean fastBlockPlacing;
+
+    @Config.Comment("Server control for fast block placing; if false, the client-side setting will be ignored and keybind will do nothing")
+    @Config.DefaultBoolean(true)
+    public static boolean fastBlockPlacingServerControl;
 
     @Config.Comment("Stops rendering potion particles from yourself")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FastBlockPlacing.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FastBlockPlacing.java
@@ -40,6 +40,7 @@ public class MixinMinecraft_FastBlockPlacing {
                     remap = false,
                     shift = At.Shift.AFTER))
     private void hodgepodge$func_147121_ag(CallbackInfo ci) {
+        if (!TweaksConfig.fastBlockPlacingServerControl) return;
         if (!TweaksConfig.fastBlockPlacing) return;
         if (thePlayer == null || thePlayer.isUsingItem()) return;
         if (objectMouseOver == null) return;

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
@@ -33,7 +33,6 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
         return fastBlockPlacingServerControl;
     }
 
-
     public boolean isLongerSentMessages() {
         return longerSentMessages;
     }
@@ -42,7 +41,7 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
     public IMessage onMessage(MessageConfigSync message, MessageContext ctx) {
         TweaksConfig.longerSentMessages = message.isLongerSentMessages();
 
-        if (!message.isFastBlockPlacingServerControl()){
+        if (!message.isFastBlockPlacingServerControl()) {
             TweaksConfig.fastBlockPlacing = false;
             TweaksConfig.fastBlockPlacingServerControl = false;
         }

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
@@ -10,20 +10,29 @@ import io.netty.buffer.ByteBuf;
 public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfigSync, IMessage> {
 
     private boolean longerSentMessages;
+    private boolean fastBlockPlacingServerControl;
 
     public MessageConfigSync() {
         longerSentMessages = TweaksConfig.longerSentMessages;
+        fastBlockPlacingServerControl = TweaksConfig.fastBlockPlacingServerControl;
     }
 
     @Override
     public void fromBytes(ByteBuf buf) {
         longerSentMessages = buf.readBoolean();
+        fastBlockPlacingServerControl = buf.readBoolean();
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeBoolean(longerSentMessages);
+        buf.writeBoolean(fastBlockPlacingServerControl);
     }
+
+    public boolean isFastBlockPlacingServerControl() {
+        return fastBlockPlacingServerControl;
+    }
+
 
     public boolean isLongerSentMessages() {
         return longerSentMessages;
@@ -32,6 +41,11 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
     @Override
     public IMessage onMessage(MessageConfigSync message, MessageContext ctx) {
         TweaksConfig.longerSentMessages = message.isLongerSentMessages();
+
+        if (!message.isFastBlockPlacingServerControl()){
+            TweaksConfig.fastBlockPlacing = false;
+            TweaksConfig.fastBlockPlacingServerControl = false;
+        }
 
         return null;
     }


### PR DESCRIPTION
Adds server side control for the fast block placing mixin.
If disabled on the server, the mixin is disabled and the keybind will do nothing

Needs testing in game.