### PR TITLE
feat: patch several dupes in eu2

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -416,6 +416,14 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesFluidRetrievalNode;
 
+    @Config.Comment("Caps hotkey'd stacks to their maximum stack size in filing cabinets")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesFilingCabinetDupe;
+
+    @Config.Comment("Prevent hotkeying other items onto item filters while they are open")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesFilterDupe;
+
     // Galacticraft
 
     @Config.Comment("Fix time commands with GC")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -760,6 +760,13 @@ public enum Mixins {
             .addMixinClasses("extrautilities.MixinFluidBufferRetrieval").setPhase(Phase.LATE).setSide(Side.BOTH)
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesFluidRetrievalNode)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_FILING_CABINET_DUPE(new Builder("Caps hotkey'd stacks to their maximum stack size in filing cabinets")
+            .addMixinClasses("extrautilities.MixinContainerFilingCabinet").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.fixExtraUtilitiesFilingCabinetDupe)
+            .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_FILTER_DUPE(new Builder("Prevent hotkeying other items onto item filters while they are open")
+            .addMixinClasses("extrautilities.MixinContainerFilter").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.fixExtraUtilitiesFilterDupe).addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Gliby's Voice Chat
     FIX_GLIBYS_VC_THREAD_SHUTDOWN_CLIENT(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilingCabinet.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilingCabinet.java
@@ -1,0 +1,57 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.rwtema.extrautils.gui.ContainerFilingCabinet;
+
+@Mixin(value = ContainerFilingCabinet.class)
+public abstract class MixinContainerFilingCabinet {
+
+    @Unique
+    private ItemStack hodgepodge$buffer;
+
+    @Inject(
+            method = "slotClick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;",
+                    ordinal = 1))
+    private void hodgepodge$patchFilingCabinetDupe(int slotId, int clickedButton, int mode, EntityPlayer player,
+            CallbackInfoReturnable<ItemStack> cir) {
+        if (mode != 2) {
+            return;
+        }
+        ContainerFilingCabinet cabinet = (ContainerFilingCabinet) (Object) this;
+        ItemStack stack = cabinet.getInventory().get(slotId);
+        if (stack != null && stack.getMaxStackSize() < stack.stackSize) {
+            int newSize = stack.stackSize - stack.getMaxStackSize();
+            hodgepodge$buffer = stack.copy();
+            hodgepodge$buffer.stackSize = newSize;
+            stack.stackSize = stack.getMaxStackSize();
+        }
+    }
+
+    @Inject(method = "slotClick", at = @At(value = "TAIL"))
+    private void hodgepodge$restoreItemStackSize(int slotId, int clickedButton, int mode, EntityPlayer player,
+            CallbackInfoReturnable<ItemStack> cir) {
+        if (mode != 2) {
+            return;
+        }
+        ContainerFilingCabinet cabinet = (ContainerFilingCabinet) (Object) this;
+        if (hodgepodge$buffer != null && slotId >= 0 && slotId < cabinet.getSlots().size()) {
+            Slot slot = cabinet.inventorySlots.get(slotId);
+            if (slot.getStack() == null) {
+                slot.putStack(hodgepodge$buffer.copy());
+                hodgepodge$buffer = null;
+            }
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilter.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilter.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.rwtema.extrautils.gui.ContainerFilter;
+
+@Mixin(ContainerFilter.class)
+public class MixinContainerFilter {
+
+    @Inject(
+            method = "slotClick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/inventory/Container;slotClick(IIILnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;"),
+            cancellable = true)
+    private void hodgepodge$patchFilterDupe(int slotId, int clickedButton, int mode, EntityPlayer player,
+            CallbackInfoReturnable<ItemStack> cir) {
+        if (mode != 2) {
+            return;
+        }
+        if (clickedButton == player.inventory.currentItem) {
+            cir.setReturnValue(null);
+            cir.cancel();
+        }
+    }
+}


### PR DESCRIPTION
This fixes two dupes in EU2, one of which involving a Bag of Holding and an Item Filter, the other involving any backpack-esque item and a Filing Cabinet, both due to buggy hotkey logic.

The filter dupe will let you hotkey a Bag of Holding onto the filter in your hotbar while you have it open, and then put ghost items into the "filter" like normal, instead putting them into the Bag of Holding.

This is mitigated by verifying that the slot you are hotkeying onto isn't also the currently active slot.

The Filing Cabinet doesn't cap the item stack size when you hotkey an itemstack to your inventory, allowing you to store two backpacks, pull out the stacked items, put an item in them, unstack them, and pull the item out of both of them.

This is mitigated by modifying the stack size temporarily, then restoring it after the item has been moved.