### PR TITLE
Fix Lapis Caelestis Microblocks rendering

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -389,6 +389,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesDrumEatingCells;
 
+    @Config.Comment("Fix Extra Utilities Lapis Caelestis microblocks rendering")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixExtraUtilitiesGreenscreenMicroblocks;
+
     @Config.Comment("Fixes rendering issues with transparent items from Extra Utilities")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -640,7 +640,7 @@ public enum Mixins {
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesDrumEatingCells)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
     FIX_GREENSCREEN_MICROBLOCKS(new Builder("Fix extra utilities Lapis Caelestis microblocks")
-            .addMixinClasses("extrautilities.MixinFullBrightMicroMaterial").setSide(Side.BOTH).setPhase(Phase.LATE)
+            .addMixinClasses("extrautilities.MixinFullBrightMicroMaterial").setSide(Side.CLIENT).setPhase(Phase.LATE)
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesGreenscreenMicroblocks)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -639,6 +639,10 @@ public enum Mixins {
             .addMixinClasses("extrautilities.MixinBlockDrum").setSide(Side.BOTH).setPhase(Phase.LATE)
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesDrumEatingCells)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_GREENSCREEN_MICROBLOCKS(new Builder("Fix extra utilities Lapis Caelestis microblocks")
+            .addMixinClasses("extrautilities.MixinFullBrightMicroMaterial").setSide(Side.BOTH).setPhase(Phase.LATE)
+            .setApplyIf(() -> FixesConfig.fixExtraUtilitiesGreenscreenMicroblocks)
+            .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // PortalGun
     PORTALGUN_FIX_URLS(new Builder("Fix URLs used to download the sound pack")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinFullBrightMicroMaterial.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinFullBrightMicroMaterial.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import codechicken.lib.render.CCRenderState;
+
+@Mixin(value = com.rwtema.extrautils.multipart.FullBrightMicroMaterial.Lighting.class, remap = false)
+public class MixinFullBrightMicroMaterial {
+
+    /**
+     * @author DvDmanDT
+     * @reason Fix rendering of Lapis caelestis microblocks.
+     */
+    @Overwrite
+    public void operate() {
+        CCRenderState.setBrightnessStatic(240);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinFullBrightMicroMaterial.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinFullBrightMicroMaterial.java
@@ -1,19 +1,14 @@
 package com.mitchej123.hodgepodge.mixins.late.extrautilities;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-
-import codechicken.lib.render.CCRenderState;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(value = com.rwtema.extrautils.multipart.FullBrightMicroMaterial.Lighting.class, remap = false)
 public class MixinFullBrightMicroMaterial {
 
-    /**
-     * @author DvDmanDT
-     * @reason Fix rendering of Lapis caelestis microblocks.
-     */
-    @Overwrite
-    public void operate() {
-        CCRenderState.setBrightnessStatic(240);
+    @ModifyConstant(method = "operate", constant = @Constant(intValue = 16711935))
+    int injected(int v) {
+        return 240;
     }
 }


### PR DESCRIPTION
This adds a mixin to fix the rendering of Lapis Caelestis microblocks. The core issue is that it passes an invalid brightness value, which causes the game to not render them, or render them as pitch black (with Angelica). ~~The mixin uses Overwrite instead of other options since the contents of the method is already changed by CCC to use the updated api (specifically to change `CCRenderState.setBrightness(16711935)` to `CCRenderState.setBrightnessStatic(16711935)`)~~. The mixin now uses ModifyConstant instead, to change 16711935 (0xFF00FF) to 240, which is the same brightness value the full blocks pass to the tesselator.

This fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12436