### PR TITLE
Fix Glass Bottles filling with water from some other Fluid blocks

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -340,6 +340,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixEntityAttributesRange;
 
+    @Config.Comment("Fix Glass Bottles filling with Water from some other Fluid blocks")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixGlassBottleWaterFilling;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -519,6 +519,10 @@ public enum Mixins {
             .setSide(Side.BOTH).addMixinClasses("minecraft.MixinBlockStaticLiquid")
             .setApplyIf(() -> SpeedupsConfig.lavaChunkLoading).addTargetedMod(TargetedMod.VANILLA)),
 
+    FIX_GLASS_BOTTLE_NON_WATER_BLOCKS(new Builder("Fix Glass Bottles filling with Water from some other Fluid blocks")
+            .setPhase(Phase.EARLY).setSide(Side.BOTH).addMixinClasses("minecraft.MixinItemGlassBottle")
+            .setApplyIf(() -> FixesConfig.fixGlassBottleWaterFilling).addTargetedMod(TargetedMod.VANILLA)),
+
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new Builder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("ic2.MixinIc2WaterKinetic").setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemGlassBottle.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemGlassBottle.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemGlassBottle;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+@Mixin(ItemGlassBottle.class)
+public class MixinItemGlassBottle {
+
+    @ModifyExpressionValue(
+            method = "onItemRightClick",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlock(III)Lnet/minecraft/block/Block;"))
+    private Block hodgepodge$checkWaterBlock(Block original) {
+        // If the block is not a Water block, return something with a non-water material to fail the check
+        if (original == Blocks.water) return original;
+        return Blocks.cobblestone;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17552

Original code (caused any block with the `water` material to give water, of which many modded fluid blocks have this material):
![image](https://github.com/user-attachments/assets/1579040c-045e-4ad5-ace1-1647483a50d6)