### PR TITLE
Add a search bar to the mod config gui

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/ASMConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/ASMConfig.java
@@ -3,21 +3,19 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "asm")
+@Config.RequiresMcRestart
 public class ASMConfig {
 
     @Config.Comment("Disable CoFH TileEntity cache (and patch MineFactory Reloaded and Thermal Expansion with a workaround)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean cofhWorldTransformer;
 
     @Config.Comment("Speedup progressbar")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupProgressBar;
 
     @Config.Comment("Speedup LongInt HashMap")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupLongIntHashMap;
 
     @Config.Comment("If using Bukkit/Thermos, the CraftServer package.")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -3,263 +3,213 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "fixes")
+@Config.RequiresMcRestart
 public class FixesConfig {
 
     /* ====== Minecraft fixes start ===== */
 
     @Config.Comment("Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean changeMaxNetworkNbtSizeLimit;
 
     @Config.Comment("Safely enlarge the potion array before other mods")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean enlargePotionArray;
 
     @Config.Comment("Fix bogus FMLProxyPacket NPEs on integrated server crashes.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixBogusIntegratedServerNPEs;
 
     @Config.Comment("Fix wrapped chat lines missing colors")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixChatWrappedColors;
 
     @Config.Comment("Prevents crash if server sends container with wrong itemStack size")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixContainerPutStacksInSlots;
 
     @Config.Comment("Fixes the debug hitbox of the player beeing offset")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixDebugBoundingBox;
 
     @Config.Comment("Fix losing bonus hearts on dimension change")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixDimensionChangeHearts;
 
     @Config.Comment("Fix duplicate sounds from playing when closing a gui.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixDuplicateSounds;
 
     @Config.Comment("Fix deleting stack when eating mushroom stew")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixEatingStackedStew;
 
     @Config.Comment("Fix a class name typo in MinecraftForge's initialize method")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixEffectRendererClassTypo;
 
     @Config.Comment("Fix enchantment levels not displaying properly above a certain value")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixEnchantmentNumerals;
 
     @Config.Comment("Fix fence connections with other types of fence")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixFenceConnections;
 
     @Config.Comment("Fix vanilla fire spread sometimes cause NPE on thermos")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixFireSpread;
 
     @Config.Comment("Fix Forge fluid container registry key")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixFluidContainerRegistryKey;
 
     @Config.Comment("Replace recursion with iteration in FontRenderer line wrapping code")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixFontRendererLinewrapRecursion;
 
     @Config.Comment("Fix windowId being set on openContainer even if openGui failed")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixForgeOpenGuiHandlerWindowId;
 
     @Config.Comment("Fix the Forge update checker")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixForgeUpdateChecker;
 
     @Config.Comment("Fix vanilla issue where player sounds register as animal sounds")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixFriendlyCreatureSounds;
 
     @Config.Comment("Fix Volume Slider is ineffective until reaching the lower end")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean logarithmicVolumeControl;
 
     @Config.Comment("Fix vanilla light calculation sometimes cause NPE on thermos")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixGetBlockLightValue;
 
     @Config.Comment("Fix vanilla GL state bugs causing lighting glitches in various perspectives (MC-10135).")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixGlStateBugs;
 
     @Config.Comment("Fix Game Over GUI buttons disabled if switching fullscreen")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixGuiGameOver;
 
     @Config.Comment("Fix arm not swinging when having too much haste")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHasteArmSwing;
 
     @Config.Comment("Fix vanilla Hopper hit box")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHopperHitBox;
 
     @Config.Comment("Fix Drawer + Hopper voiding items")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHopperVoidingItems;
 
     @Config.Comment("Fix oversized chat message kicking player.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHugeChatKick;
 
     @Config.Comment("Fix the bug that makes fireballs stop moving when chunk unloads")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixImmobileFireballs;
 
     @Config.Comment("Fix an overflow of the dimension id when a player logins on a server")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixLoginDimensionIDOverflow;
 
     @Config.Comment("Fixes the damage of the Thick Neutron Reflectors in the MT Core recipe (Advanced Solar Panels)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixMTCoreRecipe;
 
     @Config.Comment("Allows the server to assign the logged in UUID to the same username when online_mode is false")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNetHandlerLoginServerOfflineMode;
 
     @Config.Comment("Prevents crash if server sends itemStack with index larger than client's container")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNetHandlerPlayClientHandleSetSlot;
 
     @Config.Comment("Fix NPE in Netty's Bootstrap class")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNettyNPE;
 
     @Config.Comment("Fix northwest bias on RandomPositionGenerator")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNorthWestBias;
 
     @Config.Comment("Prevent tall grass and such to affect the perspective camera")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPerspectiveCamera;
 
     @Config.Comment("Allow some mods to properly fetch the player skin")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPlayerSkinFetching;
 
     @Config.Comment("Preserve the order of quads in terrain pass 1")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPreserveQuadOrder;
 
     @Config.Comment("Properly display level of potion effects in the inventory and on tooltips")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPotionEffectNumerals;
 
     @Config.Comment("Fix crashes with ConcurrentModificationException because of incorrectly iterating over active potions")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPotionIterating;
 
     @Config.Comment("Fix potions >= 128")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPotionLimit;
 
     @Config.Comment("Fix redstone torch leaking world")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixRedstoneTorchWorldLeak;
 
     @Config.Comment("Fix EffectRenderer and RenderGlobal leaking world instance when leaving world")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixRenderersWorldLeak;
 
     @Config.Comment("Fix game window becoming not resizable after toggling fullscrean in any way")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixResizableFullscreen;
 
     @Config.Comment("Fix resource pack folder not opening on Windows if file path has a space")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixResourcePackOpening;
 
     @Config.Comment("Fix too many allocations from Chunk Coordinate Int Pair")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixTooManyAllocationsChunkPositionIntPair;
 
     @Config.Comment("Fix exiting fullscreen when you tab out of the game")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixUnfocusedFullscreen;
 
     @Config.Comment("Fix URISyntaxException in forge.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixUrlDetection;
 
     @Config.Comment("Fixes various unchecked vanilla getBlock() methods")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixVanillaUnprotectedGetBlock;
 
     @Config.Comment("Fixes village unchecked getBlock() calls")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixVillageUncheckedGetBlock;
 
     @Config.Comment("Fix unprotected getBlock() in World")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixWorldGetBlock;
 
     @Config.Comment("Fix WorldServer leaking entities when no players are present in a dimension")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixWorldServerLeakingUnloadedEntities;
 
     @Config.Comment("Increase the maximum network packet size from the default of 2MiB")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean increasePacketSizeLimit;
 
     @Config.Comment("Stacks picked up per tick")
@@ -269,7 +219,6 @@ public class FixesConfig {
 
     @Config.Comment("Log oversized chat message to console. WARNING: might create huge log files if this happens very often.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean logHugeChat;
 
     @Config.Comment("The maximum NBT size limit in bytes when received as a network packet, the vanilla value is 2097152 (2 MiB).")
@@ -279,7 +228,6 @@ public class FixesConfig {
 
     @Config.Comment("Fix too early light initialization")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean optimizeWorldUpdateLight;
 
     @Config.Comment("The maximum size limit in bytes of a network packet to accept, the vanilla value is 2097152 (2 MiB).")
@@ -289,67 +237,54 @@ public class FixesConfig {
 
     @Config.Comment("Spigot-style extended chunk format to remove the 2MB chunk size limit")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean remove2MBChunkLimit;
 
     @Config.Comment("Disable the creative search tab since it can be very laggy in large modpacks")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean removeCreativeSearchTab;
 
     @Config.Comment("Drastically speedup animated textures (Basically the same as with optifine animations off but animations are working)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupAnimations;
 
     @Config.Comment("Stop \"You can only sleep at night\" message filling the chat")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean squashBedErrorMessage;
 
     @Config.Comment("Limits the amount of times the ItemPickupEvent triggers per tick since it can lead to a lot of lag")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean throttleItemPickupEvent;
 
     @Config.Comment("Triggers all conflicting key bindings on key press instead of a random one")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean triggerAllConflictingKeybindings;
 
     @Config.Comment("Validate vanilla packet encodings before sending in addition to on reception")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean validatePacketEncodingBeforeSending;
 
     @Config.Comment("Should the extended packet validation error cause a crash (true) or just print out an error to the log (false)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean validatePacketEncodingBeforeSendingShouldCrash;
 
     @Config.Comment("Checks saved TileEntity coordinates earlier to provide a more descriptive error message")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean earlyChunkTileCoordinateCheck;
 
     @Config.Comment("Fix the temperature can go below absolute zero at very high place")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNegativeKelvin;
 
     @Config.Comment("Destroy and log TileEntities failing the safe coordinate instead of crashing the game (can cause loss of data)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean earlyChunkTileCoordinateCheckDestructive;
 
     @Config.Comment("Fix forge command handler not checking for a / and also not running commands with any case")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixSlashCommands;
 
     @Config.Comment("Fix the command handler not allowing you to run commands typed in any case")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixCaseCommands;
 
     @Config.Comment("Limit the number of recursive cascading block updates during world generation to prevent stack overflow crashes, set to -1 to disable the limit.")
@@ -360,7 +295,6 @@ public class FixesConfig {
 
     @Config.Comment("Fix an array out of bounds caused by the GameSettings getKeyDisplayString method")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixGameSettingsArrayOutOfBounds;
 
     /* ====== Minecraft fixes end ===== */
@@ -369,7 +303,6 @@ public class FixesConfig {
 
     @Config.Comment("Remove old/stale/outdated update checks.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean removeUpdateChecks;
 
     // BetterHUD
@@ -381,335 +314,278 @@ public class FixesConfig {
 
     @Config.Comment("Fix BetterHUD armor bar rendering breaking with skulls")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixBetterHUDArmorDisplay;
 
     @Config.Comment("Fix BetterHUD freezing the game when trying to render high amounts of hp")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixBetterHUDHPDisplay;
 
     // Bibliocraft
 
     @Config.Comment("Fix Bibliocraft packet exploits")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixBibliocraftPackets;
 
     @Config.Comment("Fix Bibliocraft path sanitization")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixBibliocraftPathSanitization;
 
     // Biomes O' Plenty
 
     @Config.Comment("Removes duplicate Fermenter and Squeezer recipes and flower registration")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean deduplicateForestryCompatInBOP;
 
     @Config.Comment("BiomesOPlenty Java 12 compatibility patches.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean java12BopCompat;
 
     @Config.Comment("Remove the BOP warning on first world generation (ignored when dreamcraft is present)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean removeBOPWarning;
 
     // Candycraft
 
     @Config.Comment("Fix NPE when interacting with sugar block")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixCandycraftBlockSugarNPE;
 
     // Cofh
 
     @Config.Comment("Fix NPE in COFH's oredict")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixCofhOreDictNPE;
 
     // Extra TiC
 
     @Config.Comment("Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: (Brass, Silver, Electrum & Platinum)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean fixExtraTiCTEConflict;
 
     // Extra Utilities
 
     @Config.Comment("Fix Extra Utilities drums eating IC2 cells and Forestry capsules")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesDrumEatingCells;
 
     @Config.Comment("Fix Extra Utilities Lapis Caelestis microblocks rendering")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesGreenscreenMicroblocks;
 
     @Config.Comment("Fixes rendering issues with transparent items from Extra Utilities")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesItemRendering;
 
     @Config.Comment("Fix dupe bug with Division Sigil removing enchantment")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesUnEnchanting;
 
     @Config.Comment("Remove rain from the Last Millenium (Extra Utilities)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesLastMilleniumRain;
 
     @Config.Comment("Remove creatures from the Last Millenium (Extra Utilities)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesLastMilleniumCreatures;
 
     @Config.Comment("Prevent fluid retrieval node from voiding (Extra Utilities)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixExtraUtilitiesFluidRetrievalNode;
 
     // Galacticraft
 
     @Config.Comment("Fix time commands with GC")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixTimeCommandWithGC;
 
     // Gliby's Voice Chat
 
     @Config.Comment("Fix Gliby's voice chat not shutting down its thread cleanly")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixGlibysVoiceChatThreadStop;
 
     // Hunger Overhaul
 
     @Config.Comment("Fix Hunger Overhaul low stat effects")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHungerOverhaul;
 
     @Config.Comment("Fix some items restore 0 hunger")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHungerOverhaulRestore0Hunger;
 
     // Immersive Engineering
 
     @Config.Comment("Immersive Engineering Java 12 compatibility patch")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean java12ImmersiveEngineeringCompat;
 
     // Industrialcraft
 
     @Config.Comment("Fix lag caused by IC2 armor tick")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2ArmorLag;
 
     @Config.Comment("Fix IC2's direct inventory access")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2DirectInventoryAccess;
 
     @Config.Comment("Fix IC2 armors to avoid giving poison")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2Hazmat;
 
     @Config.Comment("Fix IC2's armor hover mode")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2HoverMode;
 
     @Config.Comment("Prevent IC2's nightvision from blinding you")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2Nightvision;
 
     @Config.Comment("Fix IC2's reactor dupe")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2ReactorDupe;
 
     @Config.Comment("Fix IC2 not loading translations from resource packs")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2ResourcePackTranslation;
 
     @Config.Comment("Fixes various unchecked IC2 getBlock() methods")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2UnprotectedGetBlock;
 
     @Config.Comment("Optimize inventory access to IC2 nuclear reactor")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean optimizeIc2ReactorInventoryAccess;
 
     @Config.Comment("Fix IC2 Crops trampling any types of farmland to dirt when sprinting")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIc2CropTrampling;
 
     // Journey Map
 
     @Config.Comment("Prevents journeymap from using illegal character in file paths")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixJourneymapFilePath;
 
     @Config.Comment("Fix jumpy scrolling in the waypoint manager screen")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixJourneymapJumpyScrolling;
 
     @Config.Comment("Prevent unbound keybinds from triggering when pressing certain keys")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixJourneymapKeybinds;
 
     // The Lord of the Rings Mod
 
     @Config.Comment("Lotr Java 12 compatibility patch")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean java12LotrCompat;
 
     // Minechem
 
     @Config.Comment("Minechem Java 12 compatibility patch")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean java12MineChemCompat;
 
     // Morpheus
 
     @Config.Comment("Fix not properly waking players if not everyone is sleeping")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixMorpheusWaking;
 
     // Optifine
 
     @Config.Comment("Forces the chunk loading option from optifine to default since other values can crash the game")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixOptifineChunkLoadingCrash;
 
     // Pam's Harvest the Nether
 
     @Config.Comment("Fix Axis aligned Bounding Box of Ignis Fruit")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixIgnisFruitAABB;
 
     @Config.Comment("If fancy graphics are enabled, Nether Leaves render sides with other Nether Leaves adjacent too")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNetherLeavesFaceRendering;
 
     // PortalGun
 
     @Config.Comment("Fix outdated URLs used in the PortalGun mod to download the sound pack")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPortalGunURLs;
 
     // Thaumcraft
 
     @Config.Comment("Fix Thaumcraft Aspects being sorted by tag instead of by name")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixThaumcraftAspectSorting;
 
     @Config.Comment("Fix golem's marker loading failure when dimensionId larger than MAX_BYTE")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixThaumcraftGolemMarkerLoading;
 
     @Config.Comment("Implement a proper hashing method for WorldCoordinates")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixThaumcraftWorldCoordinatesHashingMethod;
 
     @Config.Comment("Fix Thaumcraft leaves frequent ticking")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixThaumcraftLeavesLag;
 
     @Config.Comment("Fix Thaumcraft wand pedestal vis duplication")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixWandPedestalVisDuplication;
 
     @Config.Comment("Fix handling of null stacks in ItemWispEssence")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixNullHandlingItemWispEssence;
 
     // Thermal Dynamics
 
     @Config.Comment("Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean preventThermalDynamicsNASE;
 
     // VoxelMap
 
     @Config.Comment("Fix some NullPointerExceptions")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixVoxelMapChunkNPE;
 
     @Config.Comment("Fix Y coordinate being off by one")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixVoxelMapYCoord;
 
     // Witchery
 
     @Config.Comment("Disable Witchery potion extender for Java 12 compat")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean disableWitcheryPotionExtender;
 
     @Config.Comment("Fixes Witchery player skins reflections with inhabited mirrors")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixWitcheryReflections;
 
     @Config.Comment("Enhanced Witchery Thunder Detection for rituals and Witch Hunters")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixWitcheryThunderDetection;
 
     // Xaero's Minimap
     @Config.Comment("Fixes the player entity dot rendering when arrow is chosen")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixXaerosMinimapEntityDot;
 
     // Xaero's World Map
 
     @Config.Comment("Fix scrolling in the world map screen")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixXaerosWorldMapScroll;
 
     // ZTones
 
     @Config.Comment("Fix ZTones packet exploits")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixZTonesPackets;
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/PollutionConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/PollutionConfig.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "pollution")
+@Config.RequiresMcRestart
 public class PollutionConfig {
 
     // Minecraft
@@ -13,7 +14,6 @@ public class PollutionConfig {
 
     @Config.Comment("Make furnaces Pollute")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean furnacesPollute;
 
     @Config.Comment("Furnace pollution per second, min 1!")
@@ -28,7 +28,6 @@ public class PollutionConfig {
 
     @Config.Comment("Make rockets Pollute")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean rocketsPollute;
 
     // Railcraft
@@ -51,7 +50,6 @@ public class PollutionConfig {
 
     @Config.Comment("Make Railcraft Pollute")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean railcraftPollutes;
 
     @Config.Comment("Pollution Amount for tunnel bore")

--- a/src/main/java/com/mitchej123/hodgepodge/config/PollutionRecolorConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/PollutionRecolorConfig.java
@@ -3,33 +3,29 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "pollution_recolor")
+@Config.RequiresMcRestart
 public class PollutionRecolorConfig {
 
     @Config.Comment("Changes colors of certain blocks based on pollution levels")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean pollutionBlockRecolor;
 
     @Config.Comment("Double Plant Blocks - Recolor Block List")
     @Config.DefaultStringList({ "net.minecraft.block.BlockDoublePlant:FLOWER", })
-    @Config.RequiresMcRestart
     public static String[] renderBlockDoublePlant;
 
     @Config.Comment("Liquid Blocks - Recolor Block List")
     @Config.DefaultStringList({ "net.minecraft.block.BlockLiquid:LIQUID" })
-    @Config.RequiresMcRestart
     public static String[] renderBlockLiquid;
 
     @Config.Comment("Block Vine - Recolor Block List")
     @Config.DefaultStringList({ "net.minecraft.block.BlockVine:FLOWER", })
-    @Config.RequiresMcRestart
     public static String[] renderblockVine;
 
     @Config.Comment("Crossed Squares - Recolor Block List")
     @Config.DefaultStringList({ "net.minecraft.block.BlockTallGrass:FLOWER", "net.minecraft.block.BlockFlower:FLOWER",
             "biomesoplenty.common.blocks.BlockBOPFlower:FLOWER", "biomesoplenty.common.blocks.BlockBOPFlower2:FLOWER",
             "biomesoplenty.common.blocks.BlockBOPFoliage:FLOWER", })
-    @Config.RequiresMcRestart
     public static String[] renderCrossedSquares;
 
     @Config.Comment("Standard Blocks - Recolor Block List")
@@ -37,7 +33,6 @@ public class PollutionRecolorConfig {
             "biomesoplenty.common.blocks.BlockOriginGrass:GRASS", "biomesoplenty.common.blocks.BlockLongGrass:GRASS",
             "biomesoplenty.common.blocks.BlockNewGrass:GRASS", "tconstruct.blocks.slime.SlimeGrass:GRASS",
             "thaumcraft.common.blocks.BlockMagicalLeaves:LEAVES", })
-    @Config.RequiresMcRestart
     public static String[] renderStandardBlock;
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -3,62 +3,53 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "speedups")
+@Config.RequiresMcRestart
 public class SpeedupsConfig {
 
     // Minecraft
 
     @Config.Comment("Optimize ASMDataTable getAnnotationsFor for faster startup")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean optimizeASMDataTable;
 
     @Config.Comment("Optimize texture loading")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean optimizeTextureLoading;
 
     @Config.Comment("Optimize tileEntity removal in World.class")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean optimizeTileentityRemoval;
 
     @Config.Comment("Speedup ChunkCoordinates hashCode")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupChunkCoordinatesHashCode;
 
     @Config.Comment("Speed up grass block random ticking")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupGrassBlockRandomTicking;
 
     @Config.Comment("Speedup Vanilla Furnace recipe lookup")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupVanillaFurnace;
 
     @Config.Comment("Sets TCP_NODELAY to true, reducing network latency in multiplayer. Works on server as well as client. From makamys/CoreTweaks")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean tcpNoDelay;
 
     @Config.Comment("Speeds up ChunkProviderClient by removing chunkListing.  Note: Depends on asm.speedupLongIntHashMap")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupChunkProviderClient;
 
     // Biomes O' Plenty
 
     @Config.Comment("Speedup biome fog rendering in BiomesOPlenty")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean speedupBOPFogHandling;
 
     // VoxelMap
 
     @Config.Comment("Replace reflection in VoxelMap to directly access the fields instead.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean replaceVoxelMapReflection;
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -3,33 +3,29 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "tweaks")
+@Config.RequiresMcRestart
 public class TweaksConfig {
 
     // Minecraft
 
     @Config.Comment("Adds system info to the F3 overlay (Java version and vendor; GPU name; OpenGL version; CPU cores; OS name, version and architecture)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean addSystemInfo;
 
     @Config.Comment("Add a debug message in the chat when toggling vanilla debug options")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean addToggleDebugMessage;
 
     @Config.Comment("Uses arabic numbers for enchantment levels and potion amplifier levels instead of roman numbers")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean arabicNumbersForEnchantsPotions;
 
     @Config.Comment("Show \"cannot sleep\" messages above hotbar")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean bedMessageAboveHotbar;
 
     @Config.Comment("Moves the sprint keybind to the movement category")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean changeSprintCategory;
 
     @Config.Comment("Amount of chat lines kept (Vanilla: 100)")
@@ -39,7 +35,6 @@ public class TweaksConfig {
 
     @Config.Comment("Compacts identical consecutive chat messages together")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean compactChat;
 
     @Config.Comment("Specify default LAN port to open an integrated server on. Set to 0 to always open the server on an automatically allocated port.")
@@ -49,42 +44,34 @@ public class TweaksConfig {
 
     @Config.Comment("Disable Minecraft Realms button on main menu")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean disableRealmsButton;
 
     @Config.Comment("Stop inverting colors of crosshair")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean dontInvertCrosshairColor;
 
     @Config.Comment("Drop picked loot on entity despawn")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean dropPickedLootOnDespawn;
 
     @Config.Comment("Open an integrated server on a static port.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean enableDefaultLanPort;
 
     @Config.Comment("Use CMD key on MacOS to COPY / INSERT / SELECT in text fields (Chat, NEI, Server IP etc.)")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean enableMacosCmdShortcuts;
 
     @Config.Comment("Shows renderer's impact on FPS in vanilla lagometer")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean enableTileRendererProfiler;
 
     @Config.Comment("Remove the blueish sky tint from night vision")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean enhanceNightVision;
 
     @Config.Comment("Allows blocks to be placed at a faster rate (toggleable via keybind)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean fastBlockPlacing;
 
     @Config.Comment("Allow players on your server to use fast block placement")
@@ -93,32 +80,26 @@ public class TweaksConfig {
 
     @Config.Comment("Prevents the inventory from shifting when the player has active potion effects")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPotionRenderOffset;
 
     @Config.Comment("Stops rendering the crosshair when you are playing in third person")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean hideCrosshairInThirdPerson;
 
     @Config.Comment("Increase particle limit")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean increaseParticleLimit;
 
     @Config.Comment("Makes the chat history longer instead of 100 lines")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean longerChat;
 
     @Config.Comment("Allows you to send longer chat messages, up to 256 characters, instead of 100 in vanilla.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean longerSentMessages;
 
     @Config.Comment("Adds pick block functionality to survival mode")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean modernPickBlock;
 
     @Config.Comment("Particle limit (Vanilla: 4000)")
@@ -128,17 +109,14 @@ public class TweaksConfig {
 
     @Config.Comment("Prevent monsters from picking up loot.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean preventPickupLoot;
 
     @Config.Comment("Stop playing a sound when spawning a minecart in the world")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean removeSpawningMinecartSound;
 
     @Config.Comment("Doesn't render the black box behind messages when the chat is closed")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean transparentChat;
 
     @Config.Comment("Sets the interval for auto saves in ticks (20 ticks = 1 second)")
@@ -148,29 +126,24 @@ public class TweaksConfig {
 
     @Config.Comment("Reduces water opacity from 3 to 1, to match modern")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean useLighterWater;
 
     // affecting multiple mods
 
     @Config.Comment("Unbinds keybinds of certain ARR mods to avoid keybinds conflicts")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean unbindKeybindsByDefault;
 
     @Config.Comment("Adds non-vanilla blocks/items to the statistics")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean addModItemStats;
 
     @Config.Comment("Adds non-vanilla entities to the statistics")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean addModEntityStats;
 
     @Config.Comment("No stats will be registered for these enties (e.g. because another mod already adds them)")
     @Config.DefaultStringList({ "Mob", "Monster" })
-    @Config.RequiresMcRestart
     public static String[] entityStatsExclusions;
 
     @Config.Comment("Sort Mob stats lexicographically (Requires addModEntityStats)")
@@ -185,43 +158,36 @@ public class TweaksConfig {
 
     @Config.Comment("Implement container for thirsty tank")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean thirstyTankContainer;
 
     // Biomes O' Plenty
 
     @Config.Comment("Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean makeBigFirsPlantable;
 
     @Config.Comment("Remove the BOP quicksand generation")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean removeBOPQuicksandGeneration;
 
     // Extra Utilities
 
     @Config.Comment("Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far.")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean disableAidSpawnByXUSpikes;
 
     // Industrialcraft
 
     @Config.Comment("Display fluid localized name in IC2 fluid cell tooltip")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean displayIc2FluidLocalizedName;
 
     @Config.Comment("Prevent IC2's reactor's coolant slots from being accessed by automations if not a fluid reactor")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean hideIc2ReactorSlots;
 
     @Config.Comment("Give IC2 cells containers like GregTech cells do")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean ic2CellWithContainer;
 
     @Config.Comment("IC2 seed max stack size")
@@ -240,69 +206,58 @@ public class TweaksConfig {
 
     @Config.Comment("Fix vanilla potion effects rendering above the NEI tooltips in the inventory")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixPotionEffectRender;
 
     // Optifine
 
     @Config.Comment("Removes the 'GL error' message that appears when using a shader in Optifine/Shadersmod")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean removeOptifineGLErrors;
 
     // ProjectRed
 
     @Config.Comment("Fix Project Red components popping off on unloaded chunks")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixComponentsPoppingOff;
 
     @Config.Comment("Fix hotbars being dark when Project Red is installed")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean fixHudLightingGlitch;
 
     // Railcraft
 
     @Config.Comment("Wake up passive & personal anchors on player login")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean installAnchorAlarm;
 
     // Thaumcraft
 
     @Config.Comment("Add CV support to Thaumcraft wand recharge pedestal")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean addCVSupportToWandPedestal;
 
     @Config.Comment("Stops rendering potion particles from yourself")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean hidePotionParticlesFromSelf;
 
     // VoxelMap
 
     @Config.Comment("Changes the file extension of VoxelMap's cache files from .zip to .data to stop the TechnicLauncher from deleting them when updating")
     @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
     public static boolean changeCacheFileExtension;
 
     // Chunk generation and population config
 
     @Config.Comment("Disable terrain generation for new generated chunks (all blocks become air, biomes remain)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean disableChunkTerrainGeneration;
 
     @Config.Comment("Disable world type associated chunk population for new generated chunks (e.g. vanilla structures in Overworld)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean disableWorldTypeChunkPopulation;
 
     @Config.Comment("Disable all extra mod chunk population for new generated chunks (e.g. Natura's clouds)")
     @Config.DefaultBoolean(false)
-    @Config.RequiresMcRestart
     public static boolean disableModdedChunkPopulation;
 
     @Config.Comment("Avoids droping items on container close, and instead places them in the player inventory. (Inspired from EFR)")

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -177,6 +177,10 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean sortEntityStats;
 
+    @Config.Comment("Adds a search bar to the mod config GUI")
+    @Config.DefaultBoolean(true)
+    public static boolean addModConfigSearchBar;
+
     // Automagy
 
     @Config.Comment("Implement container for thirsty tank")

--- a/src/main/java/com/mitchej123/hodgepodge/config/gui/HodgepodgeGuiConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/gui/HodgepodgeGuiConfig.java
@@ -13,13 +13,14 @@ import com.mitchej123.hodgepodge.config.PollutionRecolorConfig;
 import com.mitchej123.hodgepodge.config.SpeedupsConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
-public class HodgepdgeGuiConfig extends SimpleGuiConfig {
+public class HodgepodgeGuiConfig extends SimpleGuiConfig {
 
-    public HodgepdgeGuiConfig(GuiScreen parent) throws ConfigException {
+    public HodgepodgeGuiConfig(GuiScreen parent) throws ConfigException {
         super(
                 parent,
                 "hodgepodge",
                 "hodgepodge",
+                true,
                 ASMConfig.class,
                 DebugConfig.class,
                 FixesConfig.class,

--- a/src/main/java/com/mitchej123/hodgepodge/config/gui/HodgepodgeGuiConfigFactory.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/gui/HodgepodgeGuiConfigFactory.java
@@ -8,6 +8,6 @@ public class HodgepodgeGuiConfigFactory implements SimpleGuiFactory {
 
     @Override
     public Class<? extends GuiScreen> mainConfigGuiClass() {
-        return HodgepdgeGuiConfig.class;
+        return HodgepodgeGuiConfig.class;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -433,7 +433,7 @@ public enum Mixins {
 
     ADD_MOD_CONFIG_SEARCHBAR(new Builder("Adds a search bar to the mod config GUI").setPhase(Phase.EARLY)
             .setSide(Side.CLIENT).addMixinClasses("fml.MixinGuiConfig")
-            .setApplyIf(() -> TweaksConfig.addModConfigSearchBar).addExcludedMod(TargetedMod.VANILLA)),
+            .setApplyIf(() -> TweaksConfig.addModConfigSearchBar).addTargetedMod(TargetedMod.VANILLA)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -434,7 +434,7 @@ public enum Mixins {
     ADD_MOD_CONFIG_SEARCHBAR(new Builder("Adds a search bar to the mod config GUI").setPhase(Phase.EARLY)
             .setSide(Side.CLIENT).addMixinClasses("fml.MixinGuiConfig")
             .setApplyIf(() -> TweaksConfig.addModConfigSearchBar).addTargetedMod(TargetedMod.VANILLA)),
-  
+
     FIX_BUTTON_POS_GUIOPENLINK(new Builder("Fix the buttons not being centered in the GuiConfirmOpenLink")
             .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses("minecraft.MixinGuiConfirmOpenLink")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -431,6 +431,10 @@ public enum Mixins {
                     .addMixinClasses("minecraft.MixinWorldServer_LimitUpdateRecursion")
                     .setApplyIf(() -> FixesConfig.limitRecursiveBlockUpdateDepth >= 0)),
 
+    ADD_MOD_CONFIG_SEARCHBAR(new Builder("Adds a search bar to the mod config GUI").setPhase(Phase.EARLY)
+            .setSide(Side.CLIENT).addMixinClasses("fml.MixinGuiConfig")
+            .setApplyIf(() -> TweaksConfig.addModConfigSearchBar).addExcludedMod(TargetedMod.VANILLA)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinGuiConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinGuiConfig.java
@@ -51,9 +51,6 @@ public abstract class MixinGuiConfig extends GuiScreen {
     @Unique
     private int hodgepodge$oldWidth;
 
-    @Shadow
-    public abstract void initGui();
-
     @Inject(
             method = "<init>(Lnet/minecraft/client/gui/GuiScreen;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;Ljava/lang/String;)V",
             at = @At(value = "TAIL"))
@@ -69,7 +66,7 @@ public abstract class MixinGuiConfig extends GuiScreen {
 
     @Inject(method = "initGui", at = @At(value = "TAIL"))
     private void hodgepodge$initSearchBar(CallbackInfo ci) {
-        int centeredTitleWidth = fontRendererObj.getStringWidth(this.title) / 2;
+        int centeredTitleWidth = fontRendererObj.getStringWidth(title) / 2;
         int x = width / 2 + centeredTitleWidth + 10;
         int searchWidth = width - x - 10;
         if (hodgepodge$searchBar == null) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinGuiConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinGuiConfig.java
@@ -1,0 +1,171 @@
+package com.mitchej123.hodgepodge.mixins.early.fml;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
+import net.minecraft.util.StatCollector;
+
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.client.config.GuiConfig;
+import cpw.mods.fml.client.config.GuiConfigEntries;
+import cpw.mods.fml.client.config.IConfigElement;
+
+@Mixin(GuiConfig.class)
+@SuppressWarnings("rawtypes")
+public abstract class MixinGuiConfig extends GuiScreen {
+
+    @Shadow(remap = false)
+    @Final
+    public List<IConfigElement> configElements;
+
+    @Shadow(remap = false)
+    public String title;
+
+    @Shadow(remap = false)
+    public GuiConfigEntries entryList;
+
+    @Unique
+    private List<GuiConfigEntries.IConfigEntry> hodgepodge$allEntries;
+
+    @Unique
+    private GuiTextField hodgepodge$searchBar;
+
+    @Unique
+    private static String hodgepodge$lastSearch = "";
+
+    @Unique
+    private String hodgepodge$localLastSearch = "";
+
+    @Unique
+    private int hodgepodge$oldWidth;
+
+    @Shadow
+    public abstract void initGui();
+
+    @Inject(
+            method = "<init>(Lnet/minecraft/client/gui/GuiScreen;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;Ljava/lang/String;)V",
+            at = @At(value = "TAIL"))
+    private void hodgepodge$init(GuiScreen parentScreen, List<IConfigElement> configElements, String modID,
+            String configID, boolean allRequireWorldRestart, boolean allRequireMcRestart, String title,
+            String titleLine2, CallbackInfo ci) {
+        hodgepodge$oldWidth = width;
+        hodgepodge$allEntries = new ArrayList<>(entryList.listEntries);
+        if (!(parentScreen instanceof GuiConfig)) {
+            hodgepodge$lastSearch = "";
+        }
+    }
+
+    @Inject(method = "initGui", at = @At(value = "TAIL"))
+    private void hodgepodge$initSearchBar(CallbackInfo ci) {
+        int centeredTitleWidth = fontRendererObj.getStringWidth(this.title) / 2;
+        int x = width / 2 + centeredTitleWidth + 10;
+        int searchWidth = width - x - 10;
+        if (hodgepodge$searchBar == null) {
+            hodgepodge$searchBar = new GuiTextField(fontRendererObj, x, 5, searchWidth, 12);
+        } else if (width != hodgepodge$oldWidth) {
+            hodgepodge$oldWidth = width;
+            hodgepodge$searchBar.xPosition = x;
+            hodgepodge$searchBar.width = searchWidth;
+        }
+
+        hodgepodge$searchBar.setText(hodgepodge$lastSearch);
+    }
+
+    @Inject(
+            method = "initGui",
+            at = @At(
+                    value = "FIELD",
+                    opcode = Opcodes.PUTFIELD,
+                    target = "Lcpw/mods/fml/client/config/GuiConfig;needsRefresh:Z",
+                    remap = false))
+    private void hodgepodge$captureEntries(CallbackInfo ci) {
+        hodgepodge$allEntries = new ArrayList<>(entryList.listEntries);
+    }
+
+    @Inject(method = "keyTyped", at = @At(value = "TAIL"))
+    private void hodgepodge$keyTyped(char eventChar, int eventKey, CallbackInfo ci) {
+        if (hodgepodge$searchBar.isFocused()) {
+            hodgepodge$searchBar.textboxKeyTyped(eventChar, eventKey);
+        }
+    }
+
+    @Inject(method = "mouseClicked", at = @At(value = "TAIL"))
+    private void hodgepodge$clearSearchbar(int x, int y, int mouseEvent, CallbackInfo ci) {
+        hodgepodge$searchBar.mouseClicked(x, y, mouseEvent);
+        if (mouseEvent == 1 && x >= hodgepodge$searchBar.xPosition
+                && x < hodgepodge$searchBar.xPosition + hodgepodge$searchBar.width
+                && y >= hodgepodge$searchBar.yPosition
+                && y < hodgepodge$searchBar.yPosition + hodgepodge$searchBar.height) {
+            hodgepodge$searchBar.setText("");
+        }
+    }
+
+    @Inject(method = "drawScreen", at = @At(value = "TAIL"))
+    private void hodgepodge$renderSearchBar(int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
+        hodgepodge$searchBar.drawTextBox();
+        if (!hodgepodge$searchBar.isFocused() && hodgepodge$searchBar.getText().isEmpty()) {
+            fontRendererObj.drawString("Search...", hodgepodge$searchBar.xPosition + 2, 8, -1);
+        }
+    }
+
+    @Inject(method = "updateScreen", at = @At(value = "TAIL"))
+    private void hodgepodge$updateElements(CallbackInfo ci) {
+        hodgepodge$searchBar.updateCursorCounter();
+        String searchText = hodgepodge$searchBar.getText().toLowerCase();
+        if (!searchText.isEmpty()) {
+            if (searchText.equals(hodgepodge$localLastSearch)) return;
+            hodgepodge$lastSearch = hodgepodge$localLastSearch = searchText;
+
+            Set<String> matches = new HashSet<>();
+            for (IConfigElement<?> element : configElements) {
+                if (hodgepodge$doesElementMatchSearch(element, searchText)) {
+                    matches.add(element.getName());
+                    matches.add(StatCollector.translateToLocal(element.getLanguageKey()));
+                }
+            }
+
+            List<GuiConfigEntries.IConfigEntry> entries = new ArrayList<>();
+            for (GuiConfigEntries.IConfigEntry<?> entry : hodgepodge$allEntries) {
+                if (matches.contains(entry.getName())) {
+                    entries.add(entry);
+                }
+            }
+
+            entryList.listEntries = entries;
+        } else if (!hodgepodge$localLastSearch.isEmpty()) {
+            entryList.listEntries = hodgepodge$allEntries;
+            hodgepodge$lastSearch = hodgepodge$localLastSearch = "";
+        }
+    }
+
+    @Unique
+    private boolean hodgepodge$doesElementMatchSearch(IConfigElement<?> element, String search) {
+        String name = element.getName().toLowerCase();
+        String lang = StatCollector.translateToLocal(element.getLanguageKey()).toLowerCase();
+        boolean matches = name.contains(search) || lang.contains(search);
+
+        if (!element.isProperty() && !matches) {
+            List<IConfigElement> children = element.getChildElements();
+            if (children == null) return false;
+            for (IConfigElement<?> child : children) {
+                if (child != null && hodgepodge$doesElementMatchSearch(child, search)) {
+                    return true;
+                }
+            }
+        }
+
+        return matches;
+    }
+}


### PR DESCRIPTION
I was originally going to do this for mods using NHlib configs, but figured it would be nice for other mods to have too. Also enables categorized mode for the hodgepodge config, because it was borderline unusable before.

All of the `@Config.RequiresMcRestart` annotations have been moved onto the class, because the end result is the same no matter how many options have it.

Just a simple search bar
![config_search](https://github.com/user-attachments/assets/737e75d5-e9d2-4504-9969-6d7e7483bb06)


![config_search1](https://github.com/user-attachments/assets/b35466eb-167f-447c-9f7e-875219d61f0d)