### PR TITLE
Fix xp not loading when changing dimensions

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/HodgepodgeEventHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/HodgepodgeEventHandler.java
@@ -2,6 +2,7 @@ package com.mitchej123.hodgepodge;
 
 import java.util.Set;
 
+import com.mitchej123.hodgepodge.config.FixesConfig;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
@@ -65,6 +66,14 @@ public class HodgepodgeEventHandler {
         if (event.phase == TickEvent.Phase.END && TweaksConfig.avoidDroppingItemsWhenClosing
                 && !playersClosedContainers.isEmpty()) {
             playersClosedContainers.clear();
+        }
+    }
+
+    @SubscribeEvent
+    public void onDimensionChange(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (FixesConfig.fixDimensionChangeAttributes && event.player instanceof EntityPlayerMP player) {
+            // fixes xp when changing dimensions
+            player.addExperienceLevel(0);
         }
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -36,9 +36,9 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixDebugBoundingBox;
 
-    @Config.Comment("Fix losing bonus hearts on dimension change")
+    @Config.Comment("Fix losing attributes on dimension change")
     @Config.DefaultBoolean(true)
-    public static boolean fixDimensionChangeHearts;
+    public static boolean fixDimensionChangeAttributes;
 
     @Config.Comment("Fix duplicate sounds from playing when closing a gui.")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -189,7 +189,7 @@ public enum Mixins {
             .setApplyIf(() -> TweaksConfig.enableTileRendererProfiler).addTargetedMod(TargetedMod.VANILLA)),
     DIMENSION_CHANGE_FIX(new Builder("Dimension Change Heart Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("minecraft.MixinServerConfigurationManager", "minecraft.MixinEntityPlayerMP")
-            .setApplyIf(() -> FixesConfig.fixDimensionChangeHearts).addTargetedMod(TargetedMod.VANILLA)),
+            .setApplyIf(() -> FixesConfig.fixDimensionChangeAttributes).addTargetedMod(TargetedMod.VANILLA)),
     FIX_EATING_STACKED_STEW(new Builder("Stacked Mushroom Stew Eating Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("minecraft.MixinItemSoup").setApplyIf(() -> FixesConfig.fixEatingStackedStew)
             .addTargetedMod(TargetedMod.VANILLA)),


### PR DESCRIPTION
Looks likes this was all that was needed?

Tested with Twilight Forest on client and server

Before: xp reset to 0 until next xp update
After: xp stays the same
