### PR TITLE
Add mixin to disable BOP quicksand from generating

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.5.0:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.48.09:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.48.12:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.2.1-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.2.0:dev") // Do not update, fixed afterwards

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -168,6 +168,11 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static boolean makeBigFirsPlantable;
 
+    @Config.Comment("Remove the BOP quicksand generation")
+    @Config.DefaultBoolean(false)
+    @Config.RequiresMcRestart
+    public static boolean removeBOPQuicksandGeneration;
+
     // Extra Utilities
 
     @Config.Comment("Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far.")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -509,7 +509,9 @@ public enum Mixins {
     JAVA12_BOP(new Builder("BOP Java12-safe reflection").setPhase(Phase.LATE).setSide(Side.BOTH)
             .addMixinClasses("biomesoplenty.MixinBOPBiomes").addMixinClasses("biomesoplenty.MixinBOPReflectionHelper")
             .setApplyIf(() -> FixesConfig.java12BopCompat).addTargetedMod(TargetedMod.BOP)),
-
+    DISABLE_QUICKSAND_GENERATION(new Builder("Disable BOP quicksand").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addMixinClasses("biomesoplenty.MixinDisableQuicksandGeneration")
+            .setApplyIf(() -> TweaksConfig.removeBOPQuicksandGeneration).addTargetedMod(TargetedMod.BOP)),
     // COFH
     COFH_REMOVE_TE_CACHE(
             new Builder("Remove CoFH tile entity cache").addMixinClasses("minecraft.MixinWorld_CoFH_TE_Cache")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/biomesoplenty/MixinDisableQuicksandGeneration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/biomesoplenty/MixinDisableQuicksandGeneration.java
@@ -1,0 +1,16 @@
+package com.mitchej123.hodgepodge.mixins.late.biomesoplenty;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(value = biomesoplenty.api.biome.BiomeFeatures.class, remap = false)
+public class MixinDisableQuicksandGeneration {
+
+    @Inject(method = "getFeature", at = @At("HEAD"), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
+    private void hodgepodge$getFeature(String featureName, CallbackInfoReturnable<Object> cir) {
+        if (featureName != null && featureName.equals("generateQuicksand")) cir.setReturnValue(false);
+    }
+}


### PR DESCRIPTION
This adds a (default off) mixin to disable BOP quicksand from generating. There might be better ways to do this, but this way should be compatible with addons etc.