### PR TITLE
Disables weather completely on The Last Millenium

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinWorldProviderEndOfTime.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinWorldProviderEndOfTime.java
@@ -15,4 +15,25 @@ public abstract class MixinWorldProviderEndOfTime extends WorldProvider {
     public boolean canDoRainSnowIce(Chunk chunk) {
         return false;
     }
+
+    @Override
+    public void calculateInitialWeather() {
+        this.worldObj.rainingStrength = 0.0F;
+        this.worldObj.thunderingStrength = 0.0F;
+        this.worldObj.prevRainingStrength = 0.0F;
+        this.worldObj.prevThunderingStrength = 0.0F;
+        this.worldObj.getWorldInfo().setRaining(false);
+        this.worldObj.getWorldInfo().setThundering(false);
+    }
+
+    @Override
+    public void updateWeather() {
+        if (!this.worldObj.isRemote) {
+            this.resetRainAndThunder();
+            this.worldObj.rainingStrength = 0.0F;
+            this.worldObj.thunderingStrength = 0.0F;
+            this.worldObj.prevRainingStrength = 0.0F;
+            this.worldObj.prevThunderingStrength = 0.0F;
+        }
+    }
 }


### PR DESCRIPTION
If it's raining in the Overworld and you enter The Last Millenium, it will still be raining, so fixes this.

The code is copied from Personal Space.
https://github.com/GTNewHorizons/PersonalSpace/blob/d26f154f327bac6ac55f8e08214363cf39d9ce0f/src/main/java/me/eigenraven/personalspace/world/PersonalWorldProvider.java#L197