### PR TITLE
Check for fake players before sending hotbar message

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockBed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockBed.java
@@ -22,8 +22,10 @@ public class MixinBlockBed {
                     value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/EntityPlayer;addChatComponentMessage(Lnet/minecraft/util/IChatComponent;)V"))
     public void hodgepodge$sendMessageAboveHotbar(EntityPlayer player, IChatComponent chatComponent) {
+        if (!(player instanceof EntityPlayerMP entityPlayerMP)) return;
+
         GTNHLib.proxy.sendMessageAboveHotbar(
-                (EntityPlayerMP) player,
+                entityPlayerMP,
                 chatComponent.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.WHITE)),
                 60,
                 true,


### PR DESCRIPTION
Fixes an issue with Backhand

```java
java.lang.ClassCastException: class xonin.backhand.client.world.ClientFakePlayer cannot be cast to class net.minecraft.entity.player.EntityPlayerMP (xonin.backhand.client.world.ClientFakePlayer and net.minecraft.entity.player.EntityPlayerMP are in unnamed module of loader 'Launch' @2b4bac49)
    at Launch//net.minecraft.block.BlockBed.redirect$bcf000$hodgepodge$sendMessageAboveHotbar(SourceFile:525)
    at Launch//net.minecraft.block.BlockBed.func_149727_a(SourceFile:107)
    at Launch//xonin.backhand.client.world.ClientFakePlayer.simulateBlockInteraction(ClientFakePlayer.java:85)
```