### PR TITLE
Memory optimization

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -315,6 +315,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean removeUpdateChecks;
 
+    @Config.Comment("Enable multiple fixes to reduce RAM usage")
+    @Config.DefaultBoolean(true)
+    public static boolean enableMemoryFixes;
+
     // BetterHUD
 
     @Config.Comment("Maximum hp for BetterHUD to render as hearts")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -442,6 +442,14 @@ public enum Mixins {
             .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses("minecraft.MixinGuiChat_OpenLinks").setApplyIf(() -> FixesConfig.fixChatOpenLink)),
 
+    MEMORY_FIXES_CLIENT(
+            new Builder("Memory fixes").setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
+                    .addMixinClasses("memory.MixinFMLClientHandler").setApplyIf(() -> FixesConfig.enableMemoryFixes)),
+
+    MEMORY_FIXES_IC2(new Builder("Removes allocation spam from the Direction.applyTo method").setPhase(Phase.LATE)
+            .setSide(Side.BOTH).addMixinClasses("ic2.MixinDirection_Memory")
+            .setApplyIf(() -> FixesConfig.enableMemoryFixes).addTargetedMod(TargetedMod.IC2)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinFMLClientHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinFMLClientHandler.java
@@ -1,19 +1,22 @@
 package com.mitchej123.hodgepodge.mixins.early.memory;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Table;
-import cpw.mods.fml.client.FMLClientHandler;
+import java.util.Set;
+
 import net.minecraft.util.ResourceLocation;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Set;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+
+import cpw.mods.fml.client.FMLClientHandler;
 
 @Mixin(value = FMLClientHandler.class, remap = false)
 public class MixinFMLClientHandler {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinFMLClientHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinFMLClientHandler.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.early.memory;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import cpw.mods.fml.client.FMLClientHandler;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Set;
+
+@Mixin(value = FMLClientHandler.class, remap = false)
+public class MixinFMLClientHandler {
+
+    @Shadow
+    private SetMultimap<String, ResourceLocation> missingTextures;
+    @Shadow
+    private Set<String> badTextureDomains;
+    @Shadow
+    private Table<String, String, Set<ResourceLocation>> brokenTextures;
+
+    @Inject(method = "logMissingTextureErrors", at = @At("TAIL"))
+    private void hodgepodge$freeMemory(CallbackInfo ci) {
+        missingTextures = HashMultimap.create();
+        badTextureDomains = Sets.newHashSet();
+        brokenTextures = HashBasedTable.create();
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinDirection_Memory.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinDirection_Memory.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+
+import ic2.api.Direction;
+
+@Mixin(value = Direction.class, remap = false)
+public abstract class MixinDirection_Memory {
+
+    /**
+     * @author Alexdoru
+     * @reason Reduce allocation spam
+     */
+    @Overwrite
+    public TileEntity applyTo(World world, int x, int y, int z) {
+        if (world == null) return null;
+        return switch ((Direction) (Object) this) {
+            case XN -> hodgepodge$getTE(world, x - 1, y, z);
+            case XP -> hodgepodge$getTE(world, x + 1, y, z);
+            case YN -> hodgepodge$getTE(world, x, y - 1, z);
+            case YP -> hodgepodge$getTE(world, x, y + 1, z);
+            case ZN -> hodgepodge$getTE(world, x, y, z - 1);
+            case ZP -> hodgepodge$getTE(world, x, y, z + 1);
+        };
+    }
+
+    @Unique
+    private TileEntity hodgepodge$getTE(World world, int x, int y, int z) {
+        if (world.blockExists(x, y, z)) {
+            return world.getTileEntity(x, y, z);
+        } else {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
The patched method creates a int[3] array with coords x y z for every method call

And that method gets called a lot when you have nuclear reactors

![ic2 reactor alloc spam](https://github.com/user-attachments/assets/727c9969-0081-4807-9459-9d7db338cbfb)