### PR TITLE
Transfer GT++ ASM fixes to mixins in hodgepodge

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -640,6 +640,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixWandPedestalVisDuplication;
 
+    @Config.Comment("Fix handling of null stacks in ItemWispEssence")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixNullHandlingItemWispEssence;
+
     // Thermal Dynamics
 
     @Config.Comment("Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -425,6 +425,13 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixCandycraftBlockSugarNPE;
 
+    // Cofh
+
+    @Config.Comment("Fix NPE in COFH's oredict")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixCofhOreDictNPE;
+
     // Extra TiC
 
     @Config.Comment("Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: (Brass, Silver, Electrum & Platinum)")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -5,7 +5,7 @@ import com.gtnewhorizon.gtnhlib.config.Config;
 @Config(modid = "hodgepodge", category = "fixes")
 public class FixesConfig {
 
-    // Minecraft
+    /* ====== Minecraft fixes start ===== */
 
     @Config.Comment("Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes")
     @Config.DefaultBoolean(true)
@@ -357,6 +357,13 @@ public class FixesConfig {
     @Config.DefaultInt(256) // A stack overflow with water updates happens somewhere above 300 updates with default Java
                             // settings
     public static int limitRecursiveBlockUpdateDepth;
+
+    @Config.Comment("Fix an array out of bounds caused by the GameSettings getKeyDisplayString method")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixGameSettingsArrayOutOfBounds;
+
+    /* ====== Minecraft fixes end ===== */
 
     // affecting multiple mods
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -585,6 +585,9 @@ public enum Mixins {
             .addMixinClasses("thermalexpansion.MixinTileInventoryTileLightFalse")
             .addTargetedMod(TargetedMod.THERMALEXPANSION).setApplyIf(() -> ASMConfig.cofhWorldTransformer)
             .setPhase(Phase.LATE).setSide(Side.BOTH)),
+    FIX_ORE_DICT_NPE(new Builder("Fix NPE in OreDictionaryArbiter")
+            .addMixinClasses("cofhcore.MixinOreDictionaryArbiter").setPhase(Phase.EARLY).setSide(Side.BOTH)
+            .addTargetedMod(TargetedMod.COFH_CORE).setApplyIf(() -> FixesConfig.fixCofhOreDictNPE)),
 
     // Immersive engineering
     JAVA12_IMMERSIVE_ENGINERRING(new Builder("Immersive Engineering Java-12 safe potion array resizing")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -420,6 +420,10 @@ public enum Mixins {
     FIX_CASE_COMMAND(new Builder("Fix the command handler not allowing you to run commands typed in any case")
             .setPhase(Phase.EARLY).setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses("minecraft.MixinCommandHandler_CommandFix").setApplyIf(() -> FixesConfig.fixCaseCommands)),
+    FIX_GAMESETTINGS_OUTOFBOUNDS(new Builder("Fix array out of bound error in GameSettings menu").setPhase(Phase.EARLY)
+            .setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
+            .addMixinClasses("minecraft.MixinGameSettings_FixArrayOutOfBounds")
+            .setApplyIf(() -> FixesConfig.fixGameSettingsArrayOutOfBounds).addExcludedMod(TargetedMod.LWJGL3IFY)),
 
     LIMIT_RECURSIVE_BLOCK_UPDATE_DEPTH(new Builder(
             "Limit the number of recursive cascading block updates during world generation to prevent stack overflow crashes")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -541,6 +541,12 @@ public enum Mixins {
     FIX_THAUMCRAFT_VIS_DUPLICATION(new Builder("Fix Thaumcraft Vis Duplication")
             .addMixinClasses("thaumcraft.MixinTileWandPedestal_VisDuplication").setPhase(Phase.LATE).setSide(Side.BOTH)
             .setApplyIf(() -> FixesConfig.fixWandPedestalVisDuplication).addTargetedMod(TargetedMod.THAUMCRAFT)),
+    FIX_NULL_HANDLING_ITEMWISPESSENCE_CLIENT(new Builder("Fix handling of null stacks in ItemWispEssence")
+            .addMixinClasses("thaumcraft.MixinItemWispEssence_Client").setPhase(Phase.LATE).setSide(Side.CLIENT)
+            .setApplyIf(() -> FixesConfig.fixNullHandlingItemWispEssence).addTargetedMod(TargetedMod.THAUMCRAFT)),
+    FIX_NULL_HANDLING_ITEMWISPESSENCE_BOTH(new Builder("Fix handling of null stacks in ItemWispEssence")
+            .addMixinClasses("thaumcraft.MixinItemWispEssence_Both").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.fixNullHandlingItemWispEssence).addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // BOP
     FIX_QUICKSAND_XRAY(new Builder("Fix Xray through block without collision boundingBox").setPhase(Phase.LATE)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinOreDictionaryArbiter.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinOreDictionaryArbiter.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.cofhcore;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cofh.core.util.oredict.OreDictionaryArbiter;
+
+@Mixin(OreDictionaryArbiter.class)
+public class MixinOreDictionaryArbiter {
+
+    @Inject(method = "registerOreDictionaryEntry", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void hodgepodge$fixNPE(ItemStack stack, String s, CallbackInfo ci) {
+        if (stack == null) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSettings_FixArrayOutOfBounds.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSettings_FixArrayOutOfBounds.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.settings.GameSettings;
+import net.minecraft.util.EnumChatFormatting;
+
+import org.lwjgl.input.Keyboard;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(GameSettings.class)
+public class MixinGameSettings_FixArrayOutOfBounds {
+
+    @Inject(method = "getKeyDisplayString", at = @At("HEAD"), cancellable = true)
+    private static void hodgepodge$fixArrayOutOFBounds(int keycode, CallbackInfoReturnable<String> cir) {
+        if (keycode > Keyboard.KEYBOARD_SIZE - 1) {
+            cir.setReturnValue(EnumChatFormatting.RED + "ERROR");
+        }
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinItemWispEssence_Both.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinItemWispEssence_Both.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.items.ItemWispEssence;
+
+@Mixin(ItemWispEssence.class)
+public class MixinItemWispEssence_Both {
+
+    @Inject(method = "getAspects", at = @At("HEAD"), cancellable = true, remap = false)
+    private void hodgpodge$fixNullAspect(ItemStack stack, CallbackInfoReturnable<AspectList> cir) {
+        if (stack == null) {
+            cir.setReturnValue(null);
+        }
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinItemWispEssence_Client.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinItemWispEssence_Client.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import thaumcraft.common.items.ItemWispEssence;
+
+@Mixin(ItemWispEssence.class)
+public class MixinItemWispEssence_Client {
+
+    @Inject(method = "getColorFromItemStack", at = @At("HEAD"), cancellable = true)
+    private void hodgpodge$fixNullColor(ItemStack stack, int par2, CallbackInfoReturnable<Integer> cir) {
+        if (stack == null) {
+            cir.setReturnValue(0);
+        }
+    }
+
+}


### PR DESCRIPTION
The keyboard fix in gt++ was 600 lines of broken ASM combined with reflection when it could be a 5 lines mixin 

Transfered the thaumcraft ItemWispEssence fix

Transfered the cofh npe fix

See : https://github.com/GTNewHorizons/GT5-Unofficial/pull/3238