### PR TITLE
Apply fasterRemoveAll to Entities too

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
@@ -6,7 +6,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,9 +18,9 @@ public class MixinWorldUpdateEntities {
     @Redirect(
             method = "updateEntities",
             at = @At(value = "INVOKE", target = "Ljava/util/List;removeAll(Ljava/util/Collection;)Z"))
-    public boolean fasterRemoveAll(List<TileEntity> targetList, Collection<TileEntity> collectionToRemove) {
+    public <E> boolean fasterRemoveAll(List<E> targetList, Collection<E> collectionToRemove) {
         // Borrowed from Forge for 1.12.2 -- forge: faster "contains" makes this removal much more efficient
-        final Set<TileEntity> setToRemove = Collections.newSetFromMap(new IdentityHashMap<>());
+        final Set<E> setToRemove = Collections.newSetFromMap(new IdentityHashMap<>());
         setToRemove.addAll(collectionToRemove);
         return targetList.removeAll(setToRemove);
     }


### PR DESCRIPTION
Makes `fasterRemoveAll` apply to regular entities alongside tile entities by making the mixin slightly more generic.