### PR TITLE
Modular Powersuits energy methods to only interacts with MPS equipment

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,6 +35,7 @@ dependencies {
     transformedModCompileOnly("curse.maven:extra-utilities-225561:2264384")
     transformedModCompileOnly(rfg.deobf("curse.maven:extratic-72728:2299292"))
     transformedModCompileOnly(rfg.deobf("curse.maven:journeymap-32274:4500658"))
+    transformedModCompileOnly("curse.maven:modular-powersuits-235442:2666986")
     transformedModCompileOnly(rfg.deobf("curse.maven:morpheus-69118:2280761"))
     transformedModCompileOnly(deobf('https://dist.creeper.host/ichun/filespg/PortalGun-4.0.0-beta-6.jar'))
     transformedModCompileOnly("curse.maven:travellers-gear-224440:2262113")

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -265,6 +265,17 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean improveMfrBlockBreaker;
 
+    // Modular Powersuits
+    @Config.Comment("Prevents ModularPowerSuits from charging and draining RF energy from other non-MPS items in inventory")
+    @Config.DefaultBoolean(false)
+    public static boolean preventMPSEnergyTransferRF;
+    @Config.Comment("Prevents ModularPowerSuits from charging and draining EU energy from other non-MPS items in inventory")
+    @Config.DefaultBoolean(false)
+    public static boolean preventMPSEnergyTransferEU;
+    @Config.Comment("Prevents ModularPowerSuits from charging and draining ME energy from other non-MPS items in inventory")
+    @Config.DefaultBoolean(false)
+    public static boolean preventMPSEnergyTransferME;
+
     // NotEnoughItems
 
     @Config.Comment("Fix vanilla potion effects rendering above the NEI tooltips in the inventory")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -710,6 +710,17 @@ public enum Mixins {
             .addMixinClasses("minechem.MixinPotionInjector").setApplyIf(() -> FixesConfig.java12MineChemCompat)
             .addTargetedMod(TargetedMod.MINECHEM)),
 
+    // Modular Powersuits
+    MPS_PREVENT_RF_ENERGY_SYPHON(new Builder("Prevent MPS from charging and draining RF from Inventory")
+            .setPhase(Phase.LATE).setSide(Side.BOTH).addMixinClasses("mps.MixinElectricAdapterRF")
+            .setApplyIf(() -> TweaksConfig.preventMPSEnergyTransferRF).addTargetedMod(TargetedMod.MODULARPOWERSUITS)),
+    MPS_PREVENT_EU_ENERGY_SYPHON(new Builder("Prevent MPS from charging and draining EU from Inventory")
+            .setPhase(Phase.LATE).setSide(Side.BOTH).addMixinClasses("mps.MixinElectricAdapterEU")
+            .setApplyIf(() -> TweaksConfig.preventMPSEnergyTransferEU).addTargetedMod(TargetedMod.MODULARPOWERSUITS)),
+    MPS_PREVENT_ME_ENERGY_SYPHON(new Builder("Prevent MPS from charging and draining ME from Inventory")
+            .setPhase(Phase.LATE).setSide(Side.BOTH).addMixinClasses("mps.MixinElectricAdapterME")
+            .setApplyIf(() -> TweaksConfig.preventMPSEnergyTransferME).addTargetedMod(TargetedMod.MODULARPOWERSUITS)),
+
     // MrTJPCore (Project Red)
     FIX_HUD_LIGHTING_GLITCH(new Builder("HUD Lighting glitch").setPhase(Phase.LATE).setSide(Side.BOTH)
             .addMixinClasses("mrtjpcore.MixinFXEngine").setApplyIf(() -> TweaksConfig.fixHudLightingGlitch)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -37,6 +37,7 @@ public enum TargetedMod {
     LWJGL3IFY("lwjgl3ify", "me.eigenraven.lwjgl3ify.core.Lwjgl3ifyCoremod", "lwjgl3ify"),
     MINECHEM("Minechem", null, "minechem"),
     MINEFACTORY_RELOADED("MineFactory Reloaded", null, "MineFactoryReloaded"),
+    MODULARPOWERSUITS("MachineMuse's Modular Powersuits", null, "powersuits"),
     MORPHEUS("Morpheus", null, "Morpheus"),
     MRTJPCORE("MrTJPCore", null, "MrTJPCoreMod"),
     NOTENOUGHITEMS("NotEnoughItems", "codechicken.nei.asm.NEICorePlugin", "NotEnoughItems"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/mps/MixinElectricAdapterEU.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/mps/MixinElectricAdapterEU.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.mps;
+
+import net.machinemuse.api.electricity.ElectricAdapter;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ElectricAdapter.class)
+public class MixinElectricAdapterEU {
+
+    @Redirect(
+            method = "wrap",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/machinemuse/powersuits/common/ModCompatibility;isIndustrialCraftLoaded()Z"),
+            remap = false)
+    private static boolean hodgepodge$DisableInventorySynphonMPSforEU() {
+        return false;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/mps/MixinElectricAdapterME.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/mps/MixinElectricAdapterME.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.mps;
+
+import net.machinemuse.api.electricity.ElectricAdapter;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ElectricAdapter.class)
+public class MixinElectricAdapterME {
+
+    @Redirect(
+            method = "wrap",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/machinemuse/powersuits/common/ModCompatibility;isAppengLoaded()Z"),
+            remap = false)
+    private static boolean hodgepodge$DisableInventorySynphonMPSforME() {
+        return false;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/mps/MixinElectricAdapterRF.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/mps/MixinElectricAdapterRF.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.late.mps;
+
+import net.machinemuse.api.electricity.ElectricAdapter;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ElectricAdapter.class)
+public class MixinElectricAdapterRF {
+
+    @Redirect(
+            method = "wrap",
+            at = @At(value = "INVOKE", target = "Lnet/machinemuse/powersuits/common/ModCompatibility;isRFAPILoaded()Z"),
+            remap = false)
+    private static boolean hodgepodge$DisableInventorySynphonMPSforRF() {
+        return false;
+    }
+}


### PR DESCRIPTION
Prevent Modular Powersuits from transferring energy of non-mps items in the player's inventory.

For Balancing:
- Prevents MPS from charging equipment too well, effectively making it free to use.
- Prevents MPS Batteries being meaningless as you can hoard energy devices and it will drain from those.

For Players
- Prevent important equipment you plan to use from being drained by MPS

For Fixing:
- Prevents situations where MPS was using energy from modded items without subtracting energy, effectively making it costless

For Modpack Creators
- Allows to define which Energy System MPS should interact with (RF, EU or ME - There are configs for each)