### PR TITLE
Fix npe when interacting with candycraft sugar block

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,6 +57,7 @@ dependencies {
     transformedModCompileOnly(deobfNotch("https://mediafiles.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod"))
     transformedModCompileOnly(rfg.deobf("curse.maven:xaeros-world-map-317780:4716737"))
     transformedModCompileOnly(deobf("https://forum.industrial-craft.net/core/attachment/4316-advancedsolarpanel-1-7-10-3-5-1-jar/"))
+    transformedModCompileOnly(rfg.deobf("curse.maven:candycraft-251118:2330488"))
 
     runtimeOnly(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -395,6 +395,13 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean removeBOPWarning;
 
+    // Candycraft
+
+    @Config.Comment("Fix NPE when interacting with sugar block")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixCandycraftBlockSugarNPE;
+
     // Extra TiC
 
     @Config.Comment("Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: (Brass, Silver, Electrum & Platinum)")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -828,7 +828,12 @@ public enum Mixins {
     DISABLE_MODDED_CHUNK_POPULATION(new Builder("Disable all other mod chunk population (e.g. Natura clouds")
             .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinChunkProviderServer_DisableModGeneration")
             .addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH)
-            .setApplyIf(() -> TweaksConfig.disableModdedChunkPopulation));
+            .setApplyIf(() -> TweaksConfig.disableModdedChunkPopulation)),
+
+    // Candycraft
+    FIX_SUGARBLOCK_NPE(new Builder("Fix NPE when interacting with sugar block")
+            .addMixinClasses("candycraft.MixinBlockSugar").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.fixCandycraftBlockSugarNPE).addTargetedMod(TargetedMod.CANDYCRAFT));
 
     private final List<String> mixinClasses;
     private final List<TargetedMod> targetedMods;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -15,6 +15,7 @@ public enum TargetedMod {
     BOP("BiomesOPlenty", null, "BiomesOPlenty"),
     BUGTORCH("BugTorch", "jss.bugtorch.mixinplugin.BugTorchEarlyMixins", "bugtorch"),
     BUKKIT("Bukkit/Thermos", "Bukkit", null),
+    CANDYCRAFT("candycraftmod", null, "candycraftmod"),
     COFH_CORE("CoFHCore", "cofh.asm.LoadingPlugin", "CoFHCore"),
     DAMAGE_INDICATORS("Damage Indicators", null, "DamageIndicatorsMod"),
     EXTRATIC("ExtraTiC", null, "ExtraTiC"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/candycraft/MixinBlockSugar.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/candycraft/MixinBlockSugar.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.late.candycraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.valentin4311.candycraftmod.BlockSugar;
+
+@Mixin(BlockSugar.class)
+public class MixinBlockSugar {
+
+    @Inject(at = @At("HEAD"), cancellable = true, method = "onBlockActivated")
+    private void hodgepodge$fixNPE(World par1World, int par2, int par3, int par4, EntityPlayer par5EntityPlayer,
+            int par6, float par7, float par8, float par9, CallbackInfoReturnable<Boolean> cir) {
+        if (par5EntityPlayer.getCurrentEquippedItem() == null) {
+            cir.setReturnValue(false);
+        }
+    }
+
+}


### PR DESCRIPTION
The sugar block correctly checks if the equipped item is null in the first part of it's if statement but doesn't return, this then causes an npe when it calls `player.getCurrentEquippedItem().getItem()` later.

It was reported here https://github.com/GTNewHorizons/Backhand/issues/19 but also happens without backhand installed.

Closes https://github.com/GTNewHorizons/Hodgepodge/issues/403