### PR TITLE
Fix wrong config entry order after the optimizations in #357

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/hooks/early/EarlyASMCallHooks.java
@@ -3,6 +3,9 @@ package com.mitchej123.hodgepodge.asm.hooks.early;
 import static cpw.mods.fml.common.ModContainerFactory.modTypes;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.logging.log4j.Level;
 
@@ -74,5 +77,10 @@ public class EarlyASMCallHooks {
             array[i] = (array[i] == null) ? null : array[i].intern();
         }
         return array;
+    }
+
+    public static <V> Collection<V> keySortedMapValues(Map<String, V> map) {
+        final TreeMap<String, V> sortedMap = new TreeMap<>(map);
+        return sortedMap.values();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/rfb/ForgeConfigurationTransformer.java
@@ -1,6 +1,7 @@
 package com.mitchej123.hodgepodge.rfb;
 
 import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
@@ -116,6 +117,16 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer {
                         mn.instructions.insertBefore(fInsn,
                                 new MethodInsnNode(INVOKESPECIAL, OPEN_MAP_INTERNAL, "<init>", "()V", false));
                         i += 4;
+                    }
+                } else if ("getOrderedValues".equals(mn.name)
+                        && aInsn.getOpcode() == INVOKEINTERFACE
+                        && aInsn instanceof MethodInsnNode mInsn) {
+                    if ("values".equals(mInsn.name) && "()Ljava/util/Collection;".equals(mInsn.desc)) {
+                        mInsn.setOpcode(INVOKESTATIC);
+                        mInsn.owner = EARLY_HOOKS_INTERNAL;
+                        mInsn.name = "keySortedMapValues";
+                        mInsn.desc = "(Ljava/util/Map;)Ljava/util/Collection;";
+                        mInsn.itf = false;
                     }
                 }
                 // spotless:on


### PR DESCRIPTION
Sort the config keys before saving to preserve the old configuration property order when no custom order is specified by the mod.

Closes #364 