### PR TITLE
Backport 1.20's 'pause-when-empty-seconds' server property

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,7 +61,7 @@ dependencies {
     transformedModCompileOnly(deobf("https://forum.industrial-craft.net/core/attachment/4316-advancedsolarpanel-1-7-10-3-5-1-jar/"))
     transformedModCompileOnly(rfg.deobf("curse.maven:candycraft-251118:2330488"))
 
-    devOnlyNonPublishable(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
+    transformedModCompileOnly(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
 }
 
 // Replace when RFG support deobfuscation from notch mappings

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,21 +12,21 @@ configurations {
 }
 
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.6.0:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.6.1:dev")
 
     compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.2") { transitive = false }
 
-    transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.7.11-GTNH:dev") // force a more up-to-date NEI version
-    transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-516-GTNH")
+    transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.7.15-GTNH:dev") // force a more up-to-date NEI version
+    transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-518-GTNH")
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.0:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.48:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.61:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.2.3-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.2.1:dev") // Do not update, fixed afterwards
-    transformedModCompileOnly("com.github.GTNewHorizons:Railcraft:9.16.1:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
-    transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.2-GTNH:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.3.0:dev") // Do not update, fixed afterwards
+    transformedModCompileOnly("com.github.GTNewHorizons:Railcraft:9.16.2:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
+    transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.3-GTNH:dev")
     transformedModCompileOnly(rfg.deobf("curse.maven:bibliocraft-228027:2423369"))
     transformedModCompileOnly(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612"))
     transformedModCompileOnly("curse.maven:cofh-core-69162:2388751")
@@ -45,7 +45,7 @@ dependencies {
     transformedModCompileOnly(rfg.deobf("curse.maven:glibys-voice-chat-225110:2301492"))
 
     transformedModCompileOnly(rfg.deobf("curse.maven:automagy-222153:2285272"))
-    transformedModCompileOnly("com.github.GTNewHorizons:Galacticraft:3.3.0-GTNH:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:Galacticraft:3.3.1-GTNH:dev")
     transformedModCompileOnly("curse.maven:minechem-368422:2905830")
     transformedModCompileOnly("curse.maven:thermal-dynamics-227443:2388756")
     transformedModCompileOnly("curse.maven:thermal-expansion-69163:2388759")

--- a/src/main/java/com/mitchej123/hodgepodge/commands/DebugCommand.java
+++ b/src/main/java/com/mitchej123/hodgepodge/commands/DebugCommand.java
@@ -32,7 +32,7 @@ public class DebugCommand extends CommandBase {
     }
 
     private void printHelp(ICommandSender sender) {
-        sender.addChatMessage(new ChatComponentText("Usage: hp <toggle|anchor|randomNbt|pause_when_empty>"));
+        sender.addChatMessage(new ChatComponentText("Usage: hp <toggle|anchor|randomNbt|pauseWhenEmpty>"));
         sender.addChatMessage(new ChatComponentText("\"toggle anchordebug\" - toggles RC anchor debugging"));
         sender.addChatMessage(
                 new ChatComponentText(
@@ -51,7 +51,7 @@ public class DebugCommand extends CommandBase {
         String test = ss.length == 0 ? "" : ss[0].trim();
         if (ss.length == 0 || ss.length == 1 && (test.isEmpty()
                 || Stream.of("toggle", "anchor", "randomNbt", "pauseWhenEmpty").anyMatch(s -> s.startsWith(test)))) {
-            Stream.of("toggle", "anchor", "randomNbt", "pause_when_empty")
+            Stream.of("toggle", "anchor", "randomNbt", "pauseWhenEmpty")
                     .filter(s -> test.isEmpty() || s.startsWith(test)).forEach(l::add);
         } else if (test.equals("toggle")) {
             String test1 = ss[1].trim();

--- a/src/main/java/com/mitchej123/hodgepodge/commands/DebugCommand.java
+++ b/src/main/java/com/mitchej123/hodgepodge/commands/DebugCommand.java
@@ -15,6 +15,8 @@ import net.minecraft.util.ChatComponentText;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+import com.mitchej123.hodgepodge.mixins.interfaces.IPauseWhenEmpty;
 import com.mitchej123.hodgepodge.util.AnchorAlarm;
 
 public class DebugCommand extends CommandBase {
@@ -26,11 +28,11 @@ public class DebugCommand extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "Usage: hp <subcommand>. Valid subcommands are: toggle, anchor, randomNbt.";
+        return "Usage: hp <subcommand>. Valid subcommands are: toggle, anchor, randomNbt, pauseWhenEmpty.";
     }
 
     private void printHelp(ICommandSender sender) {
-        sender.addChatMessage(new ChatComponentText("Usage: hp <toggle|anchor|randomNbt>"));
+        sender.addChatMessage(new ChatComponentText("Usage: hp <toggle|anchor|randomNbt|pause_when_empty>"));
         sender.addChatMessage(new ChatComponentText("\"toggle anchordebug\" - toggles RC anchor debugging"));
         sender.addChatMessage(
                 new ChatComponentText(
@@ -38,16 +40,19 @@ public class DebugCommand extends CommandBase {
         sender.addChatMessage(
                 new ChatComponentText(
                         "\"randomNbt [bytes]\" - adds a random byte array of the given size to the held item"));
+        sender.addChatMessage(
+                new ChatComponentText(
+                        "\"pauseWhenEmpty [seconds]\" - sets the time the server will wait before pausing when no players are online; 0 to disable"));
     }
 
     @Override
     public List<String> addTabCompletionOptions(ICommandSender sender, String[] ss) {
         List<String> l = new ArrayList<>();
         String test = ss.length == 0 ? "" : ss[0].trim();
-        if (ss.length == 0 || ss.length == 1
-                && (test.isEmpty() || Stream.of("toggle", "anchor", "randomNbt").anyMatch(s -> s.startsWith(test)))) {
-            Stream.of("toggle", "anchor", "randomNbt").filter(s -> test.isEmpty() || s.startsWith(test))
-                    .forEach(l::add);
+        if (ss.length == 0 || ss.length == 1 && (test.isEmpty()
+                || Stream.of("toggle", "anchor", "randomNbt", "pauseWhenEmpty").anyMatch(s -> s.startsWith(test)))) {
+            Stream.of("toggle", "anchor", "randomNbt", "pause_when_empty")
+                    .filter(s -> test.isEmpty() || s.startsWith(test)).forEach(l::add);
         } else if (test.equals("toggle")) {
             String test1 = ss[1].trim();
             if (test1.isEmpty() || "anchordebug".startsWith(test1)) l.add("anchordebug");
@@ -112,6 +117,38 @@ public class DebugCommand extends CommandBase {
                 stack.stackTagCompound.setByteArray("DebugJunk", randomData);
                 player.inventory.inventoryChanged = true;
                 player.inventoryContainer.detectAndSendChanges();
+                break;
+            case "pauseWhenEmpty":
+                if (!TweaksConfig.pauseWhenEmpty) {
+                    sender.addChatMessage(new ChatComponentText("'pauseWhenEmpty' config option is disabled"));
+                    return;
+                }
+                if (strings.length < 2) {
+                    printHelp(sender);
+                    return;
+                }
+                final int pauseTimeout = NumberUtils.toInt(strings[1], -1);
+                if (pauseTimeout < 0) {
+                    printHelp(sender);
+                    return;
+                }
+
+                MinecraftServer server = MinecraftServer.getServer();
+                if (!server.isDedicatedServer()) {
+                    sender.addChatMessage(
+                            new ChatComponentText("'hp pauseWhenEmpty' only applies to dedicated servers"));
+                    return;
+                }
+
+                if (server instanceof IPauseWhenEmpty p) {
+                    p.setPauseWhenEmptySeconds(pauseTimeout);
+                    sender.addChatMessage(
+                            new ChatComponentText(
+                                    String.format(
+                                            "Server property 'pause-when-empty-seconds' set to %d",
+                                            pauseTimeout)));
+                }
+
                 break;
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -128,6 +128,10 @@ public class TweaksConfig {
     @Config.DefaultInt(900)
     public static int autoSaveInterval;
 
+    @Config.Comment("Backports 1.20's 'pause-when-empty-seconds' server property")
+    @Config.DefaultBoolean(true)
+    public static boolean pauseWhenEmpty;
+
     @Config.Comment("Reduces water opacity from 3 to 1, to match modern")
     @Config.DefaultBoolean(false)
     public static boolean useLighterWater;
@@ -306,5 +310,4 @@ public class TweaksConfig {
     @Config.Comment("Avoids droping items on container close, and instead places them in the player inventory. (Inspired from EFR)")
     @Config.DefaultBoolean(true)
     public static boolean avoidDroppingItemsWhenClosing;
-
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -128,7 +128,7 @@ public class TweaksConfig {
     @Config.DefaultInt(900)
     public static int autoSaveInterval;
 
-    @Config.Comment("Backports 1.20's 'pause-when-empty-seconds' server property")
+    @Config.Comment({"Backports 1.20's 'pause-when-empty-seconds' server property", "Default value: 0 (off)"})
     @Config.DefaultBoolean(true)
     public static boolean pauseWhenEmpty;
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -128,7 +128,7 @@ public class TweaksConfig {
     @Config.DefaultInt(900)
     public static int autoSaveInterval;
 
-    @Config.Comment({"Backports 1.20's 'pause-when-empty-seconds' server property", "Default value: 0 (off)"})
+    @Config.Comment({ "Backports 1.20's 'pause-when-empty-seconds' server property", "Default value: 0 (off)" })
     @Config.DefaultBoolean(true)
     public static boolean pauseWhenEmpty;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -418,8 +418,8 @@ public enum Mixins {
             .addMixinClasses("minecraft.server.MixinMinecraftServer_AutoSaveInterval")
             .setApplyIf(() -> TweaksConfig.autoSaveInterval != 900)),
 
-    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when noone is online after X seconds; Servers Only").setPhase(Phase.EARLY).setSide(Side.SERVER)
-            .addTargetedMod(TargetedMod.VANILLA)
+    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when noone is online after X seconds; Servers Only")
+            .setPhase(Phase.EARLY).setSide(Side.SERVER).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses("minecraft.server.MixinMinecraftServer_PauseWhenEmpty")
             .setApplyIf(() -> TweaksConfig.pauseWhenEmpty)),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -421,8 +421,8 @@ public enum Mixins {
             .addMixinClasses("minecraft.server.MixinMinecraftServer_AutoSaveInterval")
             .setApplyIf(() -> TweaksConfig.autoSaveInterval != 900)),
 
-    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when empty after X seconds; Servers Only")
-            .setPhase(Phase.EARLY).setSide(Side.SERVER).addTargetedMod(TargetedMod.VANILLA)
+    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when empty after X seconds; Servers Only").setPhase(Phase.EARLY)
+            .setSide(Side.SERVER).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses(
                     "minecraft.server.MixinMinecraftServer_PauseWhenEmpty",
                     "minecraft.server.MixinDedicatedServer_PauseWhenEmpty")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -421,7 +421,7 @@ public enum Mixins {
             .addMixinClasses("minecraft.server.MixinMinecraftServer_AutoSaveInterval")
             .setApplyIf(() -> TweaksConfig.autoSaveInterval != 900)),
 
-    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when noone is online after X seconds; Servers Only")
+    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when empty after X seconds; Servers Only")
             .setPhase(Phase.EARLY).setSide(Side.SERVER).addTargetedMod(TargetedMod.VANILLA)
             .addMixinClasses(
                     "minecraft.server.MixinMinecraftServer_PauseWhenEmpty",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -423,7 +423,9 @@ public enum Mixins {
 
     PAUSE_WHEN_EMPTY(new Builder("Pauses the server when noone is online after X seconds; Servers Only")
             .setPhase(Phase.EARLY).setSide(Side.SERVER).addTargetedMod(TargetedMod.VANILLA)
-            .addMixinClasses("minecraft.server.MixinMinecraftServer_PauseWhenEmpty")
+            .addMixinClasses(
+                    "minecraft.server.MixinMinecraftServer_PauseWhenEmpty",
+                    "minecraft.server.MixinDedicatedServer_PauseWhenEmpty")
             .setApplyIf(() -> TweaksConfig.pauseWhenEmpty)),
 
     LIGHTER_WATER(new Builder("Decreases water opacity from 3 to 1, like in modern").setPhase(Phase.EARLY)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -418,6 +418,11 @@ public enum Mixins {
             .addMixinClasses("minecraft.server.MixinMinecraftServer_AutoSaveInterval")
             .setApplyIf(() -> TweaksConfig.autoSaveInterval != 900)),
 
+    PAUSE_WHEN_EMPTY(new Builder("Pauses the server when noone is online after X seconds; Servers Only").setPhase(Phase.EARLY).setSide(Side.SERVER)
+            .addTargetedMod(TargetedMod.VANILLA)
+            .addMixinClasses("minecraft.server.MixinMinecraftServer_PauseWhenEmpty")
+            .setApplyIf(() -> TweaksConfig.pauseWhenEmpty)),
+
     LIGHTER_WATER(new Builder("Decreases water opacity from 3 to 1, like in modern").setPhase(Phase.EARLY)
             .setSide(Side.BOTH).addTargetedMod(TargetedMod.VANILLA).addMixinClasses("minecraft.MixinBlock_LighterWater")
             .setApplyIf(() -> TweaksConfig.useLighterWater)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinDedicatedServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinDedicatedServer_PauseWhenEmpty.java
@@ -1,0 +1,39 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.server;
+
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.dedicated.PropertyManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.mitchej123.hodgepodge.mixins.interfaces.IPauseWhenEmpty;
+
+@Mixin(DedicatedServer.class)
+public class MixinDedicatedServer_PauseWhenEmpty implements IPauseWhenEmpty {
+
+    @Shadow
+    private PropertyManager settings;
+
+    @Unique
+    private int hodgepodge$pauseWhenEmptySeconds = 0;
+
+    @Override
+    public int getPauseWhenEmptySeconds() {
+        return hodgepodge$pauseWhenEmptySeconds;
+    }
+
+    @Inject(
+            method = "startServer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/FMLCommonHandler;onServerStarted()V",
+                    remap = false,
+                    shift = At.Shift.AFTER))
+    public void hodgepodge$setupServer(CallbackInfoReturnable<Boolean> cir) {
+        hodgepodge$pauseWhenEmptySeconds = settings.getIntProperty("pause-when-empty-seconds", 0);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinDedicatedServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinDedicatedServer_PauseWhenEmpty.java
@@ -26,6 +26,15 @@ public class MixinDedicatedServer_PauseWhenEmpty implements IPauseWhenEmpty {
         return hodgepodge$pauseWhenEmptySeconds;
     }
 
+    @Override
+    public void setPauseWhenEmptySeconds(int value) {
+        value = Math.max(value, 0);
+        hodgepodge$pauseWhenEmptySeconds = value;
+
+        settings.setProperty("pause-when-empty-seconds", hodgepodge$pauseWhenEmptySeconds);
+        settings.saveProperties();
+    }
+
     @Inject(
             method = "startServer",
             at = @At(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
@@ -2,6 +2,7 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft.server;
 
 import net.minecraft.network.NetworkSystem;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.management.ServerConfigurationManager;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,7 +35,7 @@ public abstract class MixinMinecraftServer_PauseWhenEmpty {
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true, order = 9000)
     public void hodgepodge$tick(CallbackInfo ci) {
-        if ((Object) this instanceof IPauseWhenEmpty p) {
+        if ((Object) this instanceof DedicatedServer ds && ds instanceof IPauseWhenEmpty p) {
             int pauseTicks = p.getPauseWhenEmptySeconds() * 20;
             if (pauseTicks > 0) {
                 if (this.getCurrentPlayerCount() == 0) {
@@ -51,8 +52,10 @@ public abstract class MixinMinecraftServer_PauseWhenEmpty {
                         this.saveAllWorlds(true);
                     }
 
+                    net.minecraftforge.common.chunkio.ChunkIOExecutor.tick();
                     // to process new connections
                     this.func_147137_ag().networkTick();
+                    ds.executePendingCommands();
                     ci.cancel();
                 }
             }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
@@ -33,7 +33,7 @@ public abstract class MixinMinecraftServer_PauseWhenEmpty {
     private int hodgepodge$emptyTicks = 0;
 
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true, order = 9000)
-    public void tick(CallbackInfo ci) {
+    public void hodgepodge$tick(CallbackInfo ci) {
         if ((Object) this instanceof IPauseWhenEmpty p) {
             int pauseTicks = p.getPauseWhenEmptySeconds() * 20;
             if (pauseTicks > 0) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
@@ -1,13 +1,12 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft.server;
 
-import com.mitchej123.hodgepodge.Common;
-import com.mitchej123.hodgepodge.Hodgepodge;
+import java.io.File;
+import java.net.Proxy;
+
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.dedicated.PropertyManager;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.spongepowered.asm.logging.ILogger;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -15,12 +14,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.io.File;
-import java.net.Proxy;
+import com.mitchej123.hodgepodge.Common;
 
 @Mixin(DedicatedServer.class)
 public abstract class MixinMinecraftServer_PauseWhenEmpty extends MinecraftServer {
-    @Shadow private PropertyManager settings;
+
+    @Shadow
+    private PropertyManager settings;
 
     @Unique
     private int hodgepodge$pauseWhenEmptySeconds = 0;
@@ -31,24 +31,30 @@ public abstract class MixinMinecraftServer_PauseWhenEmpty extends MinecraftServe
         super(workDir, proxy);
     }
 
-    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lcpw/mods/fml/common/FMLCommonHandler;onServerStarted()V", shift = At.Shift.AFTER))
-    public void hodgepodge$setupServer(CallbackInfoReturnable<Boolean> cir){
+    @Inject(
+            method = "startServer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/FMLCommonHandler;onServerStarted()V",
+                    shift = At.Shift.AFTER))
+    public void hodgepodge$setupServer(CallbackInfoReturnable<Boolean> cir) {
         hodgepodge$pauseWhenEmptySeconds = settings.getIntProperty("pause-when-empty-seconds", 0);
     }
 
     @Override
-    public void tick(){
+    public void tick() {
         int pauseTicks = hodgepodge$pauseWhenEmptySeconds * 20;
-        if (pauseTicks > 0){
-            if (getCurrentPlayerCount() == 0){
+        if (pauseTicks > 0) {
+            if (getCurrentPlayerCount() == 0) {
                 this.hodgepodge$emptyTicks++;
             } else {
                 this.hodgepodge$emptyTicks = 0;
             }
 
-            if (hodgepodge$emptyTicks >= pauseTicks){
-                if (hodgepodge$emptyTicks == pauseTicks){
-                    Common.log.info("Server empty for {} seconds, saving and pausing", hodgepodge$pauseWhenEmptySeconds);
+            if (hodgepodge$emptyTicks >= pauseTicks) {
+                if (hodgepodge$emptyTicks == pauseTicks) {
+                    Common.log
+                            .info("Server empty for {} seconds, saving and pausing", hodgepodge$pauseWhenEmptySeconds);
                     this.serverConfigManager.saveAllPlayerData();
                     this.saveAllWorlds(true);
                 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
@@ -36,6 +36,7 @@ public abstract class MixinMinecraftServer_PauseWhenEmpty extends MinecraftServe
             at = @At(
                     value = "INVOKE",
                     target = "Lcpw/mods/fml/common/FMLCommonHandler;onServerStarted()V",
+                    remap = false,
                     shift = At.Shift.AFTER))
     public void hodgepodge$setupServer(CallbackInfoReturnable<Boolean> cir) {
         hodgepodge$pauseWhenEmptySeconds = settings.getIntProperty("pause-when-empty-seconds", 0);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_PauseWhenEmpty.java
@@ -1,0 +1,64 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.server;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.Hodgepodge;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.dedicated.PropertyManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.logging.ILogger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.io.File;
+import java.net.Proxy;
+
+@Mixin(DedicatedServer.class)
+public abstract class MixinMinecraftServer_PauseWhenEmpty extends MinecraftServer {
+    @Shadow private PropertyManager settings;
+
+    @Unique
+    private int hodgepodge$pauseWhenEmptySeconds = 0;
+    @Unique
+    private int hodgepodge$emptyTicks = 0;
+
+    public MixinMinecraftServer_PauseWhenEmpty(File workDir, Proxy proxy) {
+        super(workDir, proxy);
+    }
+
+    @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lcpw/mods/fml/common/FMLCommonHandler;onServerStarted()V", shift = At.Shift.AFTER))
+    public void hodgepodge$setupServer(CallbackInfoReturnable<Boolean> cir){
+        hodgepodge$pauseWhenEmptySeconds = settings.getIntProperty("pause-when-empty-seconds", 0);
+    }
+
+    @Override
+    public void tick(){
+        int pauseTicks = hodgepodge$pauseWhenEmptySeconds * 20;
+        if (pauseTicks > 0){
+            if (getCurrentPlayerCount() == 0){
+                this.hodgepodge$emptyTicks++;
+            } else {
+                this.hodgepodge$emptyTicks = 0;
+            }
+
+            if (hodgepodge$emptyTicks >= pauseTicks){
+                if (hodgepodge$emptyTicks == pauseTicks){
+                    Common.log.info("Server empty for {} seconds, saving and pausing", hodgepodge$pauseWhenEmptySeconds);
+                    this.serverConfigManager.saveAllPlayerData();
+                    this.saveAllWorlds(true);
+                }
+
+                // to process new connections
+                this.func_147137_ag().networkTick();
+                return;
+            }
+        }
+
+        super.tick();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/IPauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/IPauseWhenEmpty.java
@@ -1,0 +1,6 @@
+package com.mitchej123.hodgepodge.mixins.interfaces;
+
+public interface IPauseWhenEmpty {
+
+    int getPauseWhenEmptySeconds();
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/IPauseWhenEmpty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/IPauseWhenEmpty.java
@@ -3,4 +3,6 @@ package com.mitchej123.hodgepodge.mixins.interfaces;
 public interface IPauseWhenEmpty {
 
     int getPauseWhenEmptySeconds();
+
+    void setPauseWhenEmptySeconds(int value);
 }

--- a/src/main/resources/META-INF/hodgepodge_at.cfg
+++ b/src/main/resources/META-INF/hodgepodge_at.cfg
@@ -23,6 +23,4 @@ public net.minecraft.client.resources.SimpleReloadableResourceManager field_1105
 public net.minecraft.entity.EntityList field_75624_e # classToIDMapping
 public net.minecraft.world.WorldServer func_73053_d()V # wakeAllPlayers()
 
-protected net.minecraft.server.MinecraftServer field_71318_t # serverConfigManager
-
 public net.minecraft.server.management.PlayerManager$PlayerInstance

--- a/src/main/resources/META-INF/hodgepodge_at.cfg
+++ b/src/main/resources/META-INF/hodgepodge_at.cfg
@@ -23,4 +23,6 @@ public net.minecraft.client.resources.SimpleReloadableResourceManager field_1105
 public net.minecraft.entity.EntityList field_75624_e # classToIDMapping
 public net.minecraft.world.WorldServer func_73053_d()V # wakeAllPlayers()
 
+protected net.minecraft.server.MinecraftServer field_71318_t # serverConfigManager
+
 public net.minecraft.server.management.PlayerManager$PlayerInstance


### PR DESCRIPTION
Change from modern: default value of `pause-when-empty-seconds` is 0 which means the server wont pause.

Tested in a dev server with a value of 5.

Ticks stopped after 5 seconds, resumed when there was a connection and then stopped again when empty after 5 seconds.


Added command `/hp pauseWhenEmpty <seconds>`

![image](https://github.com/user-attachments/assets/fe6b8766-afb6-4453-9c8a-90a51f46ab6c)
![image](https://github.com/user-attachments/assets/3e2a8a20-5093-40bb-b39e-3d945c0de3f4)
![image](https://github.com/user-attachments/assets/ce592a15-b67a-42d6-9eb4-b9a8f4c32959)
