### PR TITLE
Fix off by one int clamp in Witchery's glyph rendering

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -613,6 +613,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixWitcheryThunderDetection;
 
+    @Config.Comment("Fixes some potential errors in Witchery Rendering")
+    @Config.DefaultBoolean(true)
+    public static boolean fixWitcheryRendering;
+
     // Xaero's Minimap
     @Config.Comment("Fixes the player entity dot rendering when arrow is chosen")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -840,6 +840,11 @@ public enum Mixins {
                     .setSide(Side.BOTH).setPhase(Phase.LATE).setApplyIf(() -> FixesConfig.fixWitcheryThunderDetection)
                     .addTargetedMod(TargetedMod.WITCHERY)),
 
+    FIX_WITCHERY_RENDERING(new Builder("Fixes Witchery Rendering errors")
+            .addMixinClasses("witchery.MixinBlockCircleGlyph")
+            .setSide(Side.CLIENT).setPhase(Phase.LATE).setApplyIf(() -> FixesConfig.fixWitcheryRendering)
+            .addTargetedMod(TargetedMod.WITCHERY)),
+
     // Various Exploits/Fixes
     GC_TIME_COMMAND_FIX(new Builder("GC Time Fix").addMixinClasses("minecraft.MixinTimeCommandGalacticraftFix")
             .setPhase(Phase.EARLY).setSide(Side.BOTH).setApplyIf(() -> FixesConfig.fixTimeCommandWithGC)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -841,9 +841,8 @@ public enum Mixins {
                     .addTargetedMod(TargetedMod.WITCHERY)),
 
     FIX_WITCHERY_RENDERING(new Builder("Fixes Witchery Rendering errors")
-            .addMixinClasses("witchery.MixinBlockCircleGlyph")
-            .setSide(Side.CLIENT).setPhase(Phase.LATE).setApplyIf(() -> FixesConfig.fixWitcheryRendering)
-            .addTargetedMod(TargetedMod.WITCHERY)),
+            .addMixinClasses("witchery.MixinBlockCircleGlyph").setSide(Side.CLIENT).setPhase(Phase.LATE)
+            .setApplyIf(() -> FixesConfig.fixWitcheryRendering).addTargetedMod(TargetedMod.WITCHERY)),
 
     // Various Exploits/Fixes
     GC_TIME_COMMAND_FIX(new Builder("GC Time Fix").addMixinClasses("minecraft.MixinTimeCommandGalacticraftFix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinBlockCircleGlyph.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinBlockCircleGlyph.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import com.emoniph.witchery.blocks.BlockCircleGlyph;
+import net.minecraft.util.IIcon;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(BlockCircleGlyph.class)
+public class MixinBlockCircleGlyph {
+
+    @Shadow(remap = false)
+    private IIcon[] icons;
+
+    @ModifyConstant(method = "getIcon(II)Lnet/minecraft/util/IIcon;", constant = @Constant(intValue = 12))
+    private int hodgepodge$fixMetadataClamp(int oldValue) {
+        return icons.length - 1;
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinBlockCircleGlyph.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinBlockCircleGlyph.java
@@ -1,11 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.witchery;
 
-import com.emoniph.witchery.blocks.BlockCircleGlyph;
 import net.minecraft.util.IIcon;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import com.emoniph.witchery.blocks.BlockCircleGlyph;
 
 @Mixin(BlockCircleGlyph.class)
 public class MixinBlockCircleGlyph {


### PR DESCRIPTION
Fixes a possible AIOOB caused by an int clamp being wrong in Witchery's rendering. This bug is hard to reproduce and not sure exactly where the problem comes from, but there seems to be some kind of edge case, in some combination of mods and things happening, where a glyph's metadata can be above the expected max of 11. Witchery has a clamp that prevents that would prevent that from causing an AIOOB, however the clamp is incorrect and off by one, so this makes it so the clamp at least works and prevents a crash.

See https://github.com/GTNewHorizons/Angelica/issues/778 for the original crash