### PR TITLE
Prevent CastClassException on invalid duct network

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -616,6 +616,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean preventThermalDynamicsNASE;
 
+    @Config.Comment("Prevent ClassCastException on forming invalid Thermal Dynamic fluid grid")
+    @Config.DefaultBoolean(true)
+    public static boolean preventFluidGridCrash;
+
     // VoxelMap
 
     @Config.Comment("Fix some NullPointerExceptions")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -929,6 +929,14 @@ public enum Mixins {
     ASP_RECIPE_FIX(new Builder("MT Core recipe fix").addMixinClasses("advancedsolarpanels.MixinAdvancedSolarPanel")
             .addTargetedMod(TargetedMod.ADVANCED_SOLAR_PANELS).setApplyIf(() -> FixesConfig.fixMTCoreRecipe)
             .setPhase(Phase.LATE).setSide(Side.BOTH)),
+    TD_NASE_PREVENTION(new Builder("Prevent NegativeArraySizeException on itemduct transfers")
+            .addMixinClasses("thermaldynamics.MixinSimulatedInv").setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.preventThermalDynamicsNASE).addTargetedMod(TargetedMod.THERMALDYNAMICS)
+            .setPhase(Phase.LATE)),
+    TD_FLUID_GRID_CCE(new Builder("Prevent ClassCastException on forming invalid Thermal Dynamic fluid grid")
+            .addMixinClasses("thermaldynamics.MixinTileFluidDuctSuper").setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.preventFluidGridCrash).addTargetedMod(TargetedMod.THERMALDYNAMICS)
+            .setPhase(Phase.LATE)),
 
     // Unbind Keybinds by default
     UNBIND_KEYS_TRAVELLERSGEAR(new Builder("Unbind Traveller's Gear keybinds")
@@ -950,10 +958,6 @@ public enum Mixins {
     IC2_CELL(new Builder("No IC2 Cell Consumption in tanks").addMixinClasses("ic2.MixinIC2ItemCell")
             .setPhase(Phase.LATE).setSide(Side.BOTH).setApplyIf(() -> TweaksConfig.ic2CellWithContainer)
             .addTargetedMod(TargetedMod.IC2)),
-    TD_NASE_PREVENTION(new Builder("Prevent NegativeArraySizeException on itemduct transfers")
-            .addMixinClasses("thermaldynamics.MixinSimulatedInv").setSide(Side.BOTH)
-            .setApplyIf(() -> FixesConfig.preventThermalDynamicsNASE).addTargetedMod(TargetedMod.THERMALDYNAMICS)
-            .setPhase(Phase.LATE)),
 
     // Chunk generation/population
     DISABLE_CHUNK_TERRAIN_GENERATION(new Builder("Disable chunk terrain generation").setPhase(Phase.EARLY)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thermaldynamics/MixinTileFluidDuctSuper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thermaldynamics/MixinTileFluidDuctSuper.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.thermaldynamics;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cofh.thermaldynamics.duct.fluid.FluidGridSuper;
+import cofh.thermaldynamics.duct.fluid.TileFluidDuctSuper;
+import cofh.thermaldynamics.multiblock.MultiBlockGrid;
+
+@Mixin(TileFluidDuctSuper.class)
+public class MixinTileFluidDuctSuper {
+
+    @Inject(method = "setGrid", at = @At(value = "HEAD"), remap = false, cancellable = true)
+    public void hodgepodge$setGrid(MultiBlockGrid par1, CallbackInfo ci) {
+        if (!(par1 instanceof FluidGridSuper)) {
+            par1.destroy();
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
Cancels and destroys attempts to create invalid fluid duct networks instead of crashing with CastClassException.

Thermal frequently casts objects without verifying if they are valid instances of the target class, which is why this issue persists. Unfortunately, this won’t be the last time it occurs. If it were FOSS, fixing it would be trivially easy.