### PR TITLE
Fix coretweaks hard-dep

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
@@ -100,9 +100,7 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
         try {
             final Class<?> clazz = Class.forName("makamys.coretweaks.Config");
             CoreCompat.disableCoretweaksConflictingMixins();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
+        } catch (ClassNotFoundException e) {}
         return null;
     }
 }


### PR DESCRIPTION
Throwing a RuntimeException here causes all of the early mixins to be skipped if coretweaks isn't loaded