### PR TITLE
Add option to synchronize IC2 reactors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ tasks.jar {
 }
 minecraft {
     extraRunJvmArguments.add("-Dhodgepodge.logModTimes=true")
+    // extraRunJvmArguments.addAll("-Dlegacy.debugClassLoading=true", "-Dlegacy.debugClassLoadingFiner=true", "-Dlegacy.debugClassLoadingSave=true")
 }
 
 tasks.processResources {

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -254,6 +254,7 @@ public class TweaksConfig {
 
     @Config.Comment("Synchronize IC2 reactors to the world tick time, allowing for tick-perfect automation.")
     @Config.DefaultBoolean(false)
+    @Config.RequiresMcRestart
     public static boolean synchronizeIC2Reactors;
 
     // Minechem

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -252,6 +252,10 @@ public class TweaksConfig {
     @Config.DefaultInt(0)
     public static int extraUtilitiesEnderQuarryOverride;
 
+    @Config.Comment("Synchronize IC2 reactors to the world tick time, allowing for tick-perfect automation.")
+    @Config.DefaultBoolean(false)
+    public static boolean synchronizeIC2Reactors;
+
     // Minechem
 
     @Config.Comment("Minechem Atropine High (Delirium) effect ID")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -565,6 +565,9 @@ public enum Mixins {
     IC2_CROP_TRAMPLING_FIX(new Builder("IC2 Crop Trampling Fix").setPhase(Phase.LATE).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIC2TileEntityCrop").setApplyIf(() -> FixesConfig.fixIc2CropTrampling)
             .addTargetedMod(TargetedMod.IC2)),
+    IC2_SYNC_REACTORS(new Builder("Synchronize IC2 reactors for more consistent operation").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .addMixinClasses("ic2.sync.MixinTEReactorChamber", "ic2.sync.MixinTEReactor").setApplyIf(() -> TweaksConfig.synchronizeIC2Reactors)
+            .addTargetedMod(TargetedMod.IC2)),
 
     // Disable update checkers
     BIBLIOCRAFT_UPDATE_CHECK(new Builder("Yeet Bibliocraft Update Check").setPhase(Phase.LATE).setSide(Side.CLIENT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -565,9 +565,9 @@ public enum Mixins {
     IC2_CROP_TRAMPLING_FIX(new Builder("IC2 Crop Trampling Fix").setPhase(Phase.LATE).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIC2TileEntityCrop").setApplyIf(() -> FixesConfig.fixIc2CropTrampling)
             .addTargetedMod(TargetedMod.IC2)),
-    IC2_SYNC_REACTORS(new Builder("Synchronize IC2 reactors for more consistent operation").setPhase(Phase.LATE).setSide(Side.BOTH)
-            .addMixinClasses("ic2.sync.MixinTEReactorChamber", "ic2.sync.MixinTEReactor").setApplyIf(() -> TweaksConfig.synchronizeIC2Reactors)
-            .addTargetedMod(TargetedMod.IC2)),
+    IC2_SYNC_REACTORS(new Builder("Synchronize IC2 reactors for more consistent operation").setPhase(Phase.LATE)
+            .setSide(Side.BOTH).addMixinClasses("ic2.sync.MixinTEReactorChamber", "ic2.sync.MixinTEReactor")
+            .setApplyIf(() -> TweaksConfig.synchronizeIC2Reactors).addTargetedMod(TargetedMod.IC2)),
 
     // Disable update checkers
     BIBLIOCRAFT_UPDATE_CHECK(new Builder("Yeet Bibliocraft Update Check").setPhase(Phase.LATE).setSide(Side.CLIENT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactor.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactor.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2.sync;
+
+import static java.lang.Math.floorMod;
+
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = TileEntityNuclearReactorElectric.class, remap = false)
+public abstract class MixinTEReactor {
+    @Shadow public abstract World getWorld();
+
+    @Redirect(method = "updateEntityServer", at = @At(value = "FIELD", target = "Lic2/core/block/reactor/tileentity/TileEntityNuclearReactorElectric;updateTicker:I", ordinal = 0))
+    private int hodgepodge$sync(TileEntityNuclearReactorElectric instance) {
+        // Ensure the update ticker is locked to the world time, using a modulo to never be negative.
+        // Technically, the IC2 one would roll over every ~3.5 years, but that means it's possible that
+        // nobody ever tested what would happen if it did roll over.
+        return (int) floorMod(getWorld().getTotalWorldTime(), (long) Integer.MAX_VALUE);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactor.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactor.java
@@ -2,18 +2,27 @@ package com.mitchej123.hodgepodge.mixins.late.ic2.sync;
 
 import static java.lang.Math.floorMod;
 
-import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
 import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
+
 @Mixin(value = TileEntityNuclearReactorElectric.class, remap = false)
 public abstract class MixinTEReactor {
-    @Shadow public abstract World getWorld();
 
-    @Redirect(method = "updateEntityServer", at = @At(value = "FIELD", target = "Lic2/core/block/reactor/tileentity/TileEntityNuclearReactorElectric;updateTicker:I", ordinal = 0))
+    @Shadow
+    public abstract World getWorld();
+
+    @Redirect(
+            method = "updateEntityServer",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lic2/core/block/reactor/tileentity/TileEntityNuclearReactorElectric;updateTicker:I",
+                    ordinal = 0))
     private int hodgepodge$sync(TileEntityNuclearReactorElectric instance) {
         // Ensure the update ticker is locked to the world time, using a modulo to never be negative.
         // Technically, the IC2 one would roll over every ~3.5 years, but that means it's possible that

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactorChamber.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactorChamber.java
@@ -1,0 +1,17 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2.sync;
+
+import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = TileEntityReactorChamberElectric.class, remap = false)
+public abstract class MixinTEReactorChamber extends TileEntity {
+
+    @Redirect(method = "updateEntity", at = @At(value = "FIELD", target = "Lic2/core/block/reactor/tileentity/TileEntityReactorChamberElectric;ticker:S", ordinal = 0))
+    private short hodgepodge$synchronizeReactors(TileEntityReactorChamberElectric instance) {
+        // May cause one short cycle, but afterwards will always be synced to world time
+        return (short) (instance.getWorldObj().getTotalWorldTime() % 20);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactorChamber.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/sync/MixinTEReactorChamber.java
@@ -1,15 +1,22 @@
 package com.mitchej123.hodgepodge.mixins.late.ic2.sync;
 
-import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
 import net.minecraft.tileentity.TileEntity;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
+
 @Mixin(value = TileEntityReactorChamberElectric.class, remap = false)
 public abstract class MixinTEReactorChamber extends TileEntity {
 
-    @Redirect(method = "updateEntity", at = @At(value = "FIELD", target = "Lic2/core/block/reactor/tileentity/TileEntityReactorChamberElectric;ticker:S", ordinal = 0))
+    @Redirect(
+            method = "updateEntity",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lic2/core/block/reactor/tileentity/TileEntityReactorChamberElectric;ticker:S",
+                    ordinal = 0))
     private short hodgepodge$synchronizeReactors(TileEntityReactorChamberElectric instance) {
         // May cause one short cycle, but afterwards will always be synced to world time
         return (short) (instance.getWorldObj().getTotalWorldTime() % 20);


### PR DESCRIPTION
Normally they randomize their start/stop timers, preventing nuke setups from using precise timings. Any setup with more than one reactor needs to account for the reactors having up to a 2s variance in start or stop times, requiring downtime or wasting fuel. This tweak is off by default, unless there's consensus to have it in the pack.