### PR TITLE
Improve several simulated block break actions of mods

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -551,14 +551,6 @@ public class FixesConfig {
     @Config.DefaultBoolean(false)
     public static boolean disableMassiveSacredTreeGeneration;
 
-    @Config.Comment("Improves MineFactory Reloaded smasher block to support other mods manipulating its drops")
-    @Config.DefaultBoolean(true)
-    public static boolean improveMfrBlockSmasher;
-
-    @Config.Comment("Improves MineFactory Reloaded breaker block to support other mods manipulating its drops")
-    @Config.DefaultBoolean(true)
-    public static boolean improveMfrBlockBreaker;
-
     // Morpheus
 
     @Config.Comment("Fix not properly waking players if not everyone is sleeping")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -551,6 +551,14 @@ public class FixesConfig {
     @Config.DefaultBoolean(false)
     public static boolean disableMassiveSacredTreeGeneration;
 
+    @Config.Comment("Improves MineFactory Reloaded smasher block to support other mods manipulating its drops")
+    @Config.DefaultBoolean(true)
+    public static boolean improveMfrBlockSmasher;
+
+    @Config.Comment("Improves MineFactory Reloaded breaker block to support other mods manipulating its drops")
+    @Config.DefaultBoolean(true)
+    public static boolean improveMfrBlockBreaker;
+
     // Morpheus
 
     @Config.Comment("Fix not properly waking players if not everyone is sleeping")

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -212,6 +212,12 @@ public class TweaksConfig {
     @Config.DefaultBoolean(false)
     public static boolean removeBOPQuicksandGeneration;
 
+    // Cofh
+
+    @Config.Comment("Improve CoFH's breakBlock method")
+    @Config.DefaultBoolean(true)
+    public static boolean improveCofhBreakBlock;
+
     // Extra Utilities
 
     @Config.Comment("Disables the spawn of zombie aid when zombie is killed by Extra Utilities Spikes, since it can spawn them too far.")
@@ -248,6 +254,16 @@ public class TweaksConfig {
     @Config.RangeInt(min = 1, max = 255)
     @Config.DefaultInt(255)
     public static int atropineHighID;
+
+    // Minefactory Reloaded
+
+    @Config.Comment("Improves MineFactory Reloaded smasher block to support other mods manipulating its drops")
+    @Config.DefaultBoolean(true)
+    public static boolean improveMfrBlockSmasher;
+
+    @Config.Comment("Improves MineFactory Reloaded breaker block to support other mods manipulating its drops")
+    @Config.DefaultBoolean(true)
+    public static boolean improveMfrBlockBreaker;
 
     // NotEnoughItems
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -691,6 +691,12 @@ public enum Mixins {
             .addMixinClasses("minefactoryreloaded.MixinBlockRubberSapling").setPhase(Phase.LATE).setSide(Side.BOTH)
             .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED)
             .setApplyIf(() -> FixesConfig.disableMassiveSacredTreeGeneration)),
+    MFR_IMPROVE_BLOCKSMASHER(new Builder("Improve MFR block smasher")
+            .addMixinClasses("minefactoryreloaded.MixinTileEntityBlockSmasher").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> FixesConfig.improveMfrBlockSmasher)),
+    MFR_IMPROVE_BLOCKBREAKER(new Builder("Improve MFR block breaker")
+            .addMixinClasses("minefactoryreloaded.MixinTileEntityBlockBreaker").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> FixesConfig.improveMfrBlockBreaker)),
 
     // Immersive engineering
     JAVA12_IMMERSIVE_ENGINERRING(new Builder("Immersive Engineering Java-12 safe potion array resizing")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -685,6 +685,9 @@ public enum Mixins {
     FIX_ORE_DICT_CME(new Builder("Fix race condition in CoFH oredict").addMixinClasses("cofhcore.MixinFMLEventHandler")
             .setPhase(Phase.EARLY).setSide(Side.CLIENT).addTargetedMod(TargetedMod.COFH_CORE)
             .setApplyIf(() -> FixesConfig.fixCofhOreDictCME)),
+    COFH_IMPROVE_BREAKBLOCK(new Builder("Improve CoFH breakBlock method to support mods")
+            .addMixinClasses("cofhcore.MixinBlockHelper").setPhase(Phase.EARLY).setSide(Side.CLIENT)
+            .addTargetedMod(TargetedMod.COFH_CORE).setApplyIf(() -> TweaksConfig.improveCofhBreakBlock)),
 
     // Minefactory Reloaded
     DISARM_SACRED_TREE(new Builder("Prevents Sacred Rubber Tree Generation")
@@ -693,10 +696,10 @@ public enum Mixins {
             .setApplyIf(() -> FixesConfig.disableMassiveSacredTreeGeneration)),
     MFR_IMPROVE_BLOCKSMASHER(new Builder("Improve MFR block smasher")
             .addMixinClasses("minefactoryreloaded.MixinTileEntityBlockSmasher").setPhase(Phase.LATE).setSide(Side.BOTH)
-            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> FixesConfig.improveMfrBlockSmasher)),
+            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> TweaksConfig.improveMfrBlockSmasher)),
     MFR_IMPROVE_BLOCKBREAKER(new Builder("Improve MFR block breaker")
             .addMixinClasses("minefactoryreloaded.MixinTileEntityBlockBreaker").setPhase(Phase.LATE).setSide(Side.BOTH)
-            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> FixesConfig.improveMfrBlockBreaker)),
+            .addTargetedMod(TargetedMod.MINEFACTORY_RELOADED).setApplyIf(() -> TweaksConfig.improveMfrBlockBreaker)),
 
     // Immersive engineering
     JAVA12_IMMERSIVE_ENGINERRING(new Builder("Immersive Engineering Java-12 safe potion array resizing")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinBlockHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinBlockHelper.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.mixins.early.cofhcore;
 import java.util.ArrayList;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -10,24 +11,24 @@ import net.minecraftforge.event.ForgeEventFactory;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 
 import cofh.lib.util.helpers.BlockHelper;
 
 @Mixin(BlockHelper.class)
-public abstract class MixinBlockHelper {
+public class MixinBlockHelper {
 
-    @WrapOperation(
-            method = "breakBlock(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;IIILnet/minecraft/block/Block;IZZ)Ljava/util/List;",
+    @ModifyExpressionValue(
             at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/block/Block;getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;"),
+                    target = "Lnet/minecraft/block/Block;getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;",
+                    value = "INVOKE"),
+            method = "breakBlock(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;IIILnet/minecraft/block/Block;IZZ)Ljava/util/List;",
             remap = false)
-    private static ArrayList<ItemStack> hodgepodge$breakBlock$fireDropEvent(Block block, World world, int x, int y,
-            int z, int metadata, int fortune, Operation<ArrayList<ItemStack>> original) {
-        ArrayList<ItemStack> drops = original.call(block, world, x, y, z, metadata, fortune);
-        ForgeEventFactory.fireBlockHarvesting(drops, world, block, 0, 1, 0, metadata, fortune, 1.0f, false, null);
+    private static ArrayList<ItemStack> hodgepodge$fireBlockHarvesting(ArrayList<ItemStack> drops, World world,
+            EntityPlayer player, int x, int y, int z, Block block, int fortune, boolean var7, boolean silkTouch,
+            @Local(ordinal = 6) int meta) {
+        ForgeEventFactory.fireBlockHarvesting(drops, world, block, x, y, z, meta, fortune, 1.0f, silkTouch, player);
         return drops;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinBlockHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/cofhcore/MixinBlockHelper.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.cofhcore;
+
+import java.util.ArrayList;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.event.ForgeEventFactory;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import cofh.lib.util.helpers.BlockHelper;
+
+@Mixin(BlockHelper.class)
+public abstract class MixinBlockHelper {
+
+    @WrapOperation(
+            method = "breakBlock(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;IIILnet/minecraft/block/Block;IZZ)Ljava/util/List;",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;"),
+            remap = false)
+    private static ArrayList<ItemStack> hodgepodge$breakBlock$fireDropEvent(Block block, World world, int x, int y,
+            int z, int metadata, int fortune, Operation<ArrayList<ItemStack>> original) {
+        ArrayList<ItemStack> drops = original.call(block, world, x, y, z, metadata, fortune);
+        ForgeEventFactory.fireBlockHarvesting(drops, world, block, 0, 1, 0, metadata, fortune, 1.0f, false, null);
+        return drops;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockBreaker.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockBreaker.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.late.minefactoryreloaded;
+
+import java.util.ArrayList;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.event.ForgeEventFactory;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import powercrystals.minefactoryreloaded.tile.machine.TileEntityBlockBreaker;
+
+@Mixin(TileEntityBlockBreaker.class)
+public abstract class MixinTileEntityBlockBreaker {
+
+    @WrapOperation(
+            method = "activateMachine",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;"),
+            remap = false)
+    private ArrayList<ItemStack> hodgepodge$activateMachine$fireDropEvent(Block block, World world, int x, int y, int z,
+            int metadata, int fortune, Operation<ArrayList<ItemStack>> original) {
+        ArrayList<ItemStack> drops = original.call(block, world, x, y, z, metadata, fortune);
+        ForgeEventFactory.fireBlockHarvesting(drops, world, block, 0, 1, 0, metadata, fortune, 1.0f, false, null);
+        return drops;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockBreaker.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockBreaker.java
@@ -10,24 +10,24 @@ import net.minecraftforge.event.ForgeEventFactory;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 
 import powercrystals.minefactoryreloaded.tile.machine.TileEntityBlockBreaker;
 
 @Mixin(TileEntityBlockBreaker.class)
-public abstract class MixinTileEntityBlockBreaker {
+public class MixinTileEntityBlockBreaker {
 
-    @WrapOperation(
-            method = "activateMachine",
+    @ModifyExpressionValue(
             at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/block/Block;getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;"),
+                    target = "Lnet/minecraft/block/Block;getDrops(Lnet/minecraft/world/World;IIIII)Ljava/util/ArrayList;",
+                    value = "INVOKE"),
+            method = "activateMachine",
             remap = false)
-    private ArrayList<ItemStack> hodgepodge$activateMachine$fireDropEvent(Block block, World world, int x, int y, int z,
-            int metadata, int fortune, Operation<ArrayList<ItemStack>> original) {
-        ArrayList<ItemStack> drops = original.call(block, world, x, y, z, metadata, fortune);
-        ForgeEventFactory.fireBlockHarvesting(drops, world, block, 0, 1, 0, metadata, fortune, 1.0f, false, null);
+    private ArrayList<ItemStack> hodgepodge$fireBlockHarvesting(ArrayList<ItemStack> drops,
+            @Local(ordinal = 0) World world, @Local(ordinal = 0) Block block, @Local(ordinal = 0) int x,
+            @Local(ordinal = 1) int y, @Local(ordinal = 2) int z, @Local(ordinal = 3) int meta) {
+        ForgeEventFactory.fireBlockHarvesting(drops, world, block, x, y, z, meta, 0, 1.0f, false, null);
         return drops;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockSmasher.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockSmasher.java
@@ -1,0 +1,48 @@
+package com.mitchej123.hodgepodge.mixins.late.minefactoryreloaded;
+
+import java.util.ArrayList;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.event.ForgeEventFactory;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import powercrystals.minefactoryreloaded.tile.machine.TileEntityBlockSmasher;
+import powercrystals.minefactoryreloaded.world.SmashingWorld;
+
+@Mixin(TileEntityBlockSmasher.class)
+public abstract class MixinTileEntityBlockSmasher {
+
+    @WrapOperation(
+            method = "getOutput",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lpowercrystals/minefactoryreloaded/world/SmashingWorld;smashBlock(Lnet/minecraft/item/ItemStack;Lnet/minecraft/block/Block;II)Ljava/util/ArrayList;"),
+            remap = false)
+    private ArrayList<ItemStack> hodgepodge$getOutput$fireDropEvent(SmashingWorld world, ItemStack stack, Block block,
+            int metadata, int fortune, Operation<ArrayList<ItemStack>> original) {
+        ArrayList<ItemStack> drops = original.call(world, stack, block, metadata, fortune);
+        if (drops == null) {
+            drops = block.getDrops((World) (Object) world, 0, 0, 0, metadata, fortune);
+        }
+        ForgeEventFactory.fireBlockHarvesting(
+                drops,
+                (World) (Object) world,
+                block,
+                0,
+                1,
+                0,
+                metadata,
+                fortune,
+                1.0f,
+                false,
+                null);
+        return drops;
+    }
+}


### PR DESCRIPTION
This PR intents to improve the following mods/items:
- MineFactory Reloaded
  - Block smasher
  - Block breaker
- Thermal Expansion
  - Terrain smasher

This allowes mods to manipulate the output, like EFR that changes the output of ore blocks to raw ore items. -> Make it more realistic, like a player that breaks a block, what it even is intented to be.

From my side this is tested in dev and within my full private pack (200+ mods).
However, someone should test this also in the full GTNH pack, if it breaks any maschine that break blocks or convert them to items. If it makes problems, I can will make the config defaults `false`.