### PR TITLE
Check TE coordinates early and provide a meaningful error message if they're wrong

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -317,6 +317,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean validatePacketEncodingBeforeSendingShouldCrash;
 
+    @Config.Comment("Checks saved TileEntity coordinates earlier to provide a more descriptive error message")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean earlyChunkTileCoordinateCheck;
+
     // affecting multiple mods
 
     @Config.Comment("Remove old/stale/outdated update checks.")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -376,6 +376,12 @@ public enum Mixins {
             .setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA).addMixinClasses("minecraft.MixinBlock_LighterWater")
             .setApplyIf(() -> TweaksConfig.useLighterWater)),
 
+    EARLY_CHUNK_TILE_COORDINATE_CHECK(
+            new Builder("Checks saved TileEntity coordinates earlier to provide a more descriptive error message")
+                    .setPhase(Phase.EARLY).setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA)
+                    .addMixinClasses("minecraft.MixinChunk")
+                    .setApplyIf(() -> FixesConfig.earlyChunkTileCoordinateCheck)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunk.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunk.java
@@ -1,0 +1,57 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.Common;
+
+@Mixin(Chunk.class)
+public class MixinChunk {
+
+    @Shadow
+    public World worldObj;
+
+    @Shadow
+    @Final
+    public int xPosition;
+
+    @Shadow
+    @Final
+    public int zPosition;
+
+    @Inject(method = "func_150812_a", at = @At("HEAD"))
+    void hodgepodge$validateTileInBounds(int inChunkX, int inChunkY, int inChunkZ, TileEntity tile, CallbackInfo ci) {
+        if (inChunkX < 0 || inChunkX >= 16 || inChunkY < 0 || inChunkY >= 256 || inChunkZ < 0 || inChunkZ >= 16) {
+            int dimension = Integer.MIN_VALUE;
+            try {
+                dimension = this.worldObj.provider.dimensionId;
+            } catch (Throwable t) {
+                // no-op
+            }
+            final String message = String.format(
+                    "Tile entity of type %s (%s) reports coordinates of (%d, %d, %d) that lie outside of the bounds of chunk (x=%d, z=%d) in dimension %d - ending up with illegal in-chunk coordinates of (%d, %d, %d).",
+                    tile.getClass().getName(),
+                    tile.getClass().getProtectionDomain().getCodeSource().getLocation(),
+                    tile.xCoord,
+                    tile.yCoord,
+                    tile.zCoord,
+                    this.xPosition,
+                    this.zPosition,
+                    dimension,
+                    inChunkX,
+                    inChunkY,
+                    inChunkZ);
+            final IllegalArgumentException e = new IllegalArgumentException(message);
+            Common.log.fatal("{}", message, e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Should help diagnose this crash:
```
java.lang.ArrayIndexOutOfBoundsException: Index -16 out of bounds for length 4096
	at RFB-Launch//net.minecraft.world.chunk.storage.ExtendedBlockStorage.func_76665_b(SourceFile:1093)
	at RFB-Launch//net.minecraft.world.chunk.Chunk.func_76628_c(Chunk.java:548)
	at RFB-Launch//net.minecraft.world.chunk.Chunk.func_150812_a(Chunk.java:878)
	at RFB-Launch//net.minecraft.world.chunk.Chunk.func_150813_a(Chunk.java:862)
	at RFB-Launch//net.minecraft.world.chunk.storage.AnvilChunkLoader.loadEntities(AnvilChunkLoader.java:500)
	at RFB-Launch//net.minecraftforge.common.chunkio.ChunkIOProvider.callStage2(ChunkIOProvider.java:41)
	at RFB-Launch//net.minecraftforge.common.chunkio.ChunkIOProvider.callStage2(ChunkIOProvider.java:12)
	at RFB-Launch//net.minecraftforge.common.util.AsynchronousExecutor$Task.finish(AsynchronousExecutor.java:189)
	at RFB-Launch//net.minecraftforge.common.util.AsynchronousExecutor.finishActive(AsynchronousExecutor.java:354)
	at RFB-Launch//net.minecraftforge.common.chunkio.ChunkIOExecutor.tick(ChunkIOExecutor.java:30)
	at RFB-Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:596)
	at RFB-Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
	at RFB-Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at RFB-Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
	at RFB-Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```