### PR TITLE
Split FixHandleSetSlot into container & inv

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_FixHandleSetSlot.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_FixHandleSetSlot.java
@@ -17,18 +17,27 @@ public class MixinNetHandlerPlayClient_FixHandleSetSlot {
     @Inject(
             locals = LocalCapture.CAPTURE_FAILSOFT,
             method = "handleSetSlot(Lnet/minecraft/network/play/server/S2FPacketSetSlot;)V",
-            at = { @At(
+            at = @At(
                     opcode = Opcodes.GETFIELD,
                     ordinal = 1,
                     target = "Lnet/minecraft/client/entity/EntityClientPlayerMP;inventoryContainer:Lnet/minecraft/inventory/Container;",
                     value = "FIELD"),
-                    @At(
-                            opcode = Opcodes.GETFIELD,
-                            ordinal = 1,
-                            target = "Lnet/minecraft/client/entity/EntityClientPlayerMP;openContainer:Lnet/minecraft/inventory/Container;",
-                            value = "FIELD") },
             cancellable = true)
-    public void hodgepodge$checkPacketItemStackSize(S2FPacketSetSlot packetIn, CallbackInfo ci,
+    public void hodgepodge$checkPacketItemStackSizeInventory(S2FPacketSetSlot packetIn, CallbackInfo ci,
+            EntityClientPlayerMP entityclientplayermp) {
+        if (packetIn.func_149173_d() >= entityclientplayermp.inventoryContainer.inventorySlots.size()) ci.cancel();
+    }
+
+    @Inject(
+            locals = LocalCapture.CAPTURE_FAILSOFT,
+            method = "handleSetSlot(Lnet/minecraft/network/play/server/S2FPacketSetSlot;)V",
+            at = @At(
+                    opcode = Opcodes.GETFIELD,
+                    ordinal = 1,
+                    target = "Lnet/minecraft/client/entity/EntityClientPlayerMP;openContainer:Lnet/minecraft/inventory/Container;",
+                    value = "FIELD"),
+            cancellable = true)
+    public void hodgepodge$checkPacketItemStackSizeContainer(S2FPacketSetSlot packetIn, CallbackInfo ci,
             EntityClientPlayerMP entityclientplayermp) {
         if (packetIn.func_149173_d() >= entityclientplayermp.openContainer.inventorySlots.size()) ci.cancel();
     }


### PR DESCRIPTION
FixHandleSetSlot checked the length of openContainer even when the packet was for the player's inventory.
This prevented player inventory updates when a server-side gui was open.

To fix this, the existing mixin was split into two and the cancel code was tweaked slightly (it had two targets already).

Before:
![image](https://github.com/user-attachments/assets/74418c3e-530a-4563-8777-a8a853c8c1f2)


After:
![image](https://github.com/user-attachments/assets/3ee2fba8-a862-4f62-a99c-006c41053446)

closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18170