### PR TITLE
fix entity attributes range

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -335,6 +335,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixInventorySyncLag;
 
+    @Config.Comment("Prevent the client from crashing due to invalid entity attributes range (MC-150405)")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixEntityAttributesRange;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -115,6 +115,10 @@ public enum Mixins {
     TRANSPARENT_CHAT(new Builder("Transparent Chat").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinGuiNewChat_TransparentChat").setSide(Side.CLIENT)
             .setApplyIf(() -> TweaksConfig.transparentChat).addTargetedMod(TargetedMod.VANILLA)),
+    FIX_ENTITY_ATTRIBUTES_RANGE(new Builder("Fix Entity Attributes Range").setPhase(Phase.EARLY)
+            .addMixinClasses("minecraft.MixinNetHandlerPlayClient_FixEntityAttributesRange").setSide(Side.CLIENT)
+            .setApplyIf(() -> FixesConfig.fixEntityAttributesRange).addTargetedMod(TargetedMod.VANILLA)),
+
     // config handled in mixin due to server->client config sync
     LONGER_MESSAGES_CLIENT(new Builder("Longer Messages Client Side").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinGuiChat_LongerMessages").setApplyIf(() -> true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_FixEntityAttributesRange.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_FixEntityAttributesRange.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.network.NetHandlerPlayClient;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(NetHandlerPlayClient.class)
+public class MixinNetHandlerPlayClient_FixEntityAttributesRange {
+
+    /**
+     * @author raylras
+     * @reason Prevent the client from crashing due to invalid entity attributes range.
+     *
+     * @see <a href="https://bugs.mojang.com/browse/MC-150405">MC-150405</a>
+     * @see <a href=
+     *      "https://github.com/MinecraftForge/MinecraftForge/commit/05f4f5ec775fbba7cf5c0421041f417dd4c70a36">MinecraftForge
+     *      Patch</a>
+     */
+    @ModifyConstant(method = "handleEntityProperties", constant = @Constant(doubleValue = Double.MIN_NORMAL))
+    private static double hodgepodge$FixEntityAttributesRange(double original) {
+        return -Double.MAX_VALUE;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17380.

Reproduction steps:
- A `1.7.10` Minecraft server and client, with `EnderZoo-1.7.10-1.0.15.32.jar`, `Baubles-1.7.10-1.0.1.10`, and `Thaumcraft-1.7.10-4.2.3.5`.
- Start the server and client. After joining the server, place some concussion creepers using the spawn egg.
- Close the server with the command `stop`, and set the L32 `concussionCreeperEnabled` in `server/config/enderzoo/EnderZoo.cfg` to `false`, then restart the server.
- Join the server again.
- The client should crash with the error message: `java.lang.IllegalArgumentException: Default value cannot be lower than minimum value!`.

See also:
- https://bugs.mojang.com/browse/MC-150405
- https://github.com/MinecraftForge/MinecraftForge/commit/05f4f5ec775fbba7cf5c0421041f417dd4c70a36