### PR TITLE
ArchaicFix and Angelica (removal) compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ tasks.jar {
 }
 minecraft {
     extraRunJvmArguments.add("-Dhodgepodge.logModTimes=true")
-    // extraRunJvmArguments.addAll("-Dlegacy.debugClassLoading=true", "-Dlegacy.debugClassLoadingFiner=true", "-Dlegacy.debugClassLoadingSave=true")
+    //extraRunJvmArguments.addAll("-Drfb.dumpLoadedClasses=true", "-Drfb.dumpLoadedClassesPerTransformer=true")
 }
 
 tasks.processResources {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -65,8 +65,8 @@ dependencies {
     devOnlyNonPublishable(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
 
     // For testing - HP and AF are liable to mixin the same targets
-    //runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.5")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:HPC99:dev") // mavenLocal location
+    runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.6")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:HPC99:dev") // mavenLocal location
 }
 
 // Replace when RFG support deobfuscation from notch mappings

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -65,7 +65,7 @@ dependencies {
     devOnlyNonPublishable(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
 
     // For testing - HP and AF are liable to mixin the same targets
-    runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.6")
+    runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.6:dev")
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:HPC99:dev") // mavenLocal location
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,6 +63,10 @@ dependencies {
     transformedModCompileOnly(rfg.deobf("curse.maven:candycraft-251118:2330488"))
 
     devOnlyNonPublishable(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
+
+    // For testing - HP and AF are liable to mixin the same targets
+    //runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.5")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:HPC99:dev") // mavenLocal location
 }
 
 // Replace when RFG support deobfuscation from notch mappings

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1,7 +1,6 @@
 package com.mitchej123.hodgepodge.mixins;
 
 import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.ARCHAICFIX;
-
 import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.OPTIFINE;
 import static com.mitchej123.hodgepodge.mixins.TargetedMod.ANGELICA;
 
@@ -96,8 +95,8 @@ public enum Mixins implements IMixins {
             .setSide(Side.BOTH)),
     OPTIMIZE_WORLD_UPDATE_LIGHT(new MixinBuilder("Optimize world updateLightByType method").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinWorld_FixLightUpdateLag").setSide(Side.BOTH)
-            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(ANGELICA)
-            .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> FixesConfig.optimizeWorldUpdateLight)),
+            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(ANGELICA).addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> FixesConfig.optimizeWorldUpdateLight)),
     FIX_FRIENDLY_CREATURE_SOUNDS(new MixinBuilder("Fix Friendly Creature Sounds").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinSoundHandler").setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> FixesConfig.fixFriendlyCreatureSounds)),
@@ -110,8 +109,8 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.throttleItemPickupEvent).addTargetedMod(TargetedMod.VANILLA)),
     FIX_PERSPECTIVE_CAMERA(new MixinBuilder("Camera Perspective Fix").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityRenderer").setSide(Side.CLIENT)
-            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(ANGELICA)
-            .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> FixesConfig.fixPerspectiveCamera)),
+            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(ANGELICA).addTargetedMod(TargetedMod.VANILLA)
+            .setApplyIf(() -> FixesConfig.fixPerspectiveCamera)),
     FIX_DEBUG_BOUNDING_BOX(new MixinBuilder("Fix Bounding Box").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinRenderManager").setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
             .setApplyIf(() -> FixesConfig.fixDebugBoundingBox)),
