### PR TITLE
Fix race condition in COFH's oredict initialization

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -401,6 +401,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixCofhOreDictNPE;
 
+    @Config.Comment("Fix race condition in COFH's oredict")
+    @Config.DefaultBoolean(true)
+    public static boolean fixCofhOreDictCME;
+
     // Extra TiC
 
     @Config.Comment("Disable ExtraTic's Integration with Metallurgy 3 Precious Materials Module: (Brass, Silver, Electrum & Platinum)")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -674,6 +674,9 @@ public enum Mixins {
     FIX_ORE_DICT_NPE(new Builder("Fix NPE in OreDictionaryArbiter")
             .addMixinClasses("cofhcore.MixinOreDictionaryArbiter").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addTargetedMod(TargetedMod.COFH_CORE).setApplyIf(() -> FixesConfig.fixCofhOreDictNPE)),
+    FIX_ORE_DICT_CME(new Builder("Fix race condition in CoFH oredict").addMixinClasses("cofhcore.MixinFMLEventHandler")
+            .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.COFH_CORE)
+            .setApplyIf(() -> FixesConfig.fixCofhOreDictCME)),
 
     // Minefactory Reloaded
     DISARM_SACRED_TREE(new Builder("Prevents Sacred Rubber Tree Generation")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinFMLEventHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinFMLEventHandler.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.early.cofhcore;
+
+import net.minecraft.client.Minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+
+import cofh.core.util.FMLEventHandler;
+
+@Mixin(value = FMLEventHandler.class, remap = false)
+public abstract class MixinFMLEventHandler {
+
+    @WrapWithCondition(
+            method = "handleIdMappingEvent",
+            at = @At(value = "INVOKE", target = "Lcofh/core/util/oredict/OreDictionaryArbiter;initialize()V"))
+    private boolean hodgepodge$fixNPE() {
+        return !Minecraft.getMinecraft().isSingleplayer();
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18239

The issue only happens in SP and was caused by a race condition between the server & client threads. (also wtf it re-initializes this every time a player joins???)

Disregard that the injected method is annotated with `@Mod.EventHandler` it calls it itself in various places.

https://github.com/GTNewHorizons/CoFHCore/blob/4be193afe63bcf108c5ad5abd34da34028434c65/src/main/java/cofh/core/util/FMLEventHandler.java#L38

https://github.com/GTNewHorizons/CoFHCore/blob/4be193afe63bcf108c5ad5abd34da34028434c65/src/main/java/cofh/CoFHCore.java#L191 - this is the one responsible for the race condition