### PR TITLE
Fix for NPE crash when sourceMap is empty

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -102,6 +102,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean logarithmicVolumeControl;
 
+    @Config.Comment("Fix NPE crash when no audio devices are available")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixNoAudioDeviceCrash;
+
     @Config.Comment("Fix vanilla light calculation sometimes cause NPE on thermos")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -86,6 +86,9 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinSoundManager", "minecraft.MixinSoundManagerLibraryLoader")
             .setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> FixesConfig.logarithmicVolumeControl)),
+    FIX_NO_AUDIO_DEVICE_CRASH(new Builder("Fix No Audio Device Crash").setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinSoundSystemStarterThread").setSide(Side.CLIENT)
+            .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> FixesConfig.fixNoAudioDeviceCrash)),
     THROTTLE_ITEMPICKUPEVENT(new Builder("Throttle Item Pickup Event").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityPlayer").setSide(Side.BOTH)
             .setApplyIf(() -> FixesConfig.throttleItemPickupEvent).addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundSystemStarterThread.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundSystemStarterThread.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import paulscode.sound.SoundSystem;
+
+@Mixin(targets = "net/minecraft/client/audio/SoundManager$SoundSystemStarterThread")
+public class MixinSoundSystemStarterThread extends SoundSystem {
+
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "playing(Ljava/lang/String;)Z",
+            at = @At(value = "INVOKE", target = "Lpaulscode/sound/Library;getSources()Ljava/util/HashMap;"),
+            remap = false,
+            cancellable = true)
+    private void playingPatch(CallbackInfoReturnable<Boolean> cir) {
+        if (this.soundLibrary.getSources() == null) cir.setReturnValue(false);
+    }
+}


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#17190 
Fixes GTNewHorizons/GT-New-Horizons-Modpack#17190
Fixes GTNewHorizons/GT-New-Horizons-Modpack#16281
Maybe Fixes GTNewHorizons/GT-New-Horizons-Modpack#12848 (might be another issue, but this should prevent the crash)
Fixes GTNewHorizons/Hodgepodge#406 
by adding a null check before querying the HashMap.

First time using mixins, so please add comments if there is something I can improve.

### Stacktrace of relevant NPE
```
---- Minecraft Crash Report ----
// This doesn't make any sense!

Time: 2024-09-11 17:54:09 EDT
Description: Unexpected error

java.lang.NullPointerException: Cannot invoke "java.util.HashMap.get(Object)" because the return value of "paulscode.sound.Library.getSources()" is null
    at net.minecraft.client.audio.SoundManager$SoundSystemStarterThread.playing(SoundManager.java:499)
    at net.minecraft.client.audio.SoundManager.updateAllSounds(SoundManager.java:218)
    at net.minecraft.client.audio.SoundHandler.update(SourceFile:179)
    at net.minecraft.client.Minecraft.runTick(Minecraft.java:2013)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:973)
    at net.minecraft.client.Minecraft.run(Minecraft.java:5110)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:219)
    at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:100)
    at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
    at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```


### Before Mixin
```java
    @SideOnly(Side.CLIENT)
    class SoundSystemStarterThread extends SoundSystem
    {
        private static final String __OBFID = "CL_00001145";

        private SoundSystemStarterThread() {}

        public boolean playing(String p_playing_1_)
        {
            Object object = SoundSystemConfig.THREAD_SYNC;

            synchronized (SoundSystemConfig.THREAD_SYNC)
            {
                if (this.soundLibrary == null)
                {
                    return false;
                }
                else
                {
                    Source source = (Source)this.soundLibrary.getSources().get(p_playing_1_); // crashes here when getSources returns null
                    return source == null ? false : source.playing() || source.paused() || source.preLoad;
                }
            }
        }

        SoundSystemStarterThread(Object p_i45118_2_)
        {
            this();
        }
    }
```

### With Mixin
```java
class SoundManager$SoundSystemStarterThread extends SoundSystem {
    private static final String __OBFID = "CL_00001145";
    // $FF: synthetic field
    final SoundManager this$0;

    private SoundManager$SoundSystemStarterThread(SoundManager this$0) {
        this.this$0 = this$0;
    }

    public boolean playing(String p_playing_1_) {
        Object object = SoundSystemConfig.THREAD_SYNC;
        synchronized(SoundSystemConfig.THREAD_SYNC) {
            if (this.soundLibrary == null) {
                return false;
            } else {
                Library var10000 = this.soundLibrary;
                CallbackInfoReturnable callbackInfo6 = new CallbackInfoReturnable("playing", true);
                this.handler$zcj000$hodgepodge$playingPatch(callbackInfo6); // if getSources() is null, short-circuits return false
                if (callbackInfo6.isCancelled()) {
                    return callbackInfo6.getReturnValueZ();
                } else {
                    Source source = (Source)var10000.getSources().get(p_playing_1_);
                    return source == null ? false : source.playing() || source.paused() || source.preLoad;
                }
            }
        }
    }

    SoundManager$SoundSystemStarterThread(SoundManager this$0, Object p_i45118_2_) {
        this(this$0);
    }

    @MixinMerged(
        mixin = "com.mitchej123.hodgepodge.mixins.early.minecraft.MixinSoundSystemStarterThread",
        priority = 1000,
        sessionId = "7d8ea081-07c1-4dc2-a5a0-2b9544df73c8"
    )
    private void handler$zcj000$hodgepodge$playingPatch(CallbackInfoReturnable<Boolean> cir) {
        if (this.soundLibrary.getSources() == null) {
            cir.setReturnValue(false);
        }

    }
}
```