### PR TITLE
Prevent lava from loading chunks

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -76,6 +76,11 @@ public class SpeedupsConfig {
     @Config.DefaultBoolean(true)
     public static boolean limitMobSpawningToViewDistance;
 
+    @Config.Comment("Prevents chunk loads caused by lava blocks")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean lavaChunkLoading;
+
     // Biomes O' Plenty
 
     @Config.Comment("Speedup biome fog rendering in BiomesOPlenty")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -510,6 +510,10 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinNetHandlePlayServer_FixWrongBlockPlacementCheck")
             .setApplyIf(() -> FixesConfig.fixWrongBlockPlacementDistanceCheck).addTargetedMod(TargetedMod.VANILLA)),
 
+    PREVENT_LAVA_CHUNK_LOADING(new Builder("Prevent lava blocks from loading chunks").setPhase(Phase.EARLY)
+            .setSide(Side.BOTH).addMixinClasses("minecraft.MixinBlockStaticLiquid")
+            .setApplyIf(() -> SpeedupsConfig.lavaChunkLoading).addTargetedMod(TargetedMod.VANILLA)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockStaticLiquid.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockStaticLiquid.java
@@ -16,7 +16,7 @@ public class MixinBlockStaticLiquid {
             method = "updateTick",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"))
     public Block wrapperUpdateTickGetBlock(World world, int x, int y, int z) {
-        if (!world.chunkExists(x >> 4, z >> 4)) {
+        if (!world.blockExists(x, y, z)) {
             // return something that isn't air, but also doesn't block movement so that the loop continues
             return Blocks.grass;
         } else {
@@ -26,7 +26,7 @@ public class MixinBlockStaticLiquid {
 
     @Redirect(method = "updateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isAirBlock(III)Z"))
     public boolean wrapperUpdateTickIsAirBlock(World world, int x, int y, int z) {
-        if (!world.chunkExists(x >> 4, z >> 4)) {
+        if (!world.blockExists(x, y, z)) {
             // return false so that this.isFlammable doesn't run
             return false;
         } else {
@@ -38,7 +38,7 @@ public class MixinBlockStaticLiquid {
             method = "isFlammable",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"))
     public Block wrapperIsFlammableGetBlock(World world, int x, int y, int z) {
-        if (!world.chunkExists(x >> 4, z >> 4)) {
+        if (!world.blockExists(x, y, z)) {
             // return something that isn't flammable so that the or's short circuit
             return Blocks.air;
         } else {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockStaticLiquid.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockStaticLiquid.java
@@ -1,0 +1,48 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockStaticLiquid;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(BlockStaticLiquid.class)
+public class MixinBlockStaticLiquid {
+
+    @Redirect(
+            method = "updateTick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"))
+    public Block wrapperUpdateTickGetBlock(World world, int x, int y, int z) {
+        if (!world.chunkExists(x >> 4, z >> 4)) {
+            // return something that isn't air, but also doesn't block movement so that the loop continues
+            return Blocks.grass;
+        } else {
+            return world.getBlock(x, y, z);
+        }
+    }
+
+    @Redirect(method = "updateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isAirBlock(III)Z"))
+    public boolean wrapperUpdateTickIsAirBlock(World world, int x, int y, int z) {
+        if (!world.chunkExists(x >> 4, z >> 4)) {
+            // return false so that this.isFlammable doesn't run
+            return false;
+        } else {
+            return world.isAirBlock(x, y, z);
+        }
+    }
+
+    @Redirect(
+            method = "isFlammable",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"))
+    public Block wrapperIsFlammableGetBlock(World world, int x, int y, int z) {
+        if (!world.chunkExists(x >> 4, z >> 4)) {
+            // return something that isn't flammable so that the or's short circuit
+            return Blocks.air;
+        } else {
+            return world.getBlock(x, y, z);
+        }
+    }
+}

--- a/src/main/resources/META-INF/hodgepodge_at.cfg
+++ b/src/main/resources/META-INF/hodgepodge_at.cfg
@@ -24,3 +24,5 @@ public net.minecraft.entity.EntityList field_75624_e # classToIDMapping
 public net.minecraft.world.WorldServer func_73053_d()V # wakeAllPlayers()
 
 public net.minecraft.server.management.PlayerManager$PlayerInstance
+
+public net.minecraft.world.World func_72916_c(II)Z # chunkExists

--- a/src/main/resources/META-INF/hodgepodge_at.cfg
+++ b/src/main/resources/META-INF/hodgepodge_at.cfg
@@ -24,5 +24,3 @@ public net.minecraft.entity.EntityList field_75624_e # classToIDMapping
 public net.minecraft.world.WorldServer func_73053_d()V # wakeAllPlayers()
 
 public net.minecraft.server.management.PlayerManager$PlayerInstance
-
-public net.minecraft.world.World func_72916_c(II)Z # chunkExists


### PR DESCRIPTION
In my world lava constantly loads chunks, causing quite a big performance hit. It's not so big that it's causing tps lag, but at the same time it's taking up 10-20% of my tick time, so it's low hanging fruit.

I've redirected several `World.getBlock` + analogues to check if the chunk is loaded first, and if it's not, bail. This change is fairly low risk, since this logic is only used to set flammable things around lava on fire.

Before:
https://spark.lucko.me/kUlsa23drS

BlockLiquidStatic only calls the update method, which only contains the fire logic for lava.
![image](https://github.com/user-attachments/assets/172937fa-41e9-428c-9b7c-ae29823b1fae)


After:
https://spark.lucko.me/xjzUlFbAka

![image](https://github.com/user-attachments/assets/1701b0a7-6c01-4f8c-9820-84d3a081a82b)
