### PR TITLE
Witchery - Enhanced Compatibility Thunder detection

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -582,6 +582,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixWitcheryReflections;
 
+    @Config.Comment("Enhanced Witchery Thunder Detection for rituals and Witch Hunters")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixWitcheryThunderDetection;
+
     // Xaero's World Map
 
     @Config.Comment("Fix scrolling in the world map screen")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -681,6 +681,15 @@ public enum Mixins {
             .setPhase(Phase.LATE).setApplyIf(() -> FixesConfig.fixWitcheryReflections)
             .addTargetedMod(TargetedMod.WITCHERY)),
 
+    FIX_WITCHERY_THUNDERING_DETECTION(new Builder(
+            "Fixes Witchery Thunder Detection for rituals and Witch Hunters breaking with mods modifying thunder frequency")
+                    .addMixinClasses(
+                            "witchery.MixinBlockCircle",
+                            "witchery.MixinEntityWitchHunter",
+                            "witchery.MixinRiteClimateChange")
+                    .setSide(Side.BOTH).setPhase(Phase.LATE).setApplyIf(() -> FixesConfig.fixWitcheryThunderDetection)
+                    .addTargetedMod(TargetedMod.WITCHERY)),
+
     // Various Exploits/Fixes
     GC_TIME_COMMAND_FIX(new Builder("GC Time Fix").addMixinClasses("minecraft.MixinTimeCommandGalacticraftFix")
             .setPhase(Phase.EARLY).setSide(Side.BOTH).setApplyIf(() -> FixesConfig.fixTimeCommandWithGC)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinBlockCircle.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinBlockCircle.java
@@ -1,0 +1,20 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.emoniph.witchery.blocks.BlockCircle;
+
+@Mixin(BlockCircle.class)
+public class MixinBlockCircle {
+
+    @Redirect(
+            method = "activateBlock",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isThundering()Z"))
+    private boolean hodgepodge$isThundering(World world) {
+        return world.getWorldInfo().isThundering();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityWitchHunter.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityWitchHunter.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.emoniph.witchery.entity.EntityWitchHunter;
+
+@Mixin(EntityWitchHunter.class)
+public class MixinEntityWitchHunter {
+
+    @Redirect(
+            method = "isValidLightLevel",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isThundering()Z"))
+    private boolean hodgepodge$isThundering(World world) {
+        return world.getWorldInfo().isThundering();
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinRiteClimateChange.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinRiteClimateChange.java
@@ -1,0 +1,17 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(targets = { "com.emoniph.witchery.ritual.rites.RiteClimateChange$StepClimateChange" })
+public class MixinRiteClimateChange {
+
+    @Redirect(method = "process", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isThundering()Z"))
+    private boolean hodgepodge$isThundering(World world) {
+        return world.getWorldInfo().isThundering();
+    }
+
+}


### PR DESCRIPTION
Detect `isThundering()` based on the world info rather than the frequency of thunders of said world.

This ensures that witchery can detect storm even when weather mods modify thunder frequencies during storms.

This fixes rituals that can only be used during storms and Witch Hunter spawning.

__Example of known mods that break Witchery's storm detection:__
- [Better Rain](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/2134067-better-rain-v0-15-bug-fixes)
- [Dynamic Surrounding](https://www.curseforge.com/minecraft/mc-mods/dynamic-surroundings/)