### PR TITLE
fix placing blocks isn't working downwards

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.5.0:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.33:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.36:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.2.3-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.2.1:dev") // Do not update, fixed afterwards

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlePlayServer_FixWrongBlockPlacementCheck.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlePlayServer_FixWrongBlockPlacementCheck.java
@@ -17,7 +17,7 @@ public class MixinNetHandlePlayServer_FixWrongBlockPlacementCheck {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;getDistanceSq(DDD)D"))
     private double hodgepodge$fixWrongBlockPlacementCheck(EntityPlayerMP entity, double x, double y, double z,
             Operation<Double> original) {
-        y -= entity.getEyeHeight();
+        y -= 0.5D;
         return original.call(entity, x, y, z);
     }
 }


### PR DESCRIPTION
Fix https://cdn.discordapp.com/attachments/521008249844269061/1322531840497815593/2024-12-28_12-44-05.mkv?ex=6771e002&is=67708e82&hm=71e512b93955a0133fabe21bedbd0d5628018985d990546bb169fed02f2967ad&

Tested a bit around and got `0.5` as perfect value. It matches the renderer and I'm no longer able to reproduce the issue while building upwards and downwards. Compared to the `1.5` for the digging event `0.5` is perfect for the placing event (It is logical, but it is difficult for me to explain in English).
