### PR TITLE
Add an option to destroy TileEntities with illegal coordinates instead of crashing

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.23'
 }
 
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -327,6 +327,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean earlyChunkTileCoordinateCheck;
 
+    @Config.Comment("Destroy and log TileEntities failing the safe coordinate instead of crashing the game (can cause loss of data)")
+    @Config.DefaultBoolean(false)
+    @Config.RequiresMcRestart
+    public static boolean earlyChunkTileCoordinateCheckDestructive;
+
     // affecting multiple mods
 
     @Config.Comment("Remove old/stale/outdated update checks.")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunk.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunk.java
@@ -1,5 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
@@ -12,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.config.FixesConfig;
 
 @Mixin(Chunk.class)
 public class MixinChunk {
@@ -27,7 +29,7 @@ public class MixinChunk {
     @Final
     public int zPosition;
 
-    @Inject(method = "func_150812_a", at = @At("HEAD"))
+    @Inject(method = "func_150812_a", at = @At("HEAD"), cancellable = true)
     void hodgepodge$validateTileInBounds(int inChunkX, int inChunkY, int inChunkZ, TileEntity tile, CallbackInfo ci) {
         if (inChunkX < 0 || inChunkX >= 16 || inChunkY < 0 || inChunkY >= 256 || inChunkZ < 0 || inChunkZ >= 16) {
             int dimension = Integer.MIN_VALUE;
@@ -36,8 +38,16 @@ public class MixinChunk {
             } catch (Throwable t) {
                 // no-op
             }
+            String nbt;
+            try {
+                final NBTTagCompound tag = new NBTTagCompound();
+                tile.writeToNBT(tag);
+                nbt = tag.toString();
+            } catch (Exception e) {
+                nbt = "<error happened when serializing to string: " + e.getMessage() + ">";
+            }
             final String message = String.format(
-                    "Tile entity of type %s (%s) reports coordinates of (%d, %d, %d) that lie outside of the bounds of chunk (x=%d, z=%d) in dimension %d - ending up with illegal in-chunk coordinates of (%d, %d, %d).",
+                    "Tile entity of type %s (%s) reports coordinates of (%d, %d, %d) that lie outside of the bounds of chunk (x=%d, z=%d) in dimension %d - ending up with illegal in-chunk coordinates of (%d, %d, %d). Serialized NBT of the offending TE: %s",
                     tile.getClass().getName(),
                     tile.getClass().getProtectionDomain().getCodeSource().getLocation(),
                     tile.xCoord,
@@ -48,10 +58,15 @@ public class MixinChunk {
                     dimension,
                     inChunkX,
                     inChunkY,
-                    inChunkZ);
+                    inChunkZ,
+                    nbt);
             final IllegalArgumentException e = new IllegalArgumentException(message);
             Common.log.fatal("{}", message, e);
-            throw e;
+            if (FixesConfig.earlyChunkTileCoordinateCheckDestructive) {
+                ci.cancel();
+            } else {
+                throw e;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a config option to destroy broken TEs from the world instead of crashing. This is off by default, because it can cause data loss in worlds instead of just stopping it while loading which allows for manual data recovery.
Also now logs the NBT of the offending TE to provide even more information.