### PR TITLE
fix ic2 crops making any farmland trampleable

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -556,6 +556,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean optimizeIc2ReactorInventoryAccess;
 
+    @Config.Comment("Fix IC2 Crops trampling any types of farmland to dirt when sprinting")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixIc2CropTrampling;
+
     // Journey Map
 
     @Config.Comment("Prevents journeymap from using illegal character in file paths")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -480,6 +480,9 @@ public enum Mixins {
             new Builder("IC2 Resource Pack Translation Fix").setPhase(Phase.EARLY).setSide(Side.CLIENT)
                     .addMixinClasses("fml.MixinLanguageRegistry", "fml.MixinFMLClientHandler", "ic2.MixinLocalization")
                     .setApplyIf(() -> FixesConfig.fixIc2ResourcePackTranslation).addTargetedMod(TargetedMod.IC2)),
+    IC2_CROP_TRAMPLING_FIX(new Builder("IC2 Crop Trampling Fix").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addMixinClasses("ic2.MixinIC2TileEntityCrop").setApplyIf(() -> FixesConfig.fixIc2CropTrampling)
+            .addTargetedMod(TargetedMod.IC2)),
 
     // Disable update checkers
     BIBLIOCRAFT_UPDATE_CHECK(new Builder("Yeet Bibliocraft Update Check").setPhase(Phase.LATE).setSide(Side.CLIENT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIC2TileEntityCrop.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIC2TileEntityCrop.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.tileentity.TileEntity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import ic2.core.crop.TileEntityCrop;
+
+@Mixin(TileEntityCrop.class)
+public class MixinIC2TileEntityCrop extends TileEntity {
+
+    @Inject(method = "calcTrampling", at = @At("HEAD"), cancellable = true, remap = false)
+    public void hodgepodge$fixIC2CropTrampling(CallbackInfo ci) {
+        Block below = worldObj.getBlock(this.xCoord, this.yCoord - 1, this.zCoord);
+        // If the crop is trampled (usually by sprinting over it), the block below always replaced with dirt by ic2.
+        // This only makes sense if the block was actually dirt-farmland, as otherwise special farmland may
+        // get replaced with dirt, including those that are supposed to be un-trample-able.
+        // Special handling for other farmland types that should be trample-able may be added here, if there are any.
+        if (below != Blocks.farmland) ci.cancel();
+    }
+}


### PR DESCRIPTION
Each IC2 plant can implement a `onEntityCollision` behavior for when it should be trampled.  
By default, crops can be trampled by sprinting over it.
When an IC2 crop is trampled this way, it will set the block below it to dirt.
This is an issue, because it means that even farmland which shouldn't be tramplable (at least via the vanilla falling-onto-farmland mechanic) like Fertilized Dirt can be trampled and will be replaced with *normal dirt* (instead of the un-tilled fertilized dirt).

This fix just disables the ic2 crop trampling by sprinting for blocks that aren't normal farmland.
If there are any custom farmlands that should be able to be trampled, they can just be specially cased in the fix, but I'm not aware of any.

*Could* also be implemented by calling `onFallenUpon` when attempting to trample the crop to try to invoke its trampling-by-falling-onto behavior and avoid any special-casing, but not sure if that's a good idea; who knows what devs are using that method.

After running over some crops containing plants that can be trampled:
![image](https://github.com/user-attachments/assets/ac4677be-36a8-4435-b89b-54986fcb4608)

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/4571 and thus needs a quest update to this quest
![image](https://github.com/user-attachments/assets/6d4c6ea7-4124-4323-b285-acb9d9640f83)
( https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16658 )