### PR TITLE
Fix Xaero's minimap player entity dot rendering while disabled

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,6 +57,7 @@ dependencies {
     transformedModCompileOnly(rfg.deobf("curse.maven:the-lord-of-the-rings-mod-legacy-423748:4091561"))
     transformedModCompileOnly(deobfNotch("https://mediafiles.forgecdn.net/files/2462/146/mod_voxelMap_1.7.0b_for_1.7.10.litemod"))
     transformedModCompileOnly(rfg.deobf("curse.maven:xaeros-world-map-317780:4716737"))
+    transformedModCompileOnly(rfg.deobf("curse.maven:xaeros-minimap-263420:5637000"))
     transformedModCompileOnly(deobf("https://forum.industrial-craft.net/core/attachment/4316-advancedsolarpanel-1-7-10-3-5-1-jar/"))
     transformedModCompileOnly(rfg.deobf("curse.maven:candycraft-251118:2330488"))
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -663,6 +663,12 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixWitcheryThunderDetection;
 
+    // Xaero's Minimap
+    @Config.Comment("Fixes the player entity dot rendering when arrow is chosen")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixXaerosMinimapEntityDot;
+
     // Xaero's World Map
 
     @Config.Comment("Fix scrolling in the world map screen")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -618,11 +618,16 @@ public enum Mixins {
             .setPhase(Phase.LATE).setSide(Side.CLIENT).addMixinClasses("journeymap.MixinWaypointManager")
             .setApplyIf(() -> FixesConfig.fixJourneymapJumpyScrolling).addTargetedMod(TargetedMod.JOURNEYMAP)),
 
-    // Xaero's Map
+    // Xaero's World Map
     FIX_XAEROS_WORLDMAP_SCROLL(
             new Builder("Fix Xaero's World Map map screen scrolling").addMixinClasses("xaeroworldmap.MixinGuiMap")
                     .setPhase(Phase.LATE).setSide(Side.CLIENT).setApplyIf(() -> FixesConfig.fixXaerosWorldMapScroll)
                     .addTargetedMod(TargetedMod.XAEROWORLDMAP).addTargetedMod(TargetedMod.LWJGL3IFY)),
+
+    // Xaero's Minimap
+    FIX_XAEROS_MINIMAP_ENTITYDOT(new Builder("Fix Xaero's Minimap player entity dot rendering when arrow is chosen")
+            .addMixinClasses("xaerominimap.MixinMinimapRenderer").setPhase(Phase.LATE).setSide(Side.CLIENT)
+            .setApplyIf(() -> FixesConfig.fixXaerosMinimapEntityDot).addTargetedMod(TargetedMod.XAEROMINIMAP)),
 
     // Pam's Harvest the Nether
     FIX_IGNIS_FRUIT_AABB(new Builder("Ignis Fruit").setPhase(Phase.LATE).setSide(Side.BOTH)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -51,6 +51,7 @@ public enum TargetedMod {
     VANILLA("Minecraft", null),
     VOXELMAP("VoxelMap", "com.thevoxelbox.voxelmap.litemod.VoxelMapTransformer", "voxelmap"),
     WITCHERY("Witchery", null, "witchery"),
+    XAEROMINIMAP("Xaero's Minimap", null, "XaeroMinimap"),
     XAEROWORLDMAP("Xaero's World Map", null, "XaeroWorldMap"),
     ZTONES("ZTones", null, "Ztones");
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaerominimap/MixinMinimapRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/xaerominimap/MixinMinimapRenderer.java
@@ -1,0 +1,31 @@
+package com.mitchej123.hodgepodge.mixins.late.xaerominimap;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+
+import xaero.common.minimap.MinimapProcessor;
+import xaero.common.minimap.MinimapRadar;
+import xaero.common.minimap.render.MinimapFBORenderer;
+import xaero.common.minimap.render.MinimapRenderer;
+import xaero.common.settings.ModSettings;
+
+@Mixin(value = MinimapRenderer.class, remap = false)
+public abstract class MixinMinimapRenderer {
+
+    @WrapWithCondition(
+            method = "renderMinimap",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lxaero/common/minimap/render/MinimapFBORenderer;renderMainEntityDot(Lxaero/common/minimap/MinimapProcessor;Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/entity/Entity;DDDDFLxaero/common/minimap/MinimapRadar;ZIZZZDLxaero/common/settings/ModSettings;)V"))
+    private boolean hodgepodge$fixPlayerDotRenderCheck(MinimapFBORenderer instance, MinimapProcessor minimap,
+            EntityPlayer p, Entity renderEntity, double ps, double pc, double playerX, double playerZ, float partial,
+            MinimapRadar minimapRadar, boolean lockedNorth, int style, boolean smooth, boolean debug, boolean cave,
+            double dotNameScale, ModSettings settings) {
+        return !lockedNorth && settings.mainEntityAs == 1;
+    }
+}


### PR DESCRIPTION
Xaero's minimap has three way of showing the player location either as a crosshair, dot or arrow. The dot only checks if the crosshair is not active which means you end up with the following while arrow is chosen
![xaero_mini](https://github.com/user-attachments/assets/4aaf96bc-a743-4bf3-80c9-478f351ea13d)

When the minimap is `lockedNorth` it also forces you to use the arrow which again causes the dot to render.