### PR TITLE
Fix duplicate sounds when closing a gui while one was playing

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -42,6 +42,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixDimensionChangeHearts;
 
+    @Config.Comment("Fix duplicate sounds from playing when closing a gui.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixDuplicateSounds;
+
     @Config.Comment("Fix deleting stack when eating mushroom stew")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
@@ -647,5 +652,4 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean fixZTonesPackets;
-
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -393,6 +393,11 @@ public enum Mixins {
                     .addMixinClasses("minecraft.MixinChunk")
                     .setApplyIf(() -> FixesConfig.earlyChunkTileCoordinateCheck)),
 
+    FIX_DUPLICATE_SOUNDS(new Builder("Fix duplicate sounds being played when you close a gui while one is playing")
+            .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
+            .addMixinClasses("minecraft.MixinMinecraft_FixDuplicateSounds")
+            .setApplyIf(() -> FixesConfig.fixDuplicateSounds)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FixDuplicateSounds.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FixDuplicateSounds.java
@@ -1,0 +1,31 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.SoundHandler;
+import net.minecraft.client.gui.GuiIngameMenu;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.server.integrated.IntegratedServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(Minecraft.class)
+public abstract class MixinMinecraft_FixDuplicateSounds {
+
+    @Shadow
+    public abstract boolean isSingleplayer();
+
+    @Shadow
+    private IntegratedServer theIntegratedServer;
+
+    @WrapWithCondition(
+            method = "displayGuiScreen",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/audio/SoundHandler;resumeSounds()V"))
+    private boolean hodgepodge$fixDuplicateSounds(SoundHandler instance, @Local(name = "old") GuiScreen old) {
+        return old instanceof GuiIngameMenu && isSingleplayer() && !this.theIntegratedServer.getPublic();
+    }
+}


### PR DESCRIPTION
Been bugging me lately.
There is a bug where if you open a gui after a sound plays and when you close it, it will replay from the start.