### PR TITLE
Better volume scaling

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -92,6 +92,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixFriendlyCreatureSounds;
 
+    @Config.Comment("Fix Volume Slider is ineffective until reaching the lower end")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean logarithmicVolumeControl;
+
     @Config.Comment("Fix vanilla light calculation sometimes cause NPE on thermos")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -82,6 +82,10 @@ public enum Mixins {
     FIX_FRIENDLY_CREATURE_SOUNDS(new Builder("Fix Friendly Creature Sounds").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinSoundHandler").setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> FixesConfig.fixFriendlyCreatureSounds)),
+    LOGARITHMIC_VOLUME_CONTROL(new Builder("Logarithmic Volume Control").setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinSoundManager", "minecraft.MixinSoundManagerLibraryLoader")
+            .setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> FixesConfig.logarithmicVolumeControl)),
     THROTTLE_ITEMPICKUPEVENT(new Builder("Throttle Item Pickup Event").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityPlayer").setSide(Side.BOTH)
             .setApplyIf(() -> FixesConfig.throttleItemPickupEvent).addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManager.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.audio.ISound;
+import net.minecraft.client.audio.SoundCategory;
+import net.minecraft.client.audio.SoundManager;
+import net.minecraft.client.audio.SoundPoolEntry;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SoundManager.class)
+public class MixinSoundManager {
+
+    @ModifyArg(
+            method = "setSoundCategoryVolume",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/audio/SoundManager$SoundSystemStarterThread;setMasterVolume(F)V"),
+            index = 0)
+    public float hodgepodge$modifySetMasterVolumeArg(float volume) {
+        return (float) Math.pow(volume, 2);
+    }
+
+    @Inject(method = "getNormalizedVolume", at = @At("RETURN"), cancellable = true)
+    private void hodgepodge$modifyCategoryVolume(ISound sound, SoundPoolEntry poolEntry, SoundCategory category,
+            CallbackInfoReturnable<Float> ci) {
+        float scaledVolume = (float) Math.pow(ci.getReturnValue(), 2);
+        ci.setReturnValue(scaledVolume);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManager.java
@@ -19,7 +19,8 @@ public class MixinSoundManager {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/audio/SoundManager$SoundSystemStarterThread;setMasterVolume(F)V"),
-            index = 0)
+            index = 0,
+            remap = false)
     public float hodgepodge$modifySetMasterVolumeArg(float volume) {
         return (float) Math.pow(volume, 2);
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManagerLibraryLoader.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManagerLibraryLoader.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(targets = "net.minecraft.client.audio.SoundManager$1")
+public class MixinSoundManagerLibraryLoader {
+
+    @SuppressWarnings("UnresolvedMixinReference")
+    @ModifyArg(
+            method = "run()V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/audio/SoundManager$SoundSystemStarterThread;setMasterVolume(F)V"),
+            index = 0,
+            remap = false)
+    private float hodgepodge$modifySetMasterVolumeArg(float volume) {
+        return (float) Math.pow(volume, 2);
+    }
+}


### PR DESCRIPTION
Minecraft has linear volume scaling so "turn volume to 50%" is not "I can hear 2x quieter".
I have to scale block sound all the way down to like 5% to hear not too loud sound in GTNH.
This PR tries to fix that.
It is exactly what https://modrinth.com/mod/logarithmic-volume-control does but better implementation
It fixes https://bugs.mojang.com/browse/MC-141201

Tested in full pack.
This does not change the max volume.