### PR TITLE
Update MixinGuiChat_OpenLinks.java

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiChat_OpenLinks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiChat_OpenLinks.java
@@ -5,20 +5,20 @@ import java.net.URI;
 import net.minecraft.client.gui.GuiChat;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.gtnewhorizon.gtnhlib.util.FilesUtil;
 
 @Mixin(GuiChat.class)
 public class MixinGuiChat_OpenLinks {
 
-    /**
-     * @author Alexdoru
-     * @reason The Vanilla method doesn't work on some OS
-     */
-    @Overwrite
-    protected void func_146407_a(URI uri) {
+    // @reason The Vanilla method doesn't work on some OS
+    @Inject(method = "func_146407_a", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$fixFileOpening(URI uri, CallbackInfo ci) {
         FilesUtil.openUri(uri);
+        ci.cancel();
     }
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiChat_OpenLinks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiChat_OpenLinks.java
@@ -17,7 +17,7 @@ public class MixinGuiChat_OpenLinks {
      * @reason The Vanilla method doesn't work on some OS
      */
     @Overwrite
-    private void func_146407_a(URI uri) {
+    protected void func_146407_a(URI uri) {
         FilesUtil.openUri(uri);
     }
 


### PR DESCRIPTION
Saw this error floating around in the wild:
`Caused by: org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException: PRIVATE @Overwrite method func_146407_a in mixins.hodgepodge.early.json:minecraft.MixinGuiChat_OpenLinks from mod hodgepodge cannot reduce visibiliy of PROTECTED target method`

Apparently someone's AT'd the field and made it protected.... haven't tested this (commiting from Github) so please verify before merging