### PR TITLE
Better hashcode for ChunkCoordIntPair

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.6.19:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.6.21:dev")
 
     compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.2") { transitive = false }
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -30,7 +30,7 @@ public enum Mixins {
             new Builder("Stops MC from allocating too many ChunkPositionIntPair objects")
                     .addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH).setPhase(Phase.EARLY)
                     .addMixinClasses(
-                            "minecraft.MixinChunkCoordIntPair",
+                            "minecraft.MixinChunkCoordIntPair_FixAllocations",
                             "minecraft.MixinWorld_FixAllocations",
                             "minecraft.MixinWorldClient_FixAllocations",
                             "minecraft.MixinAnvilChunkLoader_FixAllocations")
@@ -146,9 +146,11 @@ public enum Mixins {
             .addMixinClasses("minecraft.MixinChunkProviderClient_RemoveChunkListing")
             .addTargetedMod(TargetedMod.VANILLA).addExcludedMod(TargetedMod.FASTCRAFT)
             .setApplyIf(() -> SpeedupsConfig.speedupChunkProviderClient && ASMConfig.speedupLongIntHashMap)),
-    CHUNK_COORDINATES_HASHCODE(new Builder("Optimize Chunk Coordinates Hashcode").setPhase(Phase.EARLY)
-            .setSide(Side.BOTH).addMixinClasses("minecraft.MixinChunkCoordinates").addTargetedMod(TargetedMod.VANILLA)
-            .setApplyIf(() -> SpeedupsConfig.speedupChunkCoordinatesHashCode)),
+    BETTER_HASHCODES(new Builder("Optimize various Hashcode").setPhase(Phase.EARLY).setSide(Side.BOTH)
+            .addMixinClasses(
+                    "minecraft.MixinChunkCoordinates_BetterHash",
+                    "minecraft.MixinChunkCoordIntPair_BetterHash")
+            .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> SpeedupsConfig.speedupChunkCoordinatesHashCode)),
     TCP_NODELAY(new Builder("Set TCP NODELAY").setPhase(Phase.EARLY).setSide(Side.BOTH)
             .addMixinClasses("minecraft.MixinTcpNoDelay").setApplyIf(() -> SpeedupsConfig.tcpNoDelay)
             .addTargetedMod(TargetedMod.VANILLA)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkCoordIntPair_BetterHash.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkCoordIntPair_BetterHash.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.world.ChunkCoordIntPair;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import com.gtnewhorizon.gtnhlib.hash.Fnv1a32;
+
+@Mixin(ChunkCoordIntPair.class)
+public class MixinChunkCoordIntPair_BetterHash {
+
+    @Final
+    @Shadow
+    public int chunkXPos;
+    /** The Z position of this Chunk Coordinate Pair */
+    @Final
+    @Shadow
+    public int chunkZPos;
+
+    /**
+     * @author mitchej123
+     * @reason Swap out the default hashCode function with a better one
+     */
+    @Overwrite
+    public int hashCode() {
+        int hash = Fnv1a32.initialState();
+        hash = Fnv1a32.hashStep(hash, chunkXPos);
+        hash = Fnv1a32.hashStep(hash, chunkZPos);
+        return hash;
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkCoordIntPair_FixAllocations.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkCoordIntPair_FixAllocations.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import com.mitchej123.hodgepodge.mixins.interfaces.MutableChunkCoordIntPair;
 
 @Mixin(ChunkCoordIntPair.class)
-public class MixinChunkCoordIntPair implements MutableChunkCoordIntPair {
+public class MixinChunkCoordIntPair_FixAllocations implements MutableChunkCoordIntPair {
 
     @Mutable
     @Shadow

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkCoordinates_BetterHash.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkCoordinates_BetterHash.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(ChunkCoordinates.class)
-public class MixinChunkCoordinates {
+public class MixinChunkCoordinates_BetterHash {
 
     @Shadow
     public int posX;


### PR DESCRIPTION
Was causing trouble (collisions) with the large number of chunks being loaded for Distant Horizons