### PR TITLE
Configurable ender quarry RF storage

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -199,6 +199,12 @@ public class TweaksConfig {
     @Config.DefaultInt(64)
     public static int ic2SeedMaxStackSize;
 
+    @Config.Comment("Ender Quarry RF Storage Override (0 to disable)")
+    @Config.RangeInt(min = 0)
+    @Config.DefaultInt(0) // extrautilities default value
+    public static int extraUtilitiesEnderQuarryOverride;
+
+
     // Minechem
 
     @Config.Comment("Minechem Atropine High (Delirium) effect ID")

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -201,9 +201,8 @@ public class TweaksConfig {
 
     @Config.Comment("Ender Quarry RF Storage Override (0 to disable)")
     @Config.RangeInt(min = 0)
-    @Config.DefaultInt(0) // extrautilities default value
+    @Config.DefaultInt(0)
     public static int extraUtilitiesEnderQuarryOverride;
-
 
     // Minechem
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -199,7 +199,7 @@ public class TweaksConfig {
     @Config.DefaultInt(64)
     public static int ic2SeedMaxStackSize;
 
-    @Config.Comment("Ender Quarry RF Storage Override (0 to disable)")
+    @Config.Comment("Ender Quarry RF Storage Override (ExU default value: 10000000) (0 to use default value)")
     @Config.RangeInt(min = 0)
     @Config.DefaultInt(0)
     public static int extraUtilitiesEnderQuarryOverride;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -777,6 +777,10 @@ public enum Mixins {
     FIX_FILTER_DUPE(new Builder("Prevent hotkeying other items onto item filters while they are open")
             .addMixinClasses("extrautilities.MixinContainerFilter").setPhase(Phase.LATE).setSide(Side.BOTH)
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesFilterDupe).addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    CONFIGURABLE_ENDERQUARRY_ENERGY(new Builder("Ender Quarry energy storage override")
+            .addMixinClasses("extrautilities.MixinTileEntityEnderQuarry").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> TweaksConfig.extraUtilitiesEnderQuarryOverride > 0)
+            .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Gliby's Voice Chat
     FIX_GLIBYS_VC_THREAD_SHUTDOWN_CLIENT(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEntityEnderQuarry.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEntityEnderQuarry.java
@@ -1,0 +1,17 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.rwtema.extrautils.tileentity.enderquarry.TileEntityEnderQuarry;
+
+@Mixin(value = TileEntityEnderQuarry.class, remap = false)
+public class MixinTileEntityEnderQuarry {
+
+    @ModifyArg(method = "<init>", at = @At(value = "INVOKE", target = "Lcofh/api/energy/EnergyStorage;<init>(I)V"))
+    private int mixinInit(int energyStored) {
+        return TweaksConfig.extraUtilitiesEnderQuarryOverride;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEntityEnderQuarry.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEntityEnderQuarry.java
@@ -1,10 +1,10 @@
 package com.mitchej123.hodgepodge.mixins.late.extrautilities;
 
-import com.mitchej123.hodgepodge.config.TweaksConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
+import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.rwtema.extrautils.tileentity.enderquarry.TileEntityEnderQuarry;
 
 @Mixin(value = TileEntityEnderQuarry.class, remap = false)


### PR DESCRIPTION
This removes the need for GTNH's modified version of EU2, where the only changes between the modified version and release are a mitigation for one of the dupes fixed in #438, and to modify the Ender Quarry's storage (set to 200,000,000 instead of 10,000,000).

Currently, it adds one new config option, and you can set the option to 0 to disable it. It defaults to the original value of 10,000,000 instead of the modified version currently in GTNH.