### PR TITLE
Fix the healing axe not healing entities when attacking them

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -462,6 +462,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesEnderQuarryFreeze;
 
+    @Config.Comment("Fixes the healing axe not healing mobs when attacking them")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesHealingAxeHeal;
+
     // Galacticraft
 
     @Config.Comment("Fix time commands with GC")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -853,6 +853,9 @@ public enum Mixins {
             .addMixinClasses("extrautilities.MixinTileEntityEnderQuarry_FixFreeze").setPhase(Phase.LATE)
             .setSide(Side.BOTH).setApplyIf(() -> FixesConfig.fixExtraUtilitiesEnderQuarryFreeze)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_HEALING_AXE_HEAL(new Builder("Fix the healing axe not healing entities when attacking them")
+            .addMixinClasses("extrautilities.MixinItemHealingAxe").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.fixExtraUtilitiesHealingAxeHeal).addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Gliby's Voice Chat
     FIX_GLIBYS_VC_THREAD_SHUTDOWN_CLIENT(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinItemHealingAxe.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinItemHealingAxe.java
@@ -27,14 +27,6 @@ abstract public class MixinItemHealingAxe {
         return 0F;
     }
 
-    // Cancel the hunger reduction
-    @Redirect(
-            method = "onLeftClickEntity",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;addExhaustion(F)V"))
-    private void hodgepodge$redirectAddExhaustion(EntityPlayer player, float p_71020_1_) {
-
-    }
-
     // Always deal the damage at the end of the method to avoid case where the player dies before
     // dealing damage to undead mobs
     @Inject(method = "onLeftClickEntity", at = @At("RETURN"), remap = false)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinItemHealingAxe.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinItemHealingAxe.java
@@ -1,0 +1,50 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.rwtema.extrautils.item.ItemHealingAxe;
+
+@Mixin(ItemHealingAxe.class)
+abstract public class MixinItemHealingAxe {
+
+    // The original method uses `getHealth() < getHealth()` which is the cause of the bug,
+    // Replace the second getHealth call in the if statement with 0. (0 < getHealth())
+    @Redirect(
+            method = "onLeftClickEntity",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLiving;getHealth()F", ordinal = 1))
+    private float hodgepodge$redirectGetHealth(EntityLiving instance) {
+        return 0F;
+    }
+
+    // Cancel the hunger reduction
+    @Redirect(
+            method = "onLeftClickEntity",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;addExhaustion(F)V"))
+    private void hodgepodge$redirectAddExhaustion(EntityPlayer player, float p_71020_1_) {
+
+    }
+
+    // Always deal the damage at the end of the method to avoid case where the player dies before
+    // dealing damage to undead mobs
+    @Inject(method = "onLeftClickEntity", at = @At("RETURN"), remap = false)
+    private void hodgepodge$onLeftClickEntityEnd(ItemStack stack, EntityPlayer player, Entity entity,
+            CallbackInfoReturnable<Boolean> cir, @Local float k) {
+        if (player.getHealth() - (k - 0.5F) > 0F) {
+            player.setHealth(player.getHealth() - (k - 0.5F));
+        } else {
+            player.attackEntityFrom(DamageSource.causePlayerDamage(player), (k - 0.5F));
+        }
+    }
+
+}


### PR DESCRIPTION
Currently the healing axe doesn't actually heal mobs like its description says it should because of a bug/typo, the original code has `target.getHealth() < target.getHealth()` as a condition to heal
The description says "it will take some health from you and use it to heal the target, with a slight bonus", considering what pack this is i interpreted that as taking a quarter heart less than it heals

I'm a pretty new player and I don't have access to the dev discord channels so I'm not sure how exactly this will affect balance so I'll leave discussing that to the actual developers.