### PR TITLE
fix speedupAnimations setting also disabling fast placing keybind

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -13,7 +13,6 @@ import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.util.ManagedEnum;
 
 import biomesoplenty.common.eventhandler.client.gui.WorldTypeMessageEventHandler;
-import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModMetadata;
@@ -42,15 +41,12 @@ public class HodgepodgeClient {
         }
 
         FMLCommonHandler.instance().bus().register(ClientTicker.INSTANCE);
-        ClientRegistry.registerKeyBinding(ClientKeyListener.FastBlockPlacingKey);
 
         if (TweaksConfig.addSystemInfo) {
             MinecraftForge.EVENT_BUS.register(DebugScreenHandler.INSTANCE);
         }
 
-        if (FixesConfig.speedupAnimations) {
-            FMLCommonHandler.instance().bus().register(new ClientKeyListener());
-        }
+        FMLCommonHandler.instance().bus().register(new ClientKeyListener());
 
         if (Compat.isIC2CropPluginPresent()) {
             ModMetadata meta = Loader.instance().getIndexedModList().get("Ic2Nei").getMetadata();

--- a/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/handlers/ClientKeyListener.java
@@ -10,8 +10,10 @@ import org.lwjgl.input.Keyboard;
 import com.gtnewhorizon.gtnhlib.util.AboveHotbarHUD;
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.config.DebugConfig;
+import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
+import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
 import cpw.mods.fml.relauncher.Side;
@@ -24,33 +26,38 @@ public class ClientKeyListener {
             .translateToLocal("key.fastBlockPlacing.enabled");
     private static final String fastBlockPlacingDisabled = StatCollector
             .translateToLocal("key.fastBlockPlacing.disabled");
-
-    public static KeyBinding FastBlockPlacingKey = new KeyBinding(
+    private static final KeyBinding fastBlockPlacingKey = new KeyBinding(
             "key.fastBlockPlacing.desc",
             Keyboard.KEY_NONE,
             "key.hodgepodge.category");
 
+    public ClientKeyListener() {
+        ClientRegistry.registerKeyBinding(fastBlockPlacingKey);
+    }
+
     @SubscribeEvent
     public void keyPressed(InputEvent.KeyInputEvent event) {
-        int key = Keyboard.getEventKey();
-        boolean released = !Keyboard.getEventKeyState();
-        if (released) {
-            if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown()
-                    && GuiScreen.isCtrlKeyDown()) {
-                if (key == Keyboard.KEY_N) {
-                    HodgepodgeClient.animationsMode.next();
-                } else if (key == Keyboard.KEY_D && DebugConfig.renderDebug) {
-                    HodgepodgeClient.renderDebugMode.next();
+        if (TweaksConfig.fastBlockPlacingServerSide && fastBlockPlacingKey.isPressed()) {
+            TweaksConfig.fastBlockPlacing = !TweaksConfig.fastBlockPlacing;
+            AboveHotbarHUD.renderTextAboveHotbar(
+                    (TweaksConfig.fastBlockPlacing ? fastBlockPlacingEnabled : fastBlockPlacingDisabled),
+                    40,
+                    false,
+                    false);
+            return;
+        }
+        if (FixesConfig.speedupAnimations) {
+            int key = Keyboard.getEventKey();
+            boolean released = !Keyboard.getEventKeyState();
+            if (released) {
+                if (Minecraft.getMinecraft().gameSettings.showDebugInfo && GuiScreen.isShiftKeyDown()
+                        && GuiScreen.isCtrlKeyDown()) {
+                    if (key == Keyboard.KEY_N) {
+                        HodgepodgeClient.animationsMode.next();
+                    } else if (key == Keyboard.KEY_D && DebugConfig.renderDebug) {
+                        HodgepodgeClient.renderDebugMode.next();
+                    }
                 }
-            }
-        } else {
-            if (TweaksConfig.fastBlockPlacingServerSide && FastBlockPlacingKey.isPressed()) {
-                TweaksConfig.fastBlockPlacing = !TweaksConfig.fastBlockPlacing;
-                AboveHotbarHUD.renderTextAboveHotbar(
-                        (TweaksConfig.fastBlockPlacing ? fastBlockPlacingEnabled : fastBlockPlacingDisabled),
-                        40,
-                        false,
-                        false);
             }
         }
     }


### PR DESCRIPTION
The event handler is only registered if `FixesConfig.speedupAnimations` is true but that event handler is alos used for the fast placing keybind