### PR TITLE
Fix egregious memory usage of Forge's Configuration class

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,7 +1,0 @@
-
-jar {
-    manifest {
-        // I need a place to call add this IClassTransformer before CoFHCore loads its transformation target
-        attributes "CCTransformer": "com.mitchej123.hodgepodge.asm.transformers.early.EarlyClassTransformer"
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,0 @@
-//version: 1707058017
-
-plugins {
-    id 'com.gtnewhorizons.gtnhconvention'
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,19 @@
+//version: 1707058017
+
+plugins {
+    id("com.gtnewhorizons.gtnhconvention")
+}
+
+tasks.jar {
+    manifest {
+        // I need a place to call add this IClassTransformer before CoFHCore loads its transformation target
+        attributes("CCTransformer" to "com.mitchej123.hodgepodge.asm.transformers.early.EarlyClassTransformer")
+    }
+}
+
+tasks.processResources {
+    inputs.property("version", project.version.toString())
+    filesMatching("META-INF/rfb-plugin/*") {
+        expand("version" to project.version.toString())
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,6 +14,8 @@ configurations {
 dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.2.11:dev")
 
+    compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.2") { transitive = false }
+
     transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.5.25-GTNH:dev") // force a more up-to-date NEI version
     transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-348-GTNH")
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")

--- a/src/main/java/com/mitchej123/hodgepodge/asm/EarlyConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/EarlyConfig.java
@@ -1,0 +1,48 @@
+package com.mitchej123.hodgepodge.asm;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Properties;
+
+import net.minecraft.launchwrapper.Launch;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public final class EarlyConfig {
+
+    private static final Logger LOGGER = LogManager.getLogger("HodgePodgeEarly");
+
+    public static final boolean noNukeBaseMod;
+    public static final boolean noLeanerForgeConfiguration;
+
+    static {
+        Properties config = new Properties();
+        File configLocation = new File(Launch.minecraftHome, "config/hodgepodgeEarly.properties");
+        try (Reader r = new BufferedReader(new FileReader(configLocation))) {
+            config.load(r);
+        } catch (FileNotFoundException e) {
+            LOGGER.debug("No existing configuration file. Will use defaults");
+        } catch (IOException e) {
+            LOGGER.error("Error reading configuration file. Will use defaults", e);
+        }
+        noNukeBaseMod = Boolean.parseBoolean(config.getProperty("noNukeBaseMod"));
+        config.setProperty("noNukeBaseMod", String.valueOf(noNukeBaseMod));
+        noLeanerForgeConfiguration = Boolean.parseBoolean(config.getProperty("noLeanerForgeConfiguration"));
+        config.setProperty("noLeanerForgeConfiguration", String.valueOf(noLeanerForgeConfiguration));
+        try (Writer r = new BufferedWriter(new FileWriter(configLocation))) {
+            config.store(r, "Configuration file for early hodgepodge class transformers");
+        } catch (IOException e) {
+            LOGGER.error("Error reading configuration file. Will use defaults", e);
+        }
+    }
+
+    public static void ensureLoaded() {}
+}

--- a/src/main/java/com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks.java
@@ -33,6 +33,8 @@ public class EarlyASMCallHooks {
 
     private static final String INT_MIN_STRING = Integer.toString(Integer.MIN_VALUE);
     private static final String INT_MAX_STRING = Integer.toString(Integer.MAX_VALUE);
+    private static final String DOUBLE_MAX_STRING = Double.toString(Double.MAX_VALUE);
+    private static final String DOUBLE_NEG_MAX_STRING = Double.toString(-Double.MAX_VALUE);
 
     public static String intToCachedString(int value) {
         return switch (value) {
@@ -48,6 +50,15 @@ public class EarlyASMCallHooks {
             case 100 -> "100";
             default -> String.valueOf(value).intern();
         };
+    }
+
+    public static String doubleToCachedString(double value) {
+        if (value == Double.MAX_VALUE) {
+            return DOUBLE_MAX_STRING;
+        } else if (value == -Double.MAX_VALUE) {
+            return DOUBLE_NEG_MAX_STRING;
+        }
+        return String.valueOf(value).intern();
     }
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];

--- a/src/main/java/com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks.java
@@ -30,4 +30,38 @@ public class EarlyASMCallHooks {
         }
         return null;
     }
+
+    private static final String INT_MIN_STRING = Integer.toString(Integer.MIN_VALUE);
+    private static final String INT_MAX_STRING = Integer.toString(Integer.MAX_VALUE);
+
+    public static String intToCachedString(int value) {
+        return switch (value) {
+            case Integer.MIN_VALUE -> INT_MIN_STRING;
+            case Integer.MAX_VALUE -> INT_MAX_STRING;
+            case 0 -> "0";
+            case 1 -> "1";
+            case 2 -> "2";
+            case 3 -> "3";
+            case 4 -> "4";
+            case 5 -> "5";
+            case 10 -> "10";
+            case 100 -> "100";
+            default -> String.valueOf(value).intern();
+        };
+    }
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    public static String[] internArray(String[] array) {
+        if (array == null) {
+            return null;
+        }
+        if (array.length == 0) {
+            return EMPTY_STRING_ARRAY;
+        }
+        for (int i = 0; i < array.length; i++) {
+            array[i] = (array[i] == null) ? null : array[i].intern();
+        }
+        return array;
+    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
@@ -1,7 +1,11 @@
 package com.mitchej123.hodgepodge.rfb;
 
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.objectweb.asm.Opcodes.POP;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 
 import java.util.jar.Manifest;
@@ -12,8 +16,10 @@ import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
 
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
@@ -23,7 +29,9 @@ import com.mitchej123.hodgepodge.asm.EarlyConfig;
 public class ForgeConfigurationTransformer implements RfbClassTransformer {
 
     private static final String EARLY_HOOKS_INTERNAL = "com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks";
+    private static final String CATEGORY_INTERNAL = "net/minecraftforge/common/config/ConfigCategory";
     private static final String PROPERTY_INTERNAL = "net/minecraftforge/common/config/Property";
+    private static final String OPEN_MAP_INTERNAL = "it/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMap";
 
     @Pattern("[a-z0-9-]+")
     @Override
@@ -36,7 +44,8 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer {
             @NotNull RfbClassTransformer.Context context, @Nullable Manifest manifest, @NotNull String className,
             @NotNull ClassNodeHandle classNode) {
         return (!EarlyConfig.noLeanerForgeConfiguration) && classNode.isPresent()
-                && className.equals("net.minecraftforge.common.config.Property");
+                && (className.equals("net.minecraftforge.common.config.Property")
+                        || className.equals("net.minecraftforge.common.config.ConfigCategory"));
     }
 
     @Override
@@ -55,37 +64,56 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer {
             }
             for (int i = 0; i < mn.instructions.size(); i++) {
                 final AbstractInsnNode aInsn = mn.instructions.get(i);
+                // Spotless keeps indenting each else-if to the right every time here for some reason
+                // spotless:off
                 if (aInsn.getOpcode() == INVOKESTATIC && aInsn instanceof MethodInsnNode mInsn) {
-                    if (("java/lang/String".equals(mInsn.owner) && "valueOf".equals(mInsn.name)
-                            && "(I)Ljava/lang/String;".equals(mInsn.desc))
-                            || ("java/lang/Integer".equals(mInsn.owner) && "toString".equals(mInsn.name)
-                                    && "(I)Ljava/lang/String;".equals(mInsn.desc))) {
+                    if (("java/lang/String".equals(mInsn.owner)
+                            && "valueOf".equals(mInsn.name)
+                            && "(I)Ljava/lang/String;".equals(mInsn.desc)) || ("java/lang/Integer".equals(mInsn.owner)
+                            && "toString".equals(mInsn.name)
+                            && "(I)Ljava/lang/String;".equals(mInsn.desc))) {
                         mInsn.owner = EARLY_HOOKS_INTERNAL;
                         mInsn.name = "intToCachedString";
+                    } else if (("java/lang/String".equals(mInsn.owner)
+                            && "valueOf".equals(mInsn.name)
+                            && "(D)Ljava/lang/String;".equals(mInsn.desc)) || ("java/lang/Double".equals(mInsn.owner)
+                            && "toString".equals(mInsn.name)
+                            && "(D)Ljava/lang/String;".equals(mInsn.desc))) {
+                        mInsn.owner = EARLY_HOOKS_INTERNAL;
+                        mInsn.name = "doubleToCachedString";
                     }
                 } else if (aInsn.getOpcode() == PUTFIELD && aInsn instanceof FieldInsnNode fInsn) {
-                    if (PROPERTY_INTERNAL.equals(fInsn.owner)
-                            && ("value".equals(fInsn.name) || "defaultValue".equals(fInsn.name))) {
-                        final MethodInsnNode intern = new MethodInsnNode(
-                                INVOKEVIRTUAL,
+                    if (PROPERTY_INTERNAL.equals(fInsn.owner) && ("value".equals(fInsn.name) || "defaultValue".equals(
+                            fInsn.name))) {
+                        final MethodInsnNode intern = new MethodInsnNode(INVOKEVIRTUAL,
                                 "java/lang/String",
                                 "intern",
                                 "()Ljava/lang/String;",
                                 false);
                         mn.instructions.insertBefore(fInsn, intern);
                         i++;
-                    } else if (PROPERTY_INTERNAL.equals(fInsn.owner)
-                            && ("values".equals(fInsn.name) || "defaultValues".equals(fInsn.name))) {
-                                final MethodInsnNode intern = new MethodInsnNode(
-                                        INVOKESTATIC,
-                                        EARLY_HOOKS_INTERNAL,
-                                        "internArray",
-                                        "([Ljava/lang/String;)[Ljava/lang/String;",
-                                        false);
-                                mn.instructions.insertBefore(fInsn, intern);
-                                i++;
-                            }
+                    } else if (PROPERTY_INTERNAL.equals(fInsn.owner) && ("values".equals(fInsn.name)
+                            || "defaultValues".equals(fInsn.name)
+                            || "validValues".equals(fInsn.name))) {
+                        final MethodInsnNode intern = new MethodInsnNode(INVOKESTATIC,
+                                EARLY_HOOKS_INTERNAL,
+                                "internArray",
+                                "([Ljava/lang/String;)[Ljava/lang/String;",
+                                false);
+                        mn.instructions.insertBefore(fInsn, intern);
+                        i++;
+                    } else if (CATEGORY_INTERNAL.equals(fInsn.owner)
+                            && "properties".equals(fInsn.name)
+                            && "<init>".equals(mn.name)) {
+                        mn.instructions.insertBefore(fInsn, new InsnNode(POP));
+                        mn.instructions.insertBefore(fInsn, new TypeInsnNode(NEW, OPEN_MAP_INTERNAL));
+                        mn.instructions.insertBefore(fInsn, new InsnNode(DUP));
+                        mn.instructions.insertBefore(fInsn,
+                                new MethodInsnNode(INVOKESPECIAL, OPEN_MAP_INTERNAL, "<init>", "()V", false));
+                        i += 4;
+                    }
                 }
+                // spotless:on
             }
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
@@ -26,6 +26,11 @@ import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
 import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
 import com.mitchej123.hodgepodge.asm.EarlyConfig;
 
+/**
+ * Reduces the memory usage of Forge's Configuration system significantly. Deduplicates identical strings, empty arrays
+ * and switches property maps from TreeMaps to fastutil open hashmaps. Measured in the full GTNH pack to offer a 45
+ * percent memory usage reduction for Configuration classes.
+ */
 public class ForgeConfigurationTransformer implements RfbClassTransformer {
 
     private static final String EARLY_HOOKS_INTERNAL = "com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks";

--- a/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
@@ -1,0 +1,92 @@
+package com.mitchej123.hodgepodge.rfb;
+
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.PUTFIELD;
+
+import java.util.jar.Manifest;
+
+import org.intellij.lang.annotations.Pattern;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
+import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
+import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
+import com.mitchej123.hodgepodge.asm.EarlyConfig;
+
+public class ForgeConfigurationTransformer implements RfbClassTransformer {
+
+    private static final String EARLY_HOOKS_INTERNAL = "com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks";
+    private static final String PROPERTY_INTERNAL = "net/minecraftforge/common/config/Property";
+
+    @Pattern("[a-z0-9-]+")
+    @Override
+    public @NotNull String id() {
+        return "forge-configuration";
+    }
+
+    @Override
+    public boolean shouldTransformClass(@NotNull ExtensibleClassLoader classLoader,
+            @NotNull RfbClassTransformer.Context context, @Nullable Manifest manifest, @NotNull String className,
+            @NotNull ClassNodeHandle classNode) {
+        return (!EarlyConfig.noLeanerForgeConfiguration) && classNode.isPresent()
+                && className.equals("net.minecraftforge.common.config.Property");
+    }
+
+    @Override
+    public void transformClass(@NotNull ExtensibleClassLoader classLoader, @NotNull RfbClassTransformer.Context context,
+            @Nullable Manifest manifest, @NotNull String className, @NotNull ClassNodeHandle classNode) {
+        final ClassNode cn = classNode.getNode();
+        if (cn == null) {
+            return;
+        }
+        if (cn.methods == null) {
+            return;
+        }
+        for (final MethodNode mn : cn.methods) {
+            if (mn.instructions == null || mn.instructions.size() == 0) {
+                continue;
+            }
+            for (int i = 0; i < mn.instructions.size(); i++) {
+                final AbstractInsnNode aInsn = mn.instructions.get(i);
+                if (aInsn.getOpcode() == INVOKESTATIC && aInsn instanceof MethodInsnNode mInsn) {
+                    if (("java/lang/String".equals(mInsn.owner) && "valueOf".equals(mInsn.name)
+                            && "(I)Ljava/lang/String;".equals(mInsn.desc))
+                            || ("java/lang/Integer".equals(mInsn.owner) && "toString".equals(mInsn.name)
+                                    && "(I)Ljava/lang/String;".equals(mInsn.desc))) {
+                        mInsn.owner = EARLY_HOOKS_INTERNAL;
+                        mInsn.name = "intToCachedString";
+                    }
+                } else if (aInsn.getOpcode() == PUTFIELD && aInsn instanceof FieldInsnNode fInsn) {
+                    if (PROPERTY_INTERNAL.equals(fInsn.owner)
+                            && ("value".equals(fInsn.name) || "defaultValue".equals(fInsn.name))) {
+                        final MethodInsnNode intern = new MethodInsnNode(
+                                INVOKEVIRTUAL,
+                                "java/lang/String",
+                                "intern",
+                                "()Ljava/lang/String;",
+                                false);
+                        mn.instructions.insertBefore(fInsn, intern);
+                        i++;
+                    } else if (PROPERTY_INTERNAL.equals(fInsn.owner)
+                            && ("values".equals(fInsn.name) || "defaultValues".equals(fInsn.name))) {
+                                final MethodInsnNode intern = new MethodInsnNode(
+                                        INVOKESTATIC,
+                                        EARLY_HOOKS_INTERNAL,
+                                        "internArray",
+                                        "([Ljava/lang/String;)[Ljava/lang/String;",
+                                        false);
+                                mn.instructions.insertBefore(fInsn, intern);
+                                i++;
+                            }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/rfb/HodgepodgeRfbPlugin.java
+++ b/src/main/java/com/mitchej123/hodgepodge/rfb/HodgepodgeRfbPlugin.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.rfb;
+
+import net.minecraft.launchwrapper.Launch;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.gtnewhorizons.retrofuturabootstrap.api.PluginContext;
+import com.gtnewhorizons.retrofuturabootstrap.api.RfbClassTransformer;
+import com.gtnewhorizons.retrofuturabootstrap.api.RfbPlugin;
+import com.mitchej123.hodgepodge.asm.EarlyConfig;
+
+public class HodgepodgeRfbPlugin implements RfbPlugin {
+
+    @Override
+    public void onConstruction(@NotNull PluginContext ctx) {
+        Launch.blackboard.put("hodgepodge.rfbPluginLoaded", Boolean.TRUE);
+        EarlyConfig.ensureLoaded();
+    }
+
+    @Override
+    public @NotNull RfbClassTransformer @Nullable [] makeTransformers() {
+        return new RfbClassTransformer[] { new ForgeConfigurationTransformer() };
+    }
+}

--- a/src/main/resources/META-INF/rfb-plugin/hodgepodge.properties
+++ b/src/main/resources/META-INF/rfb-plugin/hodgepodge.properties
@@ -6,4 +6,4 @@ transformerExclusions=
 versionConstraints=
 loadBefore=
 loadAfter=mixin
-loadRequires=
+loadRequires=gtnhlib

--- a/src/main/resources/META-INF/rfb-plugin/hodgepodge.properties
+++ b/src/main/resources/META-INF/rfb-plugin/hodgepodge.properties
@@ -1,0 +1,9 @@
+name=Hodgepodge
+version=${version}
+additionalVersions=
+className=com.mitchej123.hodgepodge.rfb.HodgepodgeRfbPlugin
+transformerExclusions=
+versionConstraints=
+loadBefore=
+loadAfter=mixin
+loadRequires=


### PR DESCRIPTION
Using an RFB plugin (lwjgl3ify required, otherwise this PR does nothing) this transforms Forge's Configuration classes to use less memory by:
 - assigning constant strings to common values directly
 - deduplicating other strings using Java's builtin interner
 - deduplicating empty arrays to a single instance
 - replacing TreeMaps for properties with fastutil's openhashmap - the ordering of the treemap does not matter for the configuration code so this is safe (unless someone does something weird to it via reflection)

Overall in the full pack these changes reduce Configuration memory usage by 45%: 271 MB to 149 MB.