### PR TITLE
add nametag/hit brightness fix

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -307,6 +307,16 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixChatOpenLink;
 
+    @Config.Comment("Fix nametags of spiders, endermen and ender dragons being rendered too dark")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixNametagBrightness;
+
+    @Config.Comment("Fix spiders, endermen and ender dragons being rendered too red when hit")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixHitEffectBrightness;
+
     /* ====== Minecraft fixes end ===== */
 
     // affecting multiple mods

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -442,6 +442,14 @@ public enum Mixins {
             .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses("minecraft.MixinGuiChat_OpenLinks").setApplyIf(() -> FixesConfig.fixChatOpenLink)),
 
+    FIX_NAMETAG_BRIGHTNESS(new Builder("Fix nametag brightness").setPhase(Phase.EARLY).setSide(Side.CLIENT)
+            .addMixinClasses("minecraft.MixinRendererLivingEntity_NametagBrightness")
+            .setApplyIf(() -> FixesConfig.fixNametagBrightness).addTargetedMod(TargetedMod.VANILLA)),
+
+    FIX_HIT_EFFECT_BRIGHTNESS(new Builder("Fix hit effect brightness").setPhase(Phase.EARLY).setSide(Side.CLIENT)
+            .addMixinClasses("minecraft.MixinRendererLivingEntity_HitEffectBrightness")
+            .setApplyIf(() -> FixesConfig.fixHitEffectBrightness).addTargetedMod(TargetedMod.VANILLA)),
+
     MEMORY_FIXES_CLIENT(
             new Builder("Memory fixes").setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
                     .addMixinClasses("memory.MixinFMLClientHandler").setApplyIf(() -> FixesConfig.enableMemoryFixes)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRendererLivingEntity_HitEffectBrightness.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRendererLivingEntity_HitEffectBrightness.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import net.minecraft.entity.EntityLivingBase;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RendererLivingEntity.class)
+public class MixinRendererLivingEntity_HitEffectBrightness {
+
+    @Inject(
+            method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V",
+            at = { @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/model/ModelBase;render(Lnet/minecraft/entity/Entity;FFFFFF)V",
+                    shift = At.Shift.AFTER,
+                    ordinal = 0),
+                    @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;inheritRenderPass(Lnet/minecraft/entity/EntityLivingBase;IF)I",
+                            shift = At.Shift.AFTER) },
+            slice = @Slice(
+                    from = @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;shouldRenderPass(Lnet/minecraft/entity/EntityLivingBase;IF)I")))
+    private void hodgepodge$applyDefaultBlendFunc(EntityLivingBase entity, double p_76986_2_, double p_76986_4_,
+            double p_76986_6_, float p_76986_8_, float p_76986_9_, CallbackInfo ci) {
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRendererLivingEntity_NametagBrightness.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRendererLivingEntity_NametagBrightness.java
@@ -1,0 +1,57 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import net.minecraft.entity.EntityLivingBase;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
+
+@Mixin(RendererLivingEntity.class)
+public class MixinRendererLivingEntity_NametagBrightness {
+
+    @Inject(
+            method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V",
+            at = { @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;shouldRenderPass(Lnet/minecraft/entity/EntityLivingBase;IF)I"),
+                    @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;inheritRenderPass(Lnet/minecraft/entity/EntityLivingBase;IF)I") })
+    private void hodgepodge$storeLightmap(EntityLivingBase entity, double p_76986_2_, double p_76986_4_,
+            double p_76986_6_, float p_76986_8_, float p_76986_9_, CallbackInfo ci,
+            @Share("lastBrightnessX") LocalFloatRef lastBrightnessX,
+            @Share("lastBrightnessY") LocalFloatRef lastBrightnessY) {
+        lastBrightnessX.set(OpenGlHelper.lastBrightnessX);
+        lastBrightnessY.set(OpenGlHelper.lastBrightnessY);
+    }
+
+    @Inject(
+            method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V",
+            at = { @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/model/ModelBase;render(Lnet/minecraft/entity/Entity;FFFFFF)V",
+                    shift = At.Shift.AFTER,
+                    ordinal = 0),
+                    @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;inheritRenderPass(Lnet/minecraft/entity/EntityLivingBase;IF)I",
+                            shift = At.Shift.AFTER) },
+            slice = @Slice(
+                    from = @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;shouldRenderPass(Lnet/minecraft/entity/EntityLivingBase;IF)I")))
+    private void hodgepodge$applyLightmap(EntityLivingBase entity, double p_76986_2_, double p_76986_4_,
+            double p_76986_6_, float p_76986_8_, float p_76986_9_, CallbackInfo ci,
+            @Share("lastBrightnessX") LocalFloatRef lastBrightnessX,
+            @Share("lastBrightnessY") LocalFloatRef lastBrightnessY) {
+        OpenGlHelper
+                .setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, lastBrightnessX.get(), lastBrightnessY.get());
+    }
+}


### PR DESCRIPTION
- fixes the nametag of spiders, endermen and ender dragons being rendered too dark, because the lightmap coords were getting overwritten and not reset
- fixes spiders, endermen and ender dragons being rendered too red when hit, because the blend function was overwritten and not reset