### PR TITLE
Bug fix : slash command + case command fix

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -342,6 +342,16 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean earlyChunkTileCoordinateCheckDestructive;
 
+    @Config.Comment("Fix forge command handler not checking for a / and also not running commands with any case")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixSlashCommands;
+
+    @Config.Comment("Fix the command handler not allowing you to run commands typed in any case")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixCaseCommands;
+
     // affecting multiple mods
 
     @Config.Comment("Remove old/stale/outdated update checks.")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -398,6 +398,16 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinMinecraft_FixDuplicateSounds")
             .setApplyIf(() -> FixesConfig.fixDuplicateSounds)),
 
+    FIX_SLASH_COMMAND(
+            new Builder("Fix forge command handler not checking for a / and also not running commands with any case")
+                    .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
+                    .addMixinClasses("minecraft.MixinClientCommandHandler_CommandFix")
+                    .setApplyIf(() -> FixesConfig.fixSlashCommands)),
+
+    FIX_CASE_COMMAND(new Builder("Fix the command handler not allowing you to run commands typed in any case")
+            .setPhase(Phase.EARLY).setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA)
+            .addMixinClasses("minecraft.MixinCommandHandler_CommandFix").setApplyIf(() -> FixesConfig.fixCaseCommands)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinClientCommandHandler_CommandFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinClientCommandHandler_CommandFix.java
@@ -1,0 +1,36 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Locale;
+
+import net.minecraft.command.ICommandSender;
+import net.minecraftforge.client.ClientCommandHandler;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+@Mixin(ClientCommandHandler.class)
+public class MixinClientCommandHandler_CommandFix {
+
+    @Inject(method = "executeCommand", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$checkSlash(ICommandSender sender, String message, CallbackInfoReturnable<Integer> cir) {
+        if (!message.trim().startsWith("/")) {
+            cir.setReturnValue(0);
+        }
+    }
+
+    @ModifyExpressionValue(
+            method = "executeCommand",
+            at = @At(value = "INVOKE", target = "Ljava/lang/String;split(Ljava/lang/String;)[Ljava/lang/String;"))
+    private String[] hodgepodge$caseCommand(String[] original) {
+        final String s = original[0];
+        if (s != null) {
+            original[0] = s.toLowerCase(Locale.ENGLISH);
+        }
+        return original;
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCommandHandler_CommandFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCommandHandler_CommandFix.java
@@ -1,0 +1,58 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Locale;
+
+import net.minecraft.command.CommandHandler;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+@Mixin(CommandHandler.class)
+public class MixinCommandHandler_CommandFix {
+
+    @ModifyExpressionValue(
+            method = "executeCommand",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/lang/String;split(Ljava/lang/String;)[Ljava/lang/String;",
+                    remap = false))
+    private String[] hodgepodge$caseCommand(String[] original) {
+        final String s = original[0];
+        if (s != null) {
+            original[0] = s.toLowerCase(Locale.ENGLISH);
+        }
+        return original;
+    }
+
+    @ModifyArg(
+            method = "registerCommand",
+            index = 0,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                    remap = false))
+    private Object hodgepodge$caseCommand(Object s) {
+        if (s instanceof String) {
+            s = ((String) s).toLowerCase(Locale.ENGLISH);
+        }
+        return s;
+    }
+
+    @ModifyExpressionValue(
+            method = "getPossibleCommands(Lnet/minecraft/command/ICommandSender;Ljava/lang/String;)Ljava/util/List;",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/lang/String;split(Ljava/lang/String;I)[Ljava/lang/String;",
+                    remap = false))
+    private String[] hodgepodge$caseCommandTabComplete(String[] original) {
+        final String s = original[0];
+        if (s != null) {
+            original[0] = s.toLowerCase(Locale.ENGLISH);
+        }
+        return original;
+    }
+
+}


### PR DESCRIPTION
Bugs fixed :

- Forge's command handler doesn't check for a `/` at the start of a message before trying to run a command, so if you just type in the chat `commandname` it will actually run the command instead of sending a chat message

- tHe cOMmAnD HaNdLeR DoeSN'T SuPPoRt CoMManDs WriTtEN iN aNy CaSe