### PR TITLE
Prevent Massive World Destroying Sacred Rubber Tree Generation

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -529,7 +529,6 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean disableMassiveSacredTreeGeneration;
 
-
     // Morpheus
 
     @Config.Comment("Fix not properly waking players if not everyone is sleeping")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -526,7 +526,7 @@ public class FixesConfig {
     // Minefactory Reloaded
 
     @Config.Comment("Prevents Sacred Rubber Tree Generation")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     public static boolean disableMassiveSacredTreeGeneration;
 
     // Morpheus

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -498,6 +498,13 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean java12MineChemCompat;
 
+    // Minefactory Reloaded
+
+    @Config.Comment("Prevents Sacred Rubber Tree Generation")
+    @Config.DefaultBoolean(true)
+    public static boolean disableMassiveSacredTreeGeneration;
+
+
     // Morpheus
 
     @Config.Comment("Fix not properly waking players if not everyone is sleeping")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -633,7 +633,8 @@ public enum Mixins {
     // Minefactory Reloaded
     DISARM_SACRED_TREE(new Builder("Prevents Sacred Rubber Tree Generation")
             .addMixinClasses("minefactoryreloaded..MixinBlockRubberSapling").setPhase(Phase.LATE).setSide(Side.BOTH)
-            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> FixesConfig.disableMassiveSacredTreeGeneration)),
+            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED)
+            .setApplyIf(() -> FixesConfig.disableMassiveSacredTreeGeneration)),
 
     // Immersive engineering
     JAVA12_IMMERSIVE_ENGINERRING(new Builder("Immersive Engineering Java-12 safe potion array resizing")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -608,6 +608,11 @@ public enum Mixins {
             .addMixinClasses("cofhcore.MixinOreDictionaryArbiter").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addTargetedMod(TargetedMod.COFH_CORE).setApplyIf(() -> FixesConfig.fixCofhOreDictNPE)),
 
+    // Minefactory Reloaded
+    DISARM_SACRED_TREE(new Builder("Prevents Sacred Rubber Tree Generation")
+            .addMixinClasses("minefactoryreloaded..MixinBlockRubberSapling").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> FixesConfig.disableMassiveSacredTreeGeneration)),
+
     // Immersive engineering
     JAVA12_IMMERSIVE_ENGINERRING(new Builder("Immersive Engineering Java-12 safe potion array resizing")
             .setPhase(Phase.LATE).setSide(Side.BOTH).addMixinClasses("immersiveengineering.MixinIEPotions")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -632,7 +632,7 @@ public enum Mixins {
 
     // Minefactory Reloaded
     DISARM_SACRED_TREE(new Builder("Prevents Sacred Rubber Tree Generation")
-            .addMixinClasses("minefactoryreloaded..MixinBlockRubberSapling").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addMixinClasses("minefactoryreloaded.MixinBlockRubberSapling").setPhase(Phase.LATE).setSide(Side.BOTH)
             .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED)
             .setApplyIf(() -> FixesConfig.disableMassiveSacredTreeGeneration)),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinBlockRubberSapling.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinBlockRubberSapling.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.late.minefactoryreloaded;
+
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import powercrystals.minefactoryreloaded.block.BlockRubberSapling;
+import powercrystals.minefactoryreloaded.world.MineFactoryReloadedWorldGen;
+import powercrystals.minefactoryreloaded.world.WorldGenMassiveTree;
+
+import java.util.Random;
+
+@Mixin(BlockRubberSapling.class)
+public class MixinBlockRubberSapling {
+
+    /**
+     * @author DrParadox7
+     * @reason Swap Massive world-breaking tree to Mega, a still reasonably large but safe tree, should it still be obtained by chance.
+     */
+    @Redirect(
+            method = "func_149878_d",
+            at = @At(value = "INVOKE", target = "Lpowercrystals/minefactoryreloaded/world/WorldGenMassiveTree;generate(Lnet/minecraft/world/World;Ljava/util/Random;III)Z"))
+    private boolean hodgepodge$generateMassiveRubberTree(WorldGenMassiveTree instance, World world, Random random, int x, int y, int z) {
+        return MineFactoryReloadedWorldGen.generateMegaRubberTree(world, random, x, y, z, true);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinBlockRubberSapling.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinBlockRubberSapling.java
@@ -1,26 +1,32 @@
 package com.mitchej123.hodgepodge.mixins.late.minefactoryreloaded;
 
+import java.util.Random;
+
 import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+
 import powercrystals.minefactoryreloaded.block.BlockRubberSapling;
 import powercrystals.minefactoryreloaded.world.MineFactoryReloadedWorldGen;
 import powercrystals.minefactoryreloaded.world.WorldGenMassiveTree;
-
-import java.util.Random;
 
 @Mixin(BlockRubberSapling.class)
 public class MixinBlockRubberSapling {
 
     /**
      * @author DrParadox7
-     * @reason Swap Massive world-breaking tree to Mega, a still reasonably large but safe tree, should it still be obtained by chance.
+     * @reason Swap Massive world-breaking tree to Mega, a still reasonably large but safe tree, should it still be
+     *         obtained by chance.
      */
     @Redirect(
             method = "func_149878_d",
-            at = @At(value = "INVOKE", target = "Lpowercrystals/minefactoryreloaded/world/WorldGenMassiveTree;generate(Lnet/minecraft/world/World;Ljava/util/Random;III)Z"))
-    private boolean hodgepodge$generateMassiveRubberTree(WorldGenMassiveTree instance, World world, Random random, int x, int y, int z) {
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lpowercrystals/minefactoryreloaded/world/WorldGenMassiveTree;generate(Lnet/minecraft/world/World;Ljava/util/Random;III)Z"))
+    private boolean hodgepodge$generateMassiveRubberTree(WorldGenMassiveTree instance, World world, Random random,
+            int x, int y, int z) {
         return MineFactoryReloadedWorldGen.generateMegaRubberTree(world, random, x, y, z, true);
     }
 }


### PR DESCRIPTION
Prevent Massive World Destroying Sacred Rubber Tree Generation, downscaling it to a reasonable Mega sized one instead:

Sacred Rubber Tree:
![image](https://github.com/user-attachments/assets/e2d6c73d-9b55-42b4-855e-5da1c3161066)