### PR TITLE
Fix skin manager leaking client world

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -212,6 +212,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixWorldServerLeakingUnloadedEntities;
 
+    @Config.Comment("Fix skin manager leaking client world")
+    @Config.DefaultBoolean(true)
+    public static boolean fixSkinManagerLeakingClientWorld;
+
     @Config.Comment("Increase the maximum network packet size from the default of 2MiB")
     @Config.DefaultBoolean(true)
     public static boolean increasePacketSizeLimit;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -218,6 +218,9 @@ public enum Mixins {
     FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES(new Builder("Fix world server leaking unloaded entities")
             .setPhase(Phase.EARLY).setSide(Side.BOTH).addMixinClasses("minecraft.MixinWorldServerUpdateEntities")
             .setApplyIf(() -> FixesConfig.fixWorldServerLeakingUnloadedEntities).addTargetedMod(TargetedMod.VANILLA)),
+    FIX_SKIN_MANAGER_CLIENT_WORLD_LEAK(new Builder("Fix skin manager client world leak").setPhase(Phase.EARLY)
+            .setSide(Side.CLIENT).addMixinClasses("minecraft.MixinSkinManager$2")
+            .setApplyIf(() -> FixesConfig.fixSkinManagerLeakingClientWorld).addTargetedMod(TargetedMod.VANILLA)),
 
     FIX_REDSTONE_TORCH_WORLD_LEAK(new Builder("Fix world leak in redstone torch").setPhase(Phase.EARLY)
             .setSide(Side.BOTH).addMixinClasses("minecraft.MixinBlockRedstoneTorch")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSkinManager$2.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinSkinManager$2.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.resources.SkinManager;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.resources.SkinManager$2")
+public class MixinSkinManager$2 {
+
+    @Shadow(aliases = "field_152636_b", remap = false)
+    @Mutable
+    @Final
+    SkinManager.SkinAvailableCallback val$p_152789_3_;
+
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "func_152634_a()V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "net/minecraft/client/resources/SkinManager$SkinAvailableCallback.func_152121_a(Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/util/ResourceLocation;)V",
+                    shift = At.Shift.AFTER,
+                    by = 1))
+    private void hodgepodge$clearReference(CallbackInfo ignored) {
+        val$p_152789_3_ = null;
+    }
+}


### PR DESCRIPTION
1. SkinManager store all skin texture in its TextureManager, with ThreadDownloadImageData being image data. Cached skin texture are never flushed (except on game restart).
2. ThreadDownloadImageData holds onto a reference of IImageBuffer, which is a hybrid of binary data sink and onDownloadFinish callback
3. This specific subclass of IImageBuffer holds onto a callback object via a synthetic field generated by compiler, as it's an anonymous class. 
4. This callback object should implement SkinAvailableCallback, whose most notable subclass is EntityPlayerSP, which obviously strongly references its World object

This whole chain of reference creates an obscure way to leak the first client world ever loaded (and possibly more if in multiplayer game). I vaguely recall there was one or two other way this first client world is leaked. While I cannot immediately recall the details of every leak, fixing this leak should nonetheless help in the goal of not leaking any one world. 