### PR TITLE
Rework offline handler - Proxy support

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerLoginServer_OfflineMode.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerLoginServer_OfflineMode.java
@@ -19,7 +19,8 @@ public abstract class MixinNetHandlerLoginServer_OfflineMode {
     // If the player logged in before while online, they get the same UUID. Fixes issues with mods that store info
     // based on UUID (AE2 is a big one)
     @Inject(method = "func_152506_a", at = @At("HEAD"), cancellable = true)
-    protected void func_152506_a(GameProfile original, CallbackInfoReturnable<GameProfile> cir) {
+    protected void hodgepodge$handleOnlineToOfflinePlayers(GameProfile original,
+            CallbackInfoReturnable<GameProfile> cir) {
         Map<UUID, String> usernameCache = UsernameCache.getMap();
         for (Map.Entry<UUID, String> entry : usernameCache.entrySet()) {
             if (entry.getValue().equals(original.getName())) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerLoginServer_OfflineMode.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerLoginServer_OfflineMode.java
@@ -7,52 +7,25 @@ import net.minecraft.server.network.NetHandlerLoginServer;
 import net.minecraftforge.common.UsernameCache;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.mojang.authlib.GameProfile;
 
 @Mixin(NetHandlerLoginServer.class)
 public abstract class MixinNetHandlerLoginServer_OfflineMode {
 
-    @Shadow
-    private GameProfile field_147337_i;
-
-    @Shadow
-    public abstract void func_147322_a(String reason);
-
-    /**
-     * @author Caedis
-     * @reason Allows a server to run offline but only allow players who have logged in while it was online (and they
-     *         get their UUID so stuff works as expected).
-     */
-    @Overwrite
-    protected GameProfile func_152506_a(GameProfile original) {
+    // If the player logged in before while online, they get the same UUID. Fixes issues with mods that store info
+    // based on UUID (AE2 is a big one)
+    @Inject(method = "func_152506_a", at = @At("HEAD"), cancellable = true)
+    protected void func_152506_a(GameProfile original, CallbackInfoReturnable<GameProfile> cir) {
         Map<UUID, String> usernameCache = UsernameCache.getMap();
         for (Map.Entry<UUID, String> entry : usernameCache.entrySet()) {
             if (entry.getValue().equals(original.getName())) {
-                return new GameProfile(entry.getKey(), original.getName());
+                cir.setReturnValue(new GameProfile(entry.getKey(), original.getName()));
             }
         }
-        return null;
     }
 
-    @Inject(
-            method = "func_147326_c()V",
-            at = @At(
-                    value = "INVOKE_ASSIGN",
-                    target = "Lnet/minecraft/server/network/NetHandlerLoginServer;func_152506_a(Lcom/mojang/authlib/GameProfile;)Lcom/mojang/authlib/GameProfile;",
-                    shift = At.Shift.AFTER),
-            cancellable = true)
-    private void hodgepodge$func_147326_c(CallbackInfo ci) {
-        if (this.field_147337_i == null) {
-            // Disconnect null profiles from func_152506_a
-            this.func_147322_a(
-                    "Login while the server is in online mode to be able to login while it is in offline mode.");
-            ci.cancel();
-        }
-    }
 }


### PR DESCRIPTION
Reworks the offline handler to default to the old way if user is not found in cache to better support proxies