### PR TITLE
Disable water bottle infinite water

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -147,6 +147,11 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static boolean useLighterWater;
 
+    @Config.Comment("Consumes a water source block/a cauldron of water to fill a water bottle.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean disableWaterBottleInfiniteWater;
+
     // affecting multiple mods
 
     @Config.Comment("Unbinds keybinds of certain ARR mods to avoid keybinds conflicts")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -381,6 +381,10 @@ public enum Mixins {
                     .setPhase(Phase.EARLY).setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA)
                     .addMixinClasses("minecraft.MixinChunk")
                     .setApplyIf(() -> FixesConfig.earlyChunkTileCoordinateCheck)),
+    WATER_BOTTLE_CONSUME_WATER(new Builder("Consumes a water source block/a cauldron of water to fill a water bottle.")
+            .setPhase(Phase.EARLY).setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA)
+            .addMixinClasses("minecraft.MixinItemGlassBottle", "minecraft.MixinBlockCauldron")
+            .setApplyIf(() -> TweaksConfig.disableWaterBottleInfiniteWater)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockCauldron.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockCauldron.java
@@ -1,0 +1,46 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.block.BlockCauldron;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(BlockCauldron.class)
+public abstract class MixinBlockCauldron {
+
+    @Inject(
+            method = "onBlockActivated",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;",
+                    ordinal = 1,
+                    shift = At.Shift.BY,
+                    by = 3),
+            cancellable = true)
+    private void hodgepodge$returnIfCauldronNotFull(World world, int x, int y, int z, EntityPlayer player, int side,
+            float subX, float subY, float subZ, CallbackInfoReturnable<Boolean> cir,
+            @Local(ordinal = 5) int cauldronMetadata) {
+        if (cauldronMetadata < 3) {
+            cir.setReturnValue(false);
+            cir.cancel();
+        }
+    }
+
+    @ModifyArg(
+            method = "onBlockActivated",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/BlockCauldron;func_150024_a(Lnet/minecraft/world/World;IIII)V",
+                    ordinal = 1),
+            index = 4)
+    private int hodgepodge$consumeAllWater(int metadataToSet) {
+        return 0;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemGlassBottle.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemGlassBottle.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemGlassBottle;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(ItemGlassBottle.class)
+public abstract class MixinItemGlassBottle {
+
+    @Inject(
+            method = "onItemRightClick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;getMaterial()Lnet/minecraft/block/material/Material;",
+                    shift = At.Shift.BY,
+                    by = 3))
+    private void hodgepodge$removeWaterSourceBlock(ItemStack bottle, World world, EntityPlayer player,
+            CallbackInfoReturnable<ItemStack> cri, @Local(ordinal = 0) MovingObjectPosition movingobjectposition) {
+        int metadata = world.getBlockMetadata(
+                movingobjectposition.blockX,
+                movingobjectposition.blockY,
+                movingobjectposition.blockZ);
+        if (metadata == 0)
+            world.setBlockToAir(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
+    }
+}


### PR DESCRIPTION
With this pr:
-  When you use the glass bottle on a water source block , you will get a water bottle and the water source block will be consumed.
- When you use the glass bottle on a cauldron:
- - If cauldron is not full, nothing happens.
- - If cauldron is full, you will get a water bottle and the cauldron will be emptied.

This way the water bottle can be considered to contain 1000L of water.