### PR TITLE
Stop searching the same file multiple times for languages.

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -8,6 +8,10 @@ public class FixesConfig {
 
     /* ====== Minecraft fixes start ===== */
 
+    @Config.Comment("Only load languages once per File instead of once per Mod")
+    @Config.DefaultBoolean(true)
+    public static boolean onlyLoadLanguagesOnce;
+
     @Config.Comment("Modify the maximum NBT size limit when received as a network packet, to avoid large NBT-related crashes")
     @Config.DefaultBoolean(true)
     public static boolean changeMaxNetworkNbtSizeLimit;
@@ -664,4 +668,5 @@ public class FixesConfig {
     @Config.Comment("Fix ZTones packet exploits")
     @Config.DefaultBoolean(true)
     public static boolean fixZTonesPackets;
+
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -19,6 +19,9 @@ import cpw.mods.fml.relauncher.FMLLaunchHandler;
 public enum Mixins {
 
     // Vanilla Fixes
+    ONLY_LOAD_LANGUAGES_ONCE_PER_FILE(new Builder("Only load languages once per file").setPhase(Phase.EARLY)
+            .setSide(Side.BOTH).addMixinClasses("minecraft.MixinLanguageRegistry")
+            .setApplyIf(() -> FixesConfig.onlyLoadLanguagesOnce).addTargetedMod(TargetedMod.VANILLA)),
     CHANGE_CATEGORY_SPRINT_KEY(
             new Builder("Moves the sprint keybind to the movement category").addTargetedMod(TargetedMod.VANILLA)
                     .setSide(Side.CLIENT).setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinGameSettings_SprintKey")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinLanguageRegistry.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinLanguageRegistry.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.ModContainer;
+import cpw.mods.fml.common.registry.LanguageRegistry;
+import cpw.mods.fml.relauncher.Side;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+
+@Mixin(value = LanguageRegistry.class, remap = false)
+public class MixinLanguageRegistry {
+
+    private Set<String> examinedFiles = new ObjectOpenHashSet<>();
+
+    @Inject(method = "loadLanguagesFor", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$onlyAddLanguagesOnce(ModContainer container, Side side, CallbackInfo ci) {
+        if (!examinedFiles.add(container.getSource().getName())) {
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
Currently it looks at each loaded mod and then examines the containing file - which means for any container that has multiple mods the same jar will be examined multiple times.

Gregtech, for example:
```
$ grep "Found translations in gregtech" fml-client-latest.log | wc -l
15
```