@@ -262,7 +261,8 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixResizableFullscreen).addTargetedMod(TargetedMod.VANILLA)),
     FIX_UNFOCUSED_FULLSCREEN(new MixinBuilder("Fix Unfocused Fullscreen").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinMinecraft_UnfocusedFullscreen").setSide(Side.CLIENT)
-            .setApplyIf(() -> FixesConfig.fixUnfocusedFullscreen).addTargetedMod(TargetedMod.VANILLA).addExcludedMod(ARCHAICFIX)),
+            .setApplyIf(() -> FixesConfig.fixUnfocusedFullscreen).addTargetedMod(TargetedMod.VANILLA)
+            .addExcludedMod(ARCHAICFIX)),
     FIX_RENDERERS_WORLD_LEAK(new MixinBuilder("Fix Renderers World Leak").setPhase(Phase.EARLY)
             .addMixinClasses(
                     "minecraft.MixinMinecraft_ClearRenderersWorldLeak",
@@ -278,8 +278,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> TweaksConfig.addToggleDebugMessage).addTargetedMod(TargetedMod.VANILLA)),
     OPTIMIZE_TEXTURE_LOADING(new MixinBuilder("Optimize Texture Loading").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.textures.client.MixinTextureUtil").addTargetedMod(TargetedMod.VANILLA)
-            .addExcludedMod(ANGELICA).setApplyIf(() -> SpeedupsConfig.optimizeTextureLoading)
-            .setSide(Side.CLIENT)),
+            .addExcludedMod(ANGELICA).setApplyIf(() -> SpeedupsConfig.optimizeTextureLoading).setSide(Side.CLIENT)),
     HIDE_POTION_PARTICLES(new MixinBuilder("Hide Potion Particles").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityLivingBase_HidePotionParticles").setSide(Side.CLIENT)
             .setApplyIf(() -> TweaksConfig.hidePotionParticlesFromSelf).addTargetedMod(TargetedMod.VANILLA)),
@@ -546,7 +545,11 @@ public enum Mixins implements IMixins {
                     .setSide(Side.BOTH).addMixinClasses("minecraft.MixinItemGlassBottle")
                     .setApplyIf(() -> FixesConfig.fixGlassBottleWaterFilling).addTargetedMod(TargetedMod.VANILLA)),
 
-    FIX_IOOBE_RENDER_DISTANCE(new MixinBuilder("Fix out of bounds render distance when Optifine/Angelica is uninstalled").setPhase(Phase.EARLY).setSide(Side.CLIENT).addExcludedMod(OPTIFINE).addExcludedMod(ANGELICA).addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> true).addMixinClasses("minecraft.MixinGameSettings_ReduceRenderDistance")),
+    FIX_IOOBE_RENDER_DISTANCE(
+            new MixinBuilder("Fix out of bounds render distance when Optifine/Angelica is uninstalled")
+                    .setPhase(Phase.EARLY).setSide(Side.CLIENT).addExcludedMod(OPTIFINE).addExcludedMod(ANGELICA)
+                    .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> true)
+                    .addMixinClasses("minecraft.MixinGameSettings_ReduceRenderDistance")),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.mixins;
 import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.ARCHAICFIX;
 import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.OPTIFINE;
 import static com.mitchej123.hodgepodge.mixins.TargetedMod.ANGELICA;
+import static com.mitchej123.hodgepodge.mixins.TargetedMod.FALSETWEAKS;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -548,7 +549,7 @@ public enum Mixins implements IMixins {
     FIX_IOOBE_RENDER_DISTANCE(
             new MixinBuilder("Fix out of bounds render distance when Optifine/Angelica is uninstalled")
                     .setPhase(Phase.EARLY).setSide(Side.CLIENT).addExcludedMod(OPTIFINE).addExcludedMod(ANGELICA)
-                    .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> true)
+                    .addExcludedMod(FALSETWEAKS).addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> true)
                     .addMixinClasses("minecraft.MixinGameSettings_ReduceRenderDistance")),
 
     // Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1,5 +1,7 @@
 package com.mitchej123.hodgepodge.mixins;
 
+import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.ARCHAICFIX;
+
 import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.OPTIFINE;
 import static com.mitchej123.hodgepodge.mixins.TargetedMod.ANGELICA;
 
