### PR TITLE
server side control logic for fast block placing

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -1,5 +1,7 @@
 package com.mitchej123.hodgepodge;
 
+import java.util.Map;
+
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
 import com.mitchej123.hodgepodge.net.NetworkHandler;
@@ -13,13 +15,15 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.network.NetworkCheckHandler;
+import cpw.mods.fml.common.versioning.ArtifactVersion;
+import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
 import cpw.mods.fml.relauncher.Side;
 
 @Mod(
         modid = Hodgepodge.MODID,
         version = Hodgepodge.VERSION,
         name = Hodgepodge.NAME,
-        acceptableRemoteVersions = "*",
         dependencies = "required-after:gtnhmixins@[2.0.1,);" + "required-after:unimixins@[0.0.14,);"
                 + "required-after:gtnhlib@[0.2.2,);",
         guiFactory = "com.mitchej123.hodgepodge.config.gui.HodgepodgeGuiConfigFactory")
@@ -32,6 +36,8 @@ public class Hodgepodge {
     public static final String NAME = "Hodgepodge";
 
     public static final boolean isGTNH;
+
+    private final ArtifactVersion minimumClientJoinVersion = new DefaultArtifactVersion("2.5.36");
 
     static {
         isGTNH = true;
@@ -82,5 +88,18 @@ public class Hodgepodge {
         // needed in case ExtraUtilities' Spike was crashed (and game was switched to a main menu), so it didn't update
         // the variable
         EVENT_HANDLER.setAidTriggerDisabled(false);
+    }
+
+    /**
+     * Block any clients older than 2.5.36 from joining servers to ensure the fastBlockPlacingDisableServerSide setting
+     * is respected
+     */
+    @SuppressWarnings("unused")
+    @NetworkCheckHandler
+    public boolean checkModList(Map<String, String> versions, Side side) {
+        if (side == Side.CLIENT && versions.containsKey(Hodgepodge.MODID)) {
+            return minimumClientJoinVersion.compareTo(new DefaultArtifactVersion(versions.get(Hodgepodge.MODID))) <= 0;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -20,8 +20,10 @@ import cpw.mods.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class ClientKeyListener {
 
-    private static String fastBlockPlacingEnabled = StatCollector.translateToLocal("key.fastBlockPlacing.enabled");
-    private static String fastBlockPlacingDisabled = StatCollector.translateToLocal("key.fastBlockPlacing.disabled");
+    private static final String fastBlockPlacingEnabled = StatCollector
+            .translateToLocal("key.fastBlockPlacing.enabled");
+    private static final String fastBlockPlacingDisabled = StatCollector
+            .translateToLocal("key.fastBlockPlacing.disabled");
 
     public static KeyBinding FastBlockPlacingKey = new KeyBinding(
             "key.fastBlockPlacing.desc",
@@ -42,7 +44,7 @@ public class ClientKeyListener {
                 }
             }
         } else {
-            if (FastBlockPlacingKey.isPressed()) {
+            if (!TweaksConfig.fastBlockPlacingDisableServerSide && FastBlockPlacingKey.isPressed()) {
                 TweaksConfig.fastBlockPlacing = !TweaksConfig.fastBlockPlacing;
                 AboveHotbarHUD.renderTextAboveHotbar(
                         (TweaksConfig.fastBlockPlacing ? fastBlockPlacingEnabled : fastBlockPlacingDisabled),

--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -44,7 +44,7 @@ public class ClientKeyListener {
                 }
             }
         } else {
-            if (!TweaksConfig.fastBlockPlacingDisableServerSide && FastBlockPlacingKey.isPressed()) {
+            if (TweaksConfig.fastBlockPlacingServerSide && FastBlockPlacingKey.isPressed()) {
                 TweaksConfig.fastBlockPlacing = !TweaksConfig.fastBlockPlacing;
                 AboveHotbarHUD.renderTextAboveHotbar(
                         (TweaksConfig.fastBlockPlacing ? fastBlockPlacingEnabled : fastBlockPlacingDisabled),

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -87,6 +87,10 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static boolean fastBlockPlacing;
 
+    @Config.Comment("Block players on your server from using fast block placement")
+    @Config.DefaultBoolean(false)
+    public static boolean fastBlockPlacingDisableServerSide;
+
     @Config.Comment("Prevents the inventory from shifting when the player has active potion effects")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -87,9 +87,9 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static boolean fastBlockPlacing;
 
-    @Config.Comment("Block players on your server from using fast block placement")
-    @Config.DefaultBoolean(false)
-    public static boolean fastBlockPlacingDisableServerSide;
+    @Config.Comment("Allow players on your server to use fast block placement")
+    @Config.DefaultBoolean(true)
+    public static boolean fastBlockPlacingServerSide;
 
     @Config.Comment("Prevents the inventory from shifting when the player has active potion effects")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FastBlockPlacing.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FastBlockPlacing.java
@@ -44,6 +44,7 @@ public class MixinMinecraft_FastBlockPlacing {
                     remap = false,
                     shift = At.Shift.AFTER))
     private void hodgepodge$func_147121_ag(CallbackInfo ci) {
+        if (TweaksConfig.fastBlockPlacingDisableServerSide) return;
         if (!TweaksConfig.fastBlockPlacing) return;
         if (thePlayer == null || thePlayer.isUsingItem()) return;
         if (objectMouseOver == null) return;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FastBlockPlacing.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FastBlockPlacing.java
@@ -44,7 +44,7 @@ public class MixinMinecraft_FastBlockPlacing {
                     remap = false,
                     shift = At.Shift.AFTER))
     private void hodgepodge$func_147121_ag(CallbackInfo ci) {
-        if (TweaksConfig.fastBlockPlacingDisableServerSide) return;
+        if (!TweaksConfig.fastBlockPlacingServerSide) return;
         if (!TweaksConfig.fastBlockPlacing) return;
         if (thePlayer == null || thePlayer.isUsingItem()) return;
         if (objectMouseOver == null) return;

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
@@ -10,11 +10,11 @@ import io.netty.buffer.ByteBuf;
 public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfigSync, IMessage> {
 
     private boolean longerSentMessages;
-    private boolean fastBlockPlacingDisableServerSide;
+    private boolean fastBlockPlacingServerSide;
 
     public MessageConfigSync() {
         longerSentMessages = TweaksConfig.longerSentMessages;
-        fastBlockPlacingDisableServerSide = TweaksConfig.fastBlockPlacingDisableServerSide;
+        fastBlockPlacingServerSide = TweaksConfig.fastBlockPlacingServerSide;
     }
 
     @Override
@@ -23,20 +23,20 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
         // Ensures clients with the setting can still join servers without the setting (servers running older versions
         // of the mod)
         if (buf.readableBytes() < 1) {
-            fastBlockPlacingDisableServerSide = false;
+            fastBlockPlacingServerSide = true;
         } else {
-            fastBlockPlacingDisableServerSide = buf.readBoolean();
+            fastBlockPlacingServerSide = buf.readBoolean();
         }
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeBoolean(longerSentMessages);
-        buf.writeBoolean(fastBlockPlacingDisableServerSide);
+        buf.writeBoolean(fastBlockPlacingServerSide);
     }
 
-    public boolean isFastBlockPlacingDisableServerSide() {
-        return fastBlockPlacingDisableServerSide;
+    public boolean isFastBlockPlacingServerSide() {
+        return fastBlockPlacingServerSide;
     }
 
     public boolean isLongerSentMessages() {
@@ -47,9 +47,9 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
     public IMessage onMessage(MessageConfigSync message, MessageContext ctx) {
         TweaksConfig.longerSentMessages = message.isLongerSentMessages();
 
-        if (message.isFastBlockPlacingDisableServerSide()) {
+        if (!message.isFastBlockPlacingServerSide()) {
             TweaksConfig.fastBlockPlacing = false;
-            TweaksConfig.fastBlockPlacingDisableServerSide = true;
+            TweaksConfig.fastBlockPlacingServerSide = false;
         }
 
         return null;

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
@@ -10,19 +10,33 @@ import io.netty.buffer.ByteBuf;
 public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfigSync, IMessage> {
 
     private boolean longerSentMessages;
+    private boolean fastBlockPlacingDisableServerSide;
 
     public MessageConfigSync() {
         longerSentMessages = TweaksConfig.longerSentMessages;
+        fastBlockPlacingDisableServerSide = TweaksConfig.fastBlockPlacingDisableServerSide;
     }
 
     @Override
     public void fromBytes(ByteBuf buf) {
         longerSentMessages = buf.readBoolean();
+        // Ensures clients with the setting can still join servers without the setting (servers running older versions
+        // of the mod)
+        if (buf.readableBytes() < 1) {
+            fastBlockPlacingDisableServerSide = false;
+        } else {
+            fastBlockPlacingDisableServerSide = buf.readBoolean();
+        }
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeBoolean(longerSentMessages);
+        buf.writeBoolean(fastBlockPlacingDisableServerSide);
+    }
+
+    public boolean isFastBlockPlacingDisableServerSide() {
+        return fastBlockPlacingDisableServerSide;
     }
 
     public boolean isLongerSentMessages() {
@@ -32,6 +46,11 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
     @Override
     public IMessage onMessage(MessageConfigSync message, MessageContext ctx) {
         TweaksConfig.longerSentMessages = message.isLongerSentMessages();
+
+        if (message.isFastBlockPlacingDisableServerSide()) {
+            TweaksConfig.fastBlockPlacing = false;
+            TweaksConfig.fastBlockPlacingDisableServerSide = true;
+        }
 
         return null;
     }


### PR DESCRIPTION
Allow the server to block players from using the fast block placement feature.
Also blocks any clients from running older versions of hodgepodge to ensure the feature is respected. This should be kept in mind when updating the official servers.
Clients running this version can still join server without this feature
When merged this should be released as version 2.5.36