### PR TITLE
Swap out ObjectIntIdentityMap with ProperObjectIntIdentityMap to avoid Box/Unbox of ints

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/asm/AsmTransformers.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/AsmTransformers.java
@@ -52,6 +52,14 @@ public enum AsmTransformers {
             ImmutableList.of(TargetedMod.FASTCRAFT, TargetedMod.BUKKIT),
             "com.mitchej123.hodgepodge.asm.transformers.mc.PlayerManagerTransformer"
     ),
+    SPEEDUP_OBJECT_INT_IDENTITY_MAP(
+            "Speed up ObjectIntIdentityMap",
+            () -> ASMConfig.speedupObjectIntIdentityMap,
+            Side.BOTH,
+            null,
+            ImmutableList.of(TargetedMod.FASTCRAFT, TargetedMod.BUKKIT),
+            "com.mitchej123.hodgepodge.asm.transformers.mc.SpeedupObjectIntIdentityMapTransformer"
+    ),
     FIX_BOGUS_INTEGRATED_SERVER_NPE(
             "Fix bogus FMLProxyPacket NPEs on integrated server crashes",
             () -> FixesConfig.fixBogusIntegratedServerNPEs,

--- a/src/main/java/com/mitchej123/hodgepodge/asm/transformers/mc/SpeedupObjectIntIdentityMapTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/transformers/mc/SpeedupObjectIntIdentityMapTransformer.java
@@ -1,0 +1,107 @@
+package com.mitchej123.hodgepodge.asm.transformers.mc;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+
+import com.gtnewhorizon.gtnhlib.asm.ClassConstantPoolParser;
+
+@SuppressWarnings("unused")
+public class SpeedupObjectIntIdentityMapTransformer implements IClassTransformer {
+
+    public static final String OBJECT_INT_IDENTITY_MAP = "net/minecraft/util/ObjectIntIdentityMap";
+    public static final String OBJECT_INT_IDENTITY_MAP_OBF = "ct";
+    public static final String PROPER_OBJECT_INT_IDENTITY_MAP = "com/mitchej123/hodgepodge/util/ProperObjectIntIdentityMap";
+
+    private static final ClassConstantPoolParser cstPoolParser = new ClassConstantPoolParser(
+            OBJECT_INT_IDENTITY_MAP,
+            OBJECT_INT_IDENTITY_MAP_OBF);
+
+    private static final Logger LOGGER = LogManager.getLogger("SpeedupObjectIntIdentityMapTransformer");
+    public static final String INIT = "<init>";
+    public static final String EMPTY_DESC = "()V";
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if (basicClass == null) return null;
+        if (!cstPoolParser.find(basicClass, true)) {
+            return basicClass;
+        }
+
+        final ClassReader cr = new ClassReader(basicClass);
+        final ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        final boolean changed = transformClassNode(transformedName, cn);
+        if (changed) {
+            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            cn.accept(cw);
+            return cw.toByteArray();
+        }
+        return basicClass;
+    }
+
+    /** @return Was the class changed? */
+    public boolean transformClassNode(String transformedName, ClassNode cn) {
+        if (cn == null) {
+            return false;
+        }
+        if (transformedName.startsWith("com.mitchej123.hodgepodge.util")) {
+            return false;
+        }
+
+        boolean changed = false;
+
+        boolean objectIntIdentityMapInit = false;
+        for (MethodNode mn : cn.methods) {
+            for (AbstractInsnNode node : mn.instructions.toArray()) {
+                if (node.getOpcode() == Opcodes.NEW && node instanceof TypeInsnNode tNode) {
+                    if (!objectIntIdentityMapInit && (tNode.desc.equals(OBJECT_INT_IDENTITY_MAP)
+                            || tNode.desc.equals(OBJECT_INT_IDENTITY_MAP_OBF))) {
+                        objectIntIdentityMapInit = true;
+                        LOGGER.info("Found ObjectIntIdentityMap instantiation in " + transformedName + "." + mn.name);
+                        mn.instructions
+                                .insertBefore(tNode, new TypeInsnNode(Opcodes.NEW, PROPER_OBJECT_INT_IDENTITY_MAP));
+                        mn.instructions.remove(tNode);
+                        changed = true;
+                    }
+                } else if (node.getOpcode() == Opcodes.INVOKESPECIAL && node instanceof MethodInsnNode mNode) {
+                    if (mNode.name.equals(INIT) && mNode.desc.equals(EMPTY_DESC)) {
+                        if (objectIntIdentityMapInit && (mNode.owner.equals(OBJECT_INT_IDENTITY_MAP)
+                                || mNode.owner.equals(OBJECT_INT_IDENTITY_MAP_OBF))) {
+                            objectIntIdentityMapInit = false;
+                            LOGGER.info(
+                                    "Found ObjectIntIdentityMap constructor call in " + transformedName
+                                            + "."
+                                            + mn.name);
+                            mn.instructions.insertBefore(
+                                    mNode,
+                                    new MethodInsnNode(
+                                            Opcodes.INVOKESPECIAL,
+                                            PROPER_OBJECT_INT_IDENTITY_MAP,
+                                            INIT,
+                                            EMPTY_DESC,
+                                            false));
+                            mn.instructions.remove(mNode);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (objectIntIdentityMapInit) {
+            throw new IllegalStateException(
+                    "Failed to transform " + transformedName + " due to missing constructor call");
+        }
+
+        return changed;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/config/ASMConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/ASMConfig.java
@@ -29,4 +29,8 @@ public class ASMConfig {
     @Config.Comment("Speedup PlayerManager")
     @Config.DefaultBoolean(true)
     public static boolean speedupPlayerManager;
+
+    @Config.Comment("Speedup ObjectIntIdentityMap")
+    @Config.DefaultBoolean(true)
+    public static boolean speedupObjectIntIdentityMap;
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/FastUtilsObjectIntIdentityHashMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FastUtilsObjectIntIdentityHashMap.java
@@ -1,0 +1,104 @@
+package com.mitchej123.hodgepodge.util;
+
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
+
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+
+public class FastUtilsObjectIntIdentityHashMap<K> extends IdentityHashMap<K, Integer> {
+
+    private final Reference2IntMap<K> forwardMap;
+
+    public FastUtilsObjectIntIdentityHashMap() {
+        this(32);
+    }
+
+    public FastUtilsObjectIntIdentityHashMap(int expectedMaxSize) {
+        super(0); // Don't allocate in parent
+        this.forwardMap = new Reference2IntOpenHashMap<>(expectedMaxSize);
+        this.forwardMap.defaultReturnValue(-1);
+    }
+
+    @Override
+    public Integer put(K key, Integer value) {
+        return forwardMap.put(key, value);
+    }
+
+    public int put(K key, int value) {
+        return forwardMap.put(key, value);
+    }
+
+    @Override
+    public Integer get(Object key) {
+        int value = forwardMap.getInt(key);
+        return value == -1 ? null : value;
+    }
+
+    public int getInt(Objects key) {
+        return forwardMap.getInt(key);
+    }
+
+    @Override
+    public Integer getOrDefault(Object key, Integer defaultValue) {
+        return containsKey(key) ? forwardMap.getInt(key) : defaultValue;
+    }
+
+    public int getIntOrDefault(Object key, int defaultValue) {
+        return containsKey(key) ? forwardMap.getInt(key) : defaultValue;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return forwardMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        if (value instanceof Integer intValue) {
+            return forwardMap.containsValue(intValue.intValue());
+        }
+        return false;
+    }
+
+    @Override
+    public Integer remove(Object key) {
+        return forwardMap.removeInt(key);
+    }
+
+    @Override
+    public void clear() {
+        forwardMap.clear();
+    }
+
+    @Override
+    public int size() {
+        return forwardMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return forwardMap.isEmpty();
+    }
+
+    @Override
+    public @NotNull Set<K> keySet() {
+        return forwardMap.keySet();
+    }
+
+    @Override
+    public @NotNull Collection<Integer> values() {
+        return forwardMap.values();
+    }
+
+    @Override
+    public @NotNull Set<Map.Entry<K, Integer>> entrySet() {
+        return forwardMap.entrySet();
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/ProperObjectIntIdentityMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ProperObjectIntIdentityMap.java
@@ -1,0 +1,68 @@
+package com.mitchej123.hodgepodge.util;
+
+import net.minecraft.util.ObjectIntIdentityMap;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+// Used via ASM
+@SuppressWarnings("unused")
+public class ProperObjectIntIdentityMap extends ObjectIntIdentityMap {
+    // Avoid boxing/unboxing ints!
+
+    protected final FastUtilsObjectIntIdentityHashMap<Object> objectMap;
+    protected final ObjectArrayList<Object> objectList;
+
+    public ProperObjectIntIdentityMap() {
+        super();
+        objectMap = new FastUtilsObjectIntIdentityHashMap<>(512);
+        objectList = new ObjectArrayList<>(512);
+        super.field_148749_a = objectMap;
+        super.field_148748_b = objectList;
+    }
+
+    @Override
+    public void func_148746_a(Object key, int val) {
+        put(key, val);
+    }
+
+    @Override
+    public int func_148747_b(Object key) {
+        return get(key);
+    }
+
+    @Override
+    public Object func_148745_a(int val) {
+        return getByValue(val);
+    }
+
+    @Override
+    public boolean func_148744_b(int val) {
+        return contains(val);
+    }
+
+    public void put(Object key, int value) {
+        objectMap.put(key, value);
+        objectList.ensureCapacity(value + 1);
+        while (objectList.size() <= value) {
+            objectList.add(null);
+        }
+        objectList.set(value, key);
+    }
+
+    private void ensureSize(int value) {
+
+    }
+
+    public int get(Object key) {
+        return objectMap.getIntOrDefault(key, -1);
+    }
+
+    public Object getByValue(int value) {
+        return value >= 0 && value < this.objectList.size() ? this.objectList.get(value) : null;
+    }
+
+    public boolean contains(int value) {
+        return getByValue(value) != null;
+    }
+
+}


### PR DESCRIPTION
Also add a FastUtilsObjectIntIdentityHashMap subclass of IdentityHashMap<Object, Integer> because that was used for the variable instead of Map<>

This showed up on one of my profiles of Angelica & DH as larger than it should be IMHO, this should be no worse than the default impl and likely better