### PR TITLE
Faster client chunk provider

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ enableModernJavaSyntax = true
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
-enableGenericInjection = false
+enableGenericInjection = true
 
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.

--- a/src/main/java/com/mitchej123/hodgepodge/client/chat/ChatHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/chat/ChatHandler.java
@@ -23,7 +23,6 @@ public class ChatHandler {
         return false;
     }
 
-    @SuppressWarnings("unchecked")
     private static boolean areMessagesIdentical(IChatComponent imsg, IChatComponent prevMsg) {
         final int size1 = imsg.getSiblings().size();
         final int size2 = prevMsg.getSiblings().size();
@@ -38,7 +37,7 @@ public class ChatHandler {
         if (!(prevMsg.getSiblings().get(size2 - 1) instanceof ChatComponentCount)) {
             return false;
         }
-        final Object removed = prevMsg.getSiblings().remove(size2 - 1);
+        final IChatComponent removed = prevMsg.getSiblings().remove(size2 - 1);
         final boolean equals = imsg.equals(prevMsg);
         prevMsg.getSiblings().add(removed);
         if (equals) {

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -42,6 +42,11 @@ public class SpeedupsConfig {
     @Config.RequiresMcRestart
     public static boolean tcpNoDelay;
 
+    @Config.Comment("Speeds up ChunkProviderClient by removing chunkListing.  Note: Depends on asm.speedupLongIntHashMap")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean speedupChunkProviderClient;
+
     // Biomes O' Plenty
 
     @Config.Comment("Speedup biome fog rendering in BiomesOPlenty")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -124,6 +124,10 @@ public enum Mixins {
     SPEEDUP_GRASS_BLOCK_RANDOM_TICKING(new Builder("Speed up grass block random ticking").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinBlockGrass").addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH)
             .setApplyIf(() -> SpeedupsConfig.speedupGrassBlockRandomTicking)),
+    SPEEDUP_CHUNK_PROVIDER_CLIENT(new Builder("Speed up ChunkProviderClient").setPhase(Phase.EARLY).setSide(Side.CLIENT)
+            .addMixinClasses("minecraft.MixinChunkProviderClient_RemoveChunkListing")
+            .addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> SpeedupsConfig.speedupChunkProviderClient && ASMConfig.speedupLongIntHashMap)),
     CHUNK_COORDINATES_HASHCODE(new Builder("Optimize Chunk Coordinates Hashcode").setPhase(Phase.EARLY)
             .setSide(Side.BOTH).addMixinClasses("minecraft.MixinChunkCoordinates").addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> SpeedupsConfig.speedupChunkCoordinatesHashCode)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderClient_RemoveChunkListing.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderClient_RemoveChunkListing.java
@@ -1,0 +1,54 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Iterator;
+import java.util.List;
+
+import net.minecraft.client.multiplayer.ChunkProviderClient;
+import net.minecraft.util.LongHashMap;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.mitchej123.hodgepodge.util.FastUtilLongHashMap;
+
+/*
+ * Speed up ChunkProviderClient by removing usage of the chunkListing list (slow removals) which is identical to the
+ * chunkMapping values, and instead use an iterator from the chunkMapping values directly. NOTE: Depends on the ASM
+ * Transformer `SpeedupLongIntHashMapTransformer` to replace the LongHashMap with FastUtilLongHashMap.
+ */
+@SuppressWarnings("rawtypes")
+@Mixin(ChunkProviderClient.class)
+public class MixinChunkProviderClient_RemoveChunkListing {
+
+    @Shadow
+    private LongHashMap chunkMapping;
+
+    @Shadow
+    private List chunkListing = null;
+
+    @Redirect(
+            method = "unloadChunk",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;remove(Ljava/lang/Object;)Z", remap = false))
+    private boolean hodgepodge$unloadChunkRemoveChunkListing(List instance, Object o) {
+        // NOOP
+        return true;
+    }
+
+    @Redirect(
+            method = "loadChunk",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", remap = false))
+    private boolean hodgepodge$loadChunkRemoveChunkListing(List instance, Object o) {
+        // NOOP
+        return true;
+    }
+
+    @Redirect(
+            method = "unloadQueuedChunks",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;", remap = false))
+    private Iterator hodgepodge$getValuesIterator(List instance) {
+        // Get the iterator from the FastUtilLongHashMap instead of the chunkListing list
+        return ((FastUtilLongHashMap) chunkMapping).valuesIterator();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderClient_RemoveChunkListing.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderClient_RemoveChunkListing.java
@@ -51,4 +51,19 @@ public class MixinChunkProviderClient_RemoveChunkListing {
         // Get the iterator from the FastUtilLongHashMap instead of the chunkListing list
         return ((FastUtilLongHashMap) chunkMapping).valuesIterator();
     }
+
+    @Redirect(method = "makeString", at = @At(value = "INVOKE", target = "Ljava/util/List;size()I", remap = false))
+    private int hodgepodge$makeStringGetLoadedChunkCount(List instance) {
+        // Return the size of the FastUtilLongHashMap instead of the chunkListing list
+        return chunkMapping.getNumHashElements();
+    }
+
+    @Redirect(
+            method = "getLoadedChunkCount",
+            at = @At(value = "INVOKE", target = "Ljava/util/List;size()I", remap = false))
+    private int hodgepodge$getLoadedChunkCount(List instance) {
+        // Return the size of the FastUtilLongHashMap instead of the chunkListing list
+        return chunkMapping.getNumHashElements();
+    }
+
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/FastUtilLongHashMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FastUtilLongHashMap.java
@@ -1,5 +1,7 @@
 package com.mitchej123.hodgepodge.util;
 
+import java.util.Iterator;
+
 import net.minecraft.util.LongHashMap;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
@@ -29,7 +31,6 @@ public class FastUtilLongHashMap extends LongHashMap {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void add(long key, Object value) {
         map.put(key, value);
     }
@@ -37,5 +38,9 @@ public class FastUtilLongHashMap extends LongHashMap {
     @Override
     public Object remove(long key) {
         return map.remove(key);
+    }
+
+    public Iterator<Object> valuesIterator() {
+        return map.values().iterator();
     }
 }


### PR DESCRIPTION
Speeds up ClientChunkProvider by removing a list duplicating everything in the map because they wanted to be able to iterate over it, and decided this was better than implementing a values iterator on the map...

```java
    /**
     * This may have been intended to be an iterable version of all currently loaded chunks (MultiplayerChunkCache),
     * with identical contents to chunkMapping's values. However it is never actually added to.
     */
    private List chunkListing = new ArrayList();
```