### PR TITLE
Change File Extension of VoxelMap Cache Files

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -114,7 +114,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
 }
 
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -249,4 +249,11 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static boolean hidePotionParticlesFromSelf;
 
+    // VoxelMap
+
+    @Config.Comment("Changes the file extension of VoxelMap's cache files from .zip to .data to stop the TechnicLauncher from deleting them when updating")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean changeCacheFileExtension;
+
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
@@ -1,5 +1,6 @@
 package com.mitchej123.hodgepodge.core;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,6 +18,7 @@ import com.mitchej123.hodgepodge.config.PollutionRecolorConfig;
 import com.mitchej123.hodgepodge.config.SpeedupsConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.mixins.Mixins;
+import com.mitchej123.hodgepodge.util.VoxelMapCacheMover;
 
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 
@@ -71,7 +73,9 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
     }
 
     @Override
-    public void injectData(Map<String, Object> data) {}
+    public void injectData(Map<String, Object> data) {
+        VoxelMapCacheMover.changeFileExtensions((File) data.get("mcLocation"));
+    }
 
     @Override
     public String getAccessTransformerClass() {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -652,6 +652,13 @@ public enum Mixins {
             .addMixinClasses("voxelmap.chunk.MixinCachedRegion", "voxelmap.chunk.MixinComparisonCachedRegion")
             .addTargetedMod(TargetedMod.VOXELMAP).setApplyIf(() -> FixesConfig.fixVoxelMapChunkNPE).setPhase(Phase.LATE)
             .setSide(Side.CLIENT)),
+    VOXELMAP_FILE_EXT(new Builder("Change VoxelMap cache file extension")
+            .addMixinClasses(
+                    "voxelmap.cache.MixinCachedRegion",
+                    "voxelmap.cache.MixinCachedRegion$1",
+                    "voxelmap.cache.MixinComparisonCachedRegion")
+            .addTargetedMod(TargetedMod.VOXELMAP).setApplyIf(() -> TweaksConfig.changeCacheFileExtension)
+            .setPhase(Phase.LATE).setSide(Side.CLIENT)),
 
     // Witchery
     DISABLE_POTION_ARRAY_EXTENDER(new Builder("Disable Witchery potion array extender")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/cache/MixinCachedRegion$1.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/cache/MixinCachedRegion$1.java
@@ -1,0 +1,14 @@
+package com.mitchej123.hodgepodge.mixins.late.voxelmap.cache;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(targets = "com.thevoxelbox.voxelmap.b.c")
+public class MixinCachedRegion$1 {
+
+    @ModifyConstant(constant = @Constant(stringValue = ".zip"), method = "run()V", remap = false)
+    private String hodgepodge$modifyExtension(String original) {
+        return ".data";
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/cache/MixinCachedRegion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/cache/MixinCachedRegion.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.voxelmap.cache;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import com.thevoxelbox.voxelmap.b.b;
+
+@Mixin(b.class)
+public class MixinCachedRegion {
+
+    @ModifyConstant(
+            constant = @Constant(stringValue = ".zip"),
+            method = { "catch()V", // void load()
+                    "const()V", // void loadCachedData()
+                    "if(Lcom/thevoxelbox/voxelmap/b/b;)V" }, // ? (synthetic method)
+            remap = false)
+    private static String hodgepodge$modifyExtension(String original) {
+        return ".data";
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/cache/MixinComparisonCachedRegion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/cache/MixinComparisonCachedRegion.java
@@ -1,0 +1,16 @@
+package com.mitchej123.hodgepodge.mixins.late.voxelmap.cache;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import com.thevoxelbox.voxelmap.b.h;
+
+@Mixin(h.class)
+public class MixinComparisonCachedRegion {
+
+    @ModifyConstant(constant = @Constant(stringValue = ".zip"), method = "if()V" /* void loadStored() */, remap = false)
+    private String hodgepodge$modifyExtension(String original) {
+        return ".data";
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/chunk/MixinCachedRegion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/chunk/MixinCachedRegion.java
@@ -12,7 +12,11 @@ import com.thevoxelbox.voxelmap.b.b;
 @Mixin(b.class)
 public class MixinCachedRegion {
 
-    @Inject(at = @At("HEAD"), cancellable = true, method = "do(Lnet/minecraft/world/chunk/Chunk;II)V", remap = false)
+    @Inject(
+            at = @At("HEAD"),
+            cancellable = true,
+            method = "do(Lnet/minecraft/world/chunk/Chunk;II)V", // void loadChunkData(Chunk, int, int)
+            remap = false)
     private void hodgepodge$loadChunkData(Chunk var1, int var2, int var3, CallbackInfo ci) {
         if (var1 == null) ci.cancel();
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/chunk/MixinComparisonCachedRegion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/voxelmap/chunk/MixinComparisonCachedRegion.java
@@ -12,7 +12,11 @@ import com.thevoxelbox.voxelmap.b.h;
 @Mixin(h.class)
 public class MixinComparisonCachedRegion {
 
-    @Inject(at = @At("HEAD"), cancellable = true, method = "do(Lnet/minecraft/world/chunk/Chunk;II)V", remap = false)
+    @Inject(
+            at = @At("HEAD"),
+            cancellable = true,
+            method = "do(Lnet/minecraft/world/chunk/Chunk;II)V", // void loadChunkData(Chunk, int, int)
+            remap = false)
     private void hodgepodge$loadChunkData(Chunk var1, int var2, int var3, CallbackInfo ci) {
         if (var1 == null) ci.cancel();
     }

--- a/src/main/java/com/mitchej123/hodgepodge/util/NBTTagCompoundConcurrentModificationException.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/NBTTagCompoundConcurrentModificationException.java
@@ -10,6 +10,7 @@ import codechicken.nei.util.NBTJson;
 
 public class NBTTagCompoundConcurrentModificationException extends ConcurrentModificationException {
 
+    private static final long serialVersionUID = -5251615046217506510L;
     private final Deque<String> keyChain = new ArrayDeque<>();
     private final String source;
     private Object fullTag;

--- a/src/main/java/com/mitchej123/hodgepodge/util/VoxelMapCacheMover.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/VoxelMapCacheMover.java
@@ -1,0 +1,65 @@
+package com.mitchej123.hodgepodge.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.regex.Pattern;
+
+import com.mitchej123.hodgepodge.Common;
+
+public class VoxelMapCacheMover {
+
+    public static void changeFileExtensions(File mcDir) {
+        final Path cache = mcDir.toPath().resolve("mods").resolve("VoxelMods").resolve("voxelMap").resolve("cache");
+        if (Files.notExists(cache)) {
+            return;
+        }
+        final Visitor visitor = new Visitor();
+        try {
+            Files.walkFileTree(cache, visitor);
+        } catch (IOException e) {
+            Common.log.error("Failed to walk cache file tree", e);
+            return;
+        }
+        Common.log.info(
+                "Successfully changed the extension of {} cache files ({} failed, {} ignored)",
+                visitor.renamed,
+                visitor.failed,
+                visitor.ignored);
+    }
+
+    private static class Visitor extends SimpleFileVisitor<Path> {
+
+        private static final Pattern PATTERN = Pattern.compile("-?\\d+,-?\\d+\\.zip");
+
+        private int renamed = 0;
+        private int failed = 0;
+        private int ignored = 0;
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            super.visitFile(file, attrs);
+
+            String name = file.getFileName().toString();
+            if (PATTERN.matcher(name).matches()) {
+                try {
+                    Files.move(file, file.resolveSibling(name.replace(".zip", ".data")));
+                    this.renamed++;
+                } catch (IOException e) {
+                    Common.log.warn("Failed to change extension of " + file + " to .data", e);
+                    this.failed++;
+                }
+            } else {
+                this.ignored++;
+            }
+
+            return FileVisitResult.CONTINUE;
+        }
+
+    }
+
+}


### PR DESCRIPTION
VoxelMap caches the map in ZIP files in `./mods/VoxelMods/voxelMap/cache/`. However, TechnicLauncher recursively deletes all mod files in the `./mods/` directory, which [includes `.zip` files](https://github.com/TechnicPack/LauncherV3/blob/master/src/main/java/net/technicpack/minecraftcore/install/tasks/CleanupAndExtractModpackTask.java#L126).
Previously, the cache had to be backed up before doing any update, otherwise everything except the waypoints would be lost. With this PR, the file extension will be changed to `.data`. All existing files will be renamed.