### PR TITLE
Disable offline-mode blocking by default

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -153,7 +153,7 @@ public class FixesConfig {
     public static boolean fixMTCoreRecipe;
 
     @Config.Comment("Allows the server to assign the logged in UUID to the same username when online_mode is false")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean fixNetHandlerLoginServerOfflineMode;
 


### PR DESCRIPTION
I don't know why this is even in the mod to start with, but it's better to keep it and just turn it off unless its actually needed.

There is no point in keeping the fix on unless this causes an issue to start with. The reason is that this fix purposefully blocks offline mode accounts from being used at all unless a player first joins when the server is in online mode, which makes no sense considering the entire point of offline mode is to use an offline account. 

From reading the reason in the fix reason, all it seems to being doing is half ass fixing an issue with UUID's when it comes to offline accounts having randomized UUID's, yet this shouldn't be an issue considering offline accounts on most launchers have fixed UUID's.

Basically the reason for turning it off: 
- This breaks proxy server software that needs a server to be in offline mode to work. There is no hint to server owners what is causing this, so they are unaware of the config for turning it off even existing
- The issue this is trying to solve is a very rare issue that can only be caused by launchers that don't properly handle offline accounts.