### PR TITLE
Fix bogus FMLProxyPacket NPEs on integrated server crashes

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -17,6 +17,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean enlargePotionArray;
 
+    @Config.Comment("Fix bogus FMLProxyPacket NPEs on integrated server crashes.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixBogusIntegratedServerNPEs;
+
     @Config.Comment("Fix wrapped chat lines missing colors")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -189,6 +189,14 @@ public enum Mixins {
     FIX_HUGE_CHAT_KICK(new Builder("Fix huge chat kick").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("minecraft.MixinS02PacketChat").setApplyIf(() -> FixesConfig.fixHugeChatKick)
             .addTargetedMod(TargetedMod.VANILLA)),
+    FIX_BOGUS_INTEGRATED_SERVER_NPE(new Builder("Fix bogus FMLProxyPacket NPEs on integrated server crashes")
+            .setPhase(Phase.EARLY).setSide(Side.BOTH)
+            .addMixinClasses(
+                    "forge.MixinFMLProxyPacket",
+                    "forge.MixinFMLIndexedMessageToMessageCodec",
+                    "forge.MixinNetworkDispatcher",
+                    "minecraft.NetworkManagerAccessor")
+            .setApplyIf(() -> FixesConfig.fixBogusIntegratedServerNPEs).addTargetedMod(TargetedMod.VANILLA)),
 
     FIX_LOGIN_DIMENSION_ID_OVERFLOW(
             new Builder("Fix dimension id overflowing when a player first logins on a server").setPhase(Phase.EARLY)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinFMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinFMLIndexedMessageToMessageCodec.java
@@ -1,0 +1,46 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mitchej123.hodgepodge.mixins.hooks.NetworkDispatcherFallbackLookup;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.network.FMLIndexedMessageToMessageCodec;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.handshake.NetworkDispatcher;
+import cpw.mods.fml.common.network.internal.FMLProxyPacket;
+import cpw.mods.fml.relauncher.Side;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageCodec;
+
+@Mixin(value = FMLIndexedMessageToMessageCodec.class, remap = false)
+public abstract class MixinFMLIndexedMessageToMessageCodec<A> extends MessageToMessageCodec<FMLProxyPacket, A> {
+
+    /**
+     * Early handshake FMLProxyPackets don't have the dispatcher field set to the channel dispatcher. This leads to a
+     * NullPointerException in the packet error handling code, leading to a very confusing crash report. Here, we try to
+     * extract the real dispatcher using various possible attributes, until resorting to guessing based on the current
+     * thread.
+     */
+    @Inject(method = "encode", at = @At("TAIL"))
+    public void hodgepodge$addMissingDispatcher(ChannelHandlerContext ctx, A msg, List<Object> out, CallbackInfo ci,
+            @Local(name = "proxy") FMLProxyPacket proxy) {
+        if (proxy.getDispatcher() == null) {
+            NetworkDispatcher fallback = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
+            if (fallback == null) {
+                Side side = ctx.channel().attr(NetworkRegistry.CHANNEL_SOURCE).get();
+                if (side == null) {
+                    side = FMLCommonHandler.instance().getEffectiveSide();
+                }
+                fallback = NetworkDispatcherFallbackLookup.getFallbackDispatcher(side);
+            }
+            proxy.setDispatcher(fallback);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinFMLProxyPacket.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinFMLProxyPacket.java
@@ -1,0 +1,71 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraft.network.Packet;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.mixins.hooks.NetworkDispatcherFallbackLookup;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.network.handshake.NetworkDispatcher;
+import cpw.mods.fml.common.network.internal.FMLProxyPacket;
+import cpw.mods.fml.relauncher.Side;
+
+@Mixin(value = FMLProxyPacket.class)
+public abstract class MixinFMLProxyPacket extends Packet {
+
+    @Shadow(remap = false)
+    private Side target;
+
+    @ModifyArg(
+            method = "processPacket",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/FMLLog;log(Lorg/apache/logging/log4j/Level;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V",
+                    ordinal = 1,
+                    remap = false))
+    public Throwable hodgepodge$captureThrowable(Throwable e,
+            @Share("throwable") LocalRef<Throwable> throwableStorage) {
+        throwableStorage.set(e);
+        return e;
+    }
+
+    @Redirect(
+            method = "processPacket",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/network/handshake/NetworkDispatcher;rejectHandshake(Ljava/lang/String;)V",
+                    remap = false),
+            expect = 2)
+    public void hodgepodge$rejectHandshakeNullSafe(NetworkDispatcher dispatcher, String message,
+            @Share("throwable") LocalRef<Throwable> throwableStorage) {
+        // If on a client/integrated server, use the real exception message for a more useful error screen.
+        // Keep the real exception masked on dedicated servers to avoid leaking private information.
+        if (FMLCommonHandler.instance().getSide().isClient()
+                && "A fatal error has occured, this connection is terminated".equals(message)) {
+            final Throwable t = throwableStorage.get();
+            message = "A fatal error has occurred during the network handshake, this connection is terminated. Check the log for details. The exception caught was: "
+                    + t;
+        }
+
+        if (dispatcher == null) {
+            dispatcher = NetworkDispatcherFallbackLookup.getFallbackDispatcher(this.target);
+        }
+
+        if (dispatcher == null) {
+            // The absolute final fallback to avoid NPEs here
+            Common.log.warn("NetworkDispatcher is null, skipping rejectHandshake to avoid NPE");
+            Common.log.warn("The message would have been: {}", message);
+        } else {
+            dispatcher.rejectHandshake(message);
+        }
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinNetworkDispatcher.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinNetworkDispatcher.java
@@ -1,0 +1,52 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import java.lang.ref.WeakReference;
+
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.server.management.ServerConfigurationManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.mitchej123.hodgepodge.mixins.early.minecraft.NetworkManagerAccessor;
+import com.mitchej123.hodgepodge.mixins.hooks.NetworkDispatcherFallbackLookup;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.network.handshake.NetworkDispatcher;
+import cpw.mods.fml.relauncher.Side;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+@Mixin(NetworkDispatcher.class)
+public abstract class MixinNetworkDispatcher extends SimpleChannelInboundHandler<Packet>
+        implements ChannelOutboundHandler {
+
+    @Inject(method = "<init>(Lnet/minecraft/network/NetworkManager;)V", at = @At("RETURN"))
+    public void hodgepodge$setClientFallback(NetworkManager manager, CallbackInfo ci) {
+        NetworkDispatcherFallbackLookup.CLIENT_DISPATCHER = new WeakReference<>((NetworkDispatcher) (Object) this);
+    }
+
+    @Inject(
+            method = "<init>(Lnet/minecraft/network/NetworkManager;Lnet/minecraft/server/management/ServerConfigurationManager;)V",
+            at = @At("RETURN"))
+    public void hodgepodge$setServerFallback(NetworkManager manager, ServerConfigurationManager scm, CallbackInfo ci) {
+        NetworkDispatcherFallbackLookup.SERVER_DISPATCHER = new WeakReference<>((NetworkDispatcher) (Object) this);
+    }
+
+    @ModifyReturnValue(method = "get", at = @At("RETURN"), remap = false)
+    private static NetworkDispatcher hodgepodge$saferGet(NetworkDispatcher dispatcher, NetworkManager mgr) {
+        if (dispatcher != null) {
+            return dispatcher;
+        }
+        if (mgr != null) {
+            NetworkManagerAccessor accessor = (NetworkManagerAccessor) mgr;
+            return NetworkDispatcherFallbackLookup
+                    .getFallbackDispatcher(accessor.hodgepodge$isClientSide() ? Side.CLIENT : Side.SERVER);
+        }
+        return NetworkDispatcherFallbackLookup.getFallbackDispatcher(FMLCommonHandler.instance().getEffectiveSide());
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/NetworkManagerAccessor.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/NetworkManagerAccessor.java
@@ -1,0 +1,13 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.NetworkManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(NetworkManager.class)
+public interface NetworkManagerAccessor {
+
+    @Accessor(value = "isClientSide")
+    boolean hodgepodge$isClientSide();
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/NetworkDispatcherFallbackLookup.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/NetworkDispatcherFallbackLookup.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.hooks;
+
+import java.lang.ref.WeakReference;
+
+import cpw.mods.fml.common.network.handshake.NetworkDispatcher;
+import cpw.mods.fml.relauncher.Side;
+
+/**
+ * Forge doesn't properly set NetworkDispatcher objects on all of its networking objects, so we have to resort to
+ * caching them externally.
+ */
+public final class NetworkDispatcherFallbackLookup {
+
+    public static volatile WeakReference<NetworkDispatcher> CLIENT_DISPATCHER = new WeakReference<>(null);
+    public static volatile WeakReference<NetworkDispatcher> SERVER_DISPATCHER = new WeakReference<>(null);
+
+    private NetworkDispatcherFallbackLookup() {}
+
+    public static NetworkDispatcher getFallbackDispatcher(Side side) {
+        return switch (side) {
+            case CLIENT -> CLIENT_DISPATCHER.get();
+            case SERVER -> SERVER_DISPATCHER.get();
+        };
+    }
+}


### PR DESCRIPTION
When something throws an exception early in the server handshake process, a useless crash report is normally generated containing the following message:
```
java.lang.NullPointerException: Cannot invoke "cpw.mods.fml.common.network.handshake.NetworkDispatcher.rejectHandshake(String)" because "this.dispatcher" is null
        at RFB-Launch//cpw.mods.fml.common.network.internal.FMLProxyPacket.processPacket(FMLProxyPacket.java:110)
```
This mixin fixes that crash and a few other resulting errors, and results in a much more accurate error for the user with more details in the log:
![image](https://github.com/GTNewHorizons/Hodgepodge/assets/1017004/3c5eef32-afc9-4a9f-9e11-a72440b15b78)

The error can be reliably triggered by using the following event handler:
```java
import cpw.mods.fml.common.FMLCommonHandler;
import cpw.mods.fml.common.eventhandler.Event;
import cpw.mods.fml.common.eventhandler.SubscribeEvent;
import cpw.mods.fml.common.gameevent.PlayerEvent;
// ...
    FMLCommonHandler.instance().bus().register(this);
// ...
    @SubscribeEvent
    public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
        throw new RuntimeException("test");
    }
// ...
```