@@ -260,7 +262,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixResizableFullscreen).addTargetedMod(TargetedMod.VANILLA)),
     FIX_UNFOCUSED_FULLSCREEN(new MixinBuilder("Fix Unfocused Fullscreen").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinMinecraft_UnfocusedFullscreen").setSide(Side.CLIENT)
-            .setApplyIf(() -> FixesConfig.fixUnfocusedFullscreen).addTargetedMod(TargetedMod.VANILLA)),
+            .setApplyIf(() -> FixesConfig.fixUnfocusedFullscreen).addTargetedMod(TargetedMod.VANILLA).addExcludedMod(ARCHAICFIX)),
     FIX_RENDERERS_WORLD_LEAK(new MixinBuilder("Fix Renderers World Leak").setPhase(Phase.EARLY)
             .addMixinClasses(
                     "minecraft.MixinMinecraft_ClearRenderersWorldLeak",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1,5 +1,8 @@
 package com.mitchej123.hodgepodge.mixins;
 
+import static com.gtnewhorizon.gtnhlib.mixin.TargetedMod.OPTIFINE;
+import static com.mitchej123.hodgepodge.mixins.TargetedMod.ANGELICA;
+
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -91,7 +94,7 @@ public enum Mixins implements IMixins {
             .setSide(Side.BOTH)),
     OPTIMIZE_WORLD_UPDATE_LIGHT(new MixinBuilder("Optimize world updateLightByType method").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinWorld_FixLightUpdateLag").setSide(Side.BOTH)
-            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(TargetedMod.ANGELICA)
+            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(ANGELICA)
             .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> FixesConfig.optimizeWorldUpdateLight)),
     FIX_FRIENDLY_CREATURE_SOUNDS(new MixinBuilder("Fix Friendly Creature Sounds").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinSoundHandler").setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
@@ -105,7 +108,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.throttleItemPickupEvent).addTargetedMod(TargetedMod.VANILLA)),
     FIX_PERSPECTIVE_CAMERA(new MixinBuilder("Camera Perspective Fix").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityRenderer").setSide(Side.CLIENT)
-            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(TargetedMod.ANGELICA)
+            .addExcludedMod(TargetedMod.ARCHAICFIX).addExcludedMod(ANGELICA)
             .addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> FixesConfig.fixPerspectiveCamera)),
     FIX_DEBUG_BOUNDING_BOX(new MixinBuilder("Fix Bounding Box").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinRenderManager").setSide(Side.CLIENT).addTargetedMod(TargetedMod.VANILLA)
@@ -273,7 +276,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> TweaksConfig.addToggleDebugMessage).addTargetedMod(TargetedMod.VANILLA)),
     OPTIMIZE_TEXTURE_LOADING(new MixinBuilder("Optimize Texture Loading").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.textures.client.MixinTextureUtil").addTargetedMod(TargetedMod.VANILLA)
-            .addExcludedMod(TargetedMod.ANGELICA).setApplyIf(() -> SpeedupsConfig.optimizeTextureLoading)
+            .addExcludedMod(ANGELICA).setApplyIf(() -> SpeedupsConfig.optimizeTextureLoading)
             .setSide(Side.CLIENT)),
     HIDE_POTION_PARTICLES(new MixinBuilder("Hide Potion Particles").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinEntityLivingBase_HidePotionParticles").setSide(Side.CLIENT)
@@ -540,6 +543,8 @@ public enum Mixins implements IMixins {
             new MixinBuilder("Fix Glass Bottles filling with Water from some other Fluid blocks").setPhase(Phase.EARLY)
                     .setSide(Side.BOTH).addMixinClasses("minecraft.MixinItemGlassBottle")
                     .setApplyIf(() -> FixesConfig.fixGlassBottleWaterFilling).addTargetedMod(TargetedMod.VANILLA)),
+
+    FIX_IOOBE_RENDER_DISTANCE(new MixinBuilder("Fix out of bounds render distance when Optifine/Angelica is uninstalled").setPhase(Phase.EARLY).setSide(Side.CLIENT).addExcludedMod(OPTIFINE).addExcludedMod(ANGELICA).addTargetedMod(TargetedMod.VANILLA).setApplyIf(() -> true).addMixinClasses("minecraft.MixinGameSettings_ReduceRenderDistance")),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix").setPhase(Phase.EARLY).setSide(Side.BOTH)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -24,6 +24,7 @@ public enum TargetedMod implements ITargetedMod {
     EXTRATIC("ExtraTiC", null, "ExtraTiC"),
     EXTRA_UTILITIES("ExtraUtilities", null, "ExtraUtilities"),
     FASTCRAFT("FastCraft", "fastcraft.Tweaker"),
+    FALSETWEAKS("FalseTweaks", "com.falsepattern.falsetweaks.asm.CoreLoadingPlugin", "falsetweaks"),
     GALACTICRAFT_CORE("GalacticraftCore", "micdoodle8.mods.galacticraft.core.asm.GCLoadingPlugin", "GalacticraftCore"),
     GLIBYS_VOICE_CHAT("Gliby's Voice Chat Mod", null, "gvc"),
     GT5U("GregTech5u", null, "gregtech"), // Also matches GT6.

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSettings_ReduceRenderDistance.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSettings_ReduceRenderDistance.java
@@ -1,0 +1,17 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import static java.lang.Math.min;
+
+import net.minecraft.client.settings.GameSettings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(GameSettings.class)
+public class MixinGameSettings_ReduceRenderDistance {
+
+    @Redirect(method = "loadOptions", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;renderDistanceChunks:I"))
+    public void hodgepodge$fixOptifineChunkLoadingCrash(GameSettings instance, int value) {
+        instance.renderDistanceChunks = min(16, value);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSettings_ReduceRenderDistance.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGameSettings_ReduceRenderDistance.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 import static java.lang.Math.min;
 
 import net.minecraft.client.settings.GameSettings;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -10,7 +11,9 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(GameSettings.class)
 public class MixinGameSettings_ReduceRenderDistance {
 
-    @Redirect(method = "loadOptions", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;renderDistanceChunks:I"))
+    @Redirect(
+            method = "loadOptions",
+            at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;renderDistanceChunks:I"))
     public void hodgepodge$fixOptifineChunkLoadingCrash(GameSettings instance, int value) {
         instance.renderDistanceChunks = min(16, value);
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
@@ -1,15 +1,12 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import java.util.Collection;
 import java.util.List;
-
 import net.minecraft.world.World;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 @Mixin(World.class)
 public class MixinWorldUpdateEntities {
@@ -19,6 +16,6 @@ public class MixinWorldUpdateEntities {
             at = @At(value = "INVOKE", target = "Ljava/util/List;removeAll(Ljava/util/Collection;)Z"))
     public <E> boolean fasterRemoveAll(List<E> targetList, Collection<E> collectionToRemove) {
         // Borrowed from Forge for 1.12.2 -- forge: faster "contains" makes this removal much more efficient
-        return targetList.removeAll(new ObjectOpenHashSet<>(collectionToRemove));
+        return targetList.removeAll(new ReferenceOpenHashSet<>(collectionToRemove));
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
@@ -1,12 +1,15 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.Collection;
 import java.util.List;
+
 import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 @Mixin(World.class)
 public class MixinWorldUpdateEntities {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
@@ -1,12 +1,15 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import java.util.Collection;
 import java.util.List;
+
 import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
+
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 
 @Mixin(World.class)
 public class MixinWorldUpdateEntities {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldUpdateEntities.java
@@ -1,13 +1,9 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Set;
-
 import net.minecraft.world.World;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -20,8 +16,6 @@ public class MixinWorldUpdateEntities {
             at = @At(value = "INVOKE", target = "Ljava/util/List;removeAll(Ljava/util/Collection;)Z"))
     public <E> boolean fasterRemoveAll(List<E> targetList, Collection<E> collectionToRemove) {
         // Borrowed from Forge for 1.12.2 -- forge: faster "contains" makes this removal much more efficient
-        final Set<E> setToRemove = Collections.newSetFromMap(new IdentityHashMap<>());
-        setToRemove.addAll(collectionToRemove);
-        return targetList.removeAll(setToRemove);
+        return targetList.removeAll(new ObjectOpenHashSet<>(collectionToRemove));
     }
 }


### PR DESCRIPTION
Disables a conflicting (and identical) mixin when ArchaicFix is installed, and clamps render distance when Angelica or Optifine is missing. Vanilla by itself doesn't check if render distance is in range, so if you install Angelica, crank the render distance above 16, and uninstall Angelica, you'll get runtime crashes until you turn the render distance back down.

Requires https://github.com/embeddedt/ArchaicFix/pull/142