### PR TITLE
fix extra utilities ender quarry freeze/soft-lock randomly

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,12 +21,12 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.89:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.93:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.0-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.3.0:dev") // Do not update, fixed afterwards
     transformedModCompileOnly("com.github.GTNewHorizons:Railcraft:9.16.3:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
-    transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.7-GTNH:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.8-GTNH:dev")
     transformedModCompileOnly(rfg.deobf("curse.maven:bibliocraft-228027:2423369"))
     transformedModCompileOnly(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612"))
     transformedModCompileOnly("curse.maven:cofh-core-69162:2388751")
@@ -45,7 +45,7 @@ dependencies {
     transformedModCompileOnly(rfg.deobf("curse.maven:glibys-voice-chat-225110:2301492"))
 
     transformedModCompileOnly(rfg.deobf("curse.maven:automagy-222153:2285272"))
-    transformedModCompileOnly("com.github.GTNewHorizons:Galacticraft:3.3.3-GTNH:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:Galacticraft:3.3.4-GTNH:dev")
     transformedModCompileOnly("curse.maven:minechem-368422:2905830")
     transformedModCompileOnly("curse.maven:thermal-dynamics-227443:2388756")
     transformedModCompileOnly("curse.maven:thermal-expansion-69163:2388759")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -453,6 +453,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesFilterDupe;
 
+    @Config.Comment("Fixes Ender Quarry get stuck at a mostly random location under certain conditions")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesEnderQuarryFreeze;
+
     // Galacticraft
 
     @Config.Comment("Fix time commands with GC")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -846,6 +846,10 @@ public enum Mixins {
             .addMixinClasses("extrautilities.MixinTileEntityEnderQuarry").setPhase(Phase.LATE).setSide(Side.BOTH)
             .setApplyIf(() -> TweaksConfig.extraUtilitiesEnderQuarryOverride > 0)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_ENDERQUARRY_FREEZE(new Builder("Fix Ender Quarry freezes randomly")
+            .addMixinClasses("extrautilities.MixinTileEntityEnderQuarry_FixFreeze").setPhase(Phase.LATE)
+            .setSide(Side.BOTH).setApplyIf(() -> FixesConfig.fixExtraUtilitiesEnderQuarryFreeze)
+            .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Gliby's Voice Chat
     FIX_GLIBYS_VC_THREAD_SHUTDOWN_CLIENT(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEntityEnderQuarry_FixFreeze.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEntityEnderQuarry_FixFreeze.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.rwtema.extrautils.tileentity.enderquarry.TileEntityEnderQuarry;
+
+@Mixin(TileEntityEnderQuarry.class)
+public class MixinTileEntityEnderQuarry_FixFreeze {
+
+    @ModifyReturnValue(method = "harvestBlock", at = @At("RETURN"), remap = false)
+    private boolean hodgepodge$fixFreeze(boolean original) {
+        // To fix a weird issue with certain mods that let the Ender Quarry stuck at a
+        // mostly random location, return true also in the following (all) scenario:
+        // - The harvested block has no drops
+        // - The harvested block has unexpected drops
+        // - The harvested block has been harvested by another Entity
+        return true;
+    }
+}


### PR DESCRIPTION
This fixes an issue where the Ender Quarry get stuck at a mostly random location and wont continue with anything (soft-lock). The only thing that works at this point is breaking the quarry. placing it and starting again from zero.

The source are a few blocks from mods that either drop nothing *(having a few blocks in mind, but random mods)* or mods that converts their blocks while harvesting *(hello Underground Biomes Construct)*.

To prevent this issue we need to return `true` also in the following (so all available) scenario at the method `harvestBlock`:
- The harvested block has no drops
- The harvested block has unexpected drops
- The harvested block has been harvested by another Entity

New possible effects:
- If the block can't be harvested for some good reason, the drops (if available) get stored in the inventory and the energy will be used anyway. Don't matter if the block was really replaced with dirt or not.
- The energy get used don't matter if the item has drops or not. It's fine in my optinion as the quarry should need energy even for the try.

Not tested in the full pack, might need to check someone else. I only tested in my own full pack.