### PR TITLE
Display Mod Name under the Item's Name in Item / Block Stat GUI

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -433,9 +433,9 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinMinecraft_FixDuplicateSounds")
             .setApplyIf(() -> FixesConfig.fixDuplicateSounds)),
 
-    ADD_MOD_ITEM_STATS(new Builder("Add stats for modded items").addMixinClasses("fml.MixinGameRegistry")
-            .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> TweaksConfig.addModItemStats).setPhase(Phase.EARLY)
-            .setSide(Side.BOTH)),
+    ADD_MOD_ITEM_STATS(new Builder("Add stats for modded items")
+            .addMixinClasses("fml.MixinGameRegistry", "minecraft.MixinStats").addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> TweaksConfig.addModItemStats).setPhase(Phase.EARLY).setSide(Side.BOTH)),
 
     ADD_MOD_ENTITY_STATS(new Builder("Add stats for modded entities").addMixinClasses("minecraft.MixinStatList")
             .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> TweaksConfig.addModEntityStats).setPhase(Phase.EARLY)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemReed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemReed.java
@@ -24,8 +24,7 @@ public class MixinItemReed {
             at = @At(
                     value = "INVOKE_ASSIGN",
                     target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"),
-            ordinal = 0,
-            remap = false)
+            ordinal = 0)
     private Block onItemUseWithIsReplaceable(Block original, @Local(ordinal = 0, argsOnly = true) World world,
             @Local(ordinal = 0, argsOnly = true) int x, @Local(ordinal = 1, argsOnly = true) int y,
             @Local(ordinal = 2, argsOnly = true) int z) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSoundManager.java
@@ -12,10 +12,10 @@ public class MixinSoundManager {
     @ModifyArg(
             method = "setSoundCategoryVolume",
             at = @At(
+                    remap = false,
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/audio/SoundManager$SoundSystemStarterThread;setMasterVolume(F)V"),
-            index = 0,
-            remap = false)
+            index = 0)
     public float hodgepodge$modifySetMasterVolumeArg(float volume) {
         return (float) Math.pow(volume, 2);
     }
@@ -23,10 +23,10 @@ public class MixinSoundManager {
     @ModifyArg(
             method = "setSoundCategoryVolume",
             at = @At(
+                    remap = false,
                     value = "INVOKE",
                     target = "Lnet/minecraft/client/audio/SoundManager$SoundSystemStarterThread;setVolume(Ljava/lang/String;F)V"),
-            index = 1,
-            remap = false)
+            index = 1)
     private float hodgepodge$modifySetCategoryVolumeArg(float volume) {
         return (float) Math.pow(volume, 2);
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinStats.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinStats.java
@@ -1,0 +1,80 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.gui.achievement.GuiStats;
+import net.minecraft.item.Item;
+import net.minecraft.util.EnumChatFormatting;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.ModContainer;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
+
+@Mixin(targets = "net.minecraft.client.gui.achievement.GuiStats$Stats")
+public class MixinStats {
+
+    @Shadow(aliases = "field_148214_q", remap = false)
+    @Final
+    GuiStats this$0; // enclosing instance
+
+    @ModifyExpressionValue(
+            at = @At(
+                    target = "Lnet/minecraft/client/gui/FontRenderer;getStringWidth(Ljava/lang/String;)I",
+                    value = "INVOKE"),
+            method = "func_148213_a")
+    private int hodgepodge$max(int original, @Local Item item, @Share("modName") LocalRef<String> modNameRef) {
+        UniqueIdentifier ui = GameRegistry.findUniqueIdentifierFor(item);
+        if (ui == null) {
+            return original;
+        }
+        ModContainer mod = Loader.instance().getIndexedModList().get(ui.modId);
+        String modName = null;
+        if (mod != null) {
+            modName = mod.getName();
+        }
+        if (modName == null) {
+            modName = "Minecraft";
+        }
+        modNameRef.set(modName);
+        return Math.max(original, this.this$0.fontRendererObj.getStringWidth(modName));
+    }
+
+    @ModifyConstant(constant = @Constant(intValue = 8), method = "func_148213_a")
+    private int hodgepodge$extendBottom(int original) {
+        return original + 10;
+    }
+
+    @Inject(
+            at = @At(
+                    shift = Shift.AFTER,
+                    target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
+                    value = "INVOKE"),
+            method = "func_148213_a")
+    private void hodgepodge$drawModName(CallbackInfo ci, @Local(ordinal = 2) int k, @Local(ordinal = 3) int l,
+            @Share("modName") LocalRef<String> modNameRef) {
+        String modName = modNameRef.get();
+        if (modName == null) {
+            return;
+        }
+        this.this$0.fontRendererObj.drawStringWithShadow(
+                EnumChatFormatting.BLUE.toString() + EnumChatFormatting.ITALIC + modName,
+                k,
+                l + 10,
+                -1);
+    }
+
+}

--- a/src/main/resources/META-INF/hodgepodge_at.cfg
+++ b/src/main/resources/META-INF/hodgepodge_at.cfg
@@ -2,6 +2,7 @@ public net.minecraft.client.Minecraft field_110446_Y # fileAssets
 public net.minecraft.client.Minecraft field_110449_ao # defaultResourcePacks
 public net.minecraft.client.gui.FontRenderer func_78282_e(Ljava/lang/String;)Ljava/lang/String; # getFormatFromString(String) String
 public net.minecraft.client.gui.GuiNewChat field_146252_h # chatLines
+public net.minecraft.client.gui.GuiScreen field_146289_q # fontRendererObj
 public net.minecraft.client.model.ModelBat field_82895_a # batHead
 public net.minecraft.client.model.ModelBlaze field_78105_b # blazeHead
 public net.minecraft.client.model.ModelDragon field_78221_a # head


### PR DESCRIPTION
Example screenshot of the Block stats GUI:
![grafik](https://github.com/user-attachments/assets/b2bf69d2-1b10-4b67-b384-d8f63c39e74c)