### PR TITLE
fix wrong block placement distance check

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -321,6 +321,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixHitEffectBrightness;
 
+    @Config.Comment("Fix server-side check of block placement distance by players being not identical client-side checks")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixWrongBlockPlacementDistanceCheck;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -506,6 +506,11 @@ public enum Mixins {
             .setSide(Side.BOTH).addMixinClasses("ic2.MixinDirection_Memory")
             .setApplyIf(() -> FixesConfig.enableMemoryFixes).addTargetedMod(TargetedMod.IC2)),
 
+    FIX_PLAYER_BLOCK_PLACEMENT_DISTANCE_CHECK(new Builder("Fix wrong block placement distance check")
+            .setPhase(Phase.EARLY).setSide(Side.BOTH)
+            .addMixinClasses("minecraft.MixinNetHandlePlayServer_FixWrongBlockPlacementCheck")
+            .setApplyIf(() -> FixesConfig.fixWrongBlockPlacementDistanceCheck).addTargetedMod(TargetedMod.VANILLA)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlePlayServer_FixWrongBlockPlacementCheck.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlePlayServer_FixWrongBlockPlacementCheck.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+@Mixin(NetHandlerPlayServer.class)
+public class MixinNetHandlePlayServer_FixWrongBlockPlacementCheck {
+
+    @WrapOperation(
+            method = "processPlayerBlockPlacement",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;getDistanceSq(DDD)D"))
+    private double hodgepodge$fixWrongBlockPlacementCheck(EntityPlayerMP entity, double x, double y, double z,
+            Operation<Double> original) {
+        y -= entity.getEyeHeight();
+        return original.call(entity, x, y, z);
+    }
+}


### PR DESCRIPTION
Fix block placement distance by players being wrong.

Typical symptom are blocks on the ceiling that disappear shortly after you you placed them. You can't place a block at the ceiling but can remove the block above it. Introduces in the past when Notch splitted of the server. If I'm not wrong, it's fixed in modern Minecraft versions.

Before:
https://github.com/user-attachments/assets/d2c328ec-3442-4a6e-888b-c6792e4b6e09

After:
https://github.com/user-attachments/assets/58d47d67-ea92-4974-904d-a0cfcb93400c
