### PR TITLE
ensure drops is not null

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockSmasher.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/minefactoryreloaded/MixinTileEntityBlockSmasher.java
@@ -34,6 +34,10 @@ public class MixinTileEntityBlockSmasher {
             remap = false)
     private ArrayList<ItemStack> hodgepodge$fireBlockHarvesting(ArrayList<ItemStack> drops, ItemStack lastInputStack,
             @Local(ordinal = 0) Block block, @Local(ordinal = 0) ItemBlock lastInputItem) {
+        int metadata = lastInputItem.getMetadata(lastInputStack.getItemDamage());
+        if (drops == null) {
+            drops = block.getDrops(this._smashingWorld, 0, 1, 0, metadata, this._fortune);
+        }
         ForgeEventFactory.fireBlockHarvesting(
                 drops,
                 this._smashingWorld,
@@ -41,7 +45,7 @@ public class MixinTileEntityBlockSmasher {
                 0,
                 1,
                 0,
-                lastInputItem.getMetadata(lastInputStack.getItemDamage()),
+                metadata,
                 this._fortune,
                 1.0f,
                 false,


### PR DESCRIPTION
-> got removed falsely via commit d361e088259cdbd8ebe2790d527cdc5b4ce50775 from #478 

This change was important to fix a server crash due NullPointerException from EFR that assumes this isn't null. Reason is that the super method thinks it can't handle it and just return null.

Wasn't able to test again until now after glows changes, and well, it was merged already. That's why this PR.