### PR TITLE
Remove recursive slotClick calls when shift clicking a slot

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -32,6 +32,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixContainerPutStacksInSlots;
 
+    @Config.Comment("Backports 1.12's slot shift clicking to prevent recursion when crafting items")
+    @Config.DefaultBoolean(true)
+    public static boolean fixContainerShiftClickRecursion;
+
     @Config.Comment("Fixes the debug hitbox of the player beeing offset")
     @Config.DefaultBoolean(true)
     public static boolean fixDebugBoundingBox;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -65,6 +65,10 @@ public enum Mixins implements IMixins {
             new MixinBuilder("Prevents crash if server sends container with wrong itemStack size").setPhase(Phase.EARLY)
                     .addMixinClasses("minecraft.MixinContainer").setSide(Side.CLIENT)
                     .setApplyIf(() -> FixesConfig.fixContainerPutStacksInSlots).addTargetedMod(TargetedMod.VANILLA)),
+    FIX_CONTAINER_SHIFT_CLICK_RECURSION(
+            new MixinBuilder("Backports 1.12 logic for shift clicking slots to prevent recursion").setPhase(Phase.EARLY)
+                    .addMixinClasses("minecraft.MixinContainer_FixShiftRecursion").setSide(Side.BOTH)
+                    .setApplyIf(() -> FixesConfig.fixContainerShiftClickRecursion).addTargetedMod(TargetedMod.VANILLA)),
     FIX_NETHANDLERPLAYCLIENT_HANDLE_SET_SLOT(
             new MixinBuilder("Prevents crash if server sends itemStack with index larger than client's container")
                     .setPhase(Phase.EARLY).addMixinClasses("minecraft.MixinNetHandlerPlayClient_FixHandleSetSlot")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
@@ -18,6 +18,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 public abstract class MixinContainer_FixShiftRecursion {
 
     @Shadow
+    /* dragEvent */
     private int field_94536_g;
 
     @Shadow
@@ -30,21 +31,21 @@ public abstract class MixinContainer_FixShiftRecursion {
     public ItemStack hodgepodge$slotClickWrap(int slotId, int clickedButton, int mode, EntityPlayer player,
             Operation<ItemStack> original) {
         if (field_94536_g == 0 && mode == 1 && (clickedButton == 0 || clickedButton == 1)) {
-            ItemStack itemstack = null;
             if (slotId < 0) {
                 return null;
             }
 
-            Slot slot5 = this.inventorySlots.get(slotId);
+            Slot targetSlot = this.inventorySlots.get(slotId);
 
-            if (slot5 == null || !slot5.canTakeStack(player)) {
+            if (targetSlot == null || !targetSlot.canTakeStack(player)) {
                 return null;
             }
 
-            for (ItemStack itemstack7 = this.transferStackInSlot(player, slotId); itemstack7 != null
-                    && hodgepodge$areItemsEqual(slot5.getStack(), itemstack7); itemstack7 = this
+            ItemStack itemstack = null;
+            for (ItemStack tempStack = this.transferStackInSlot(player, slotId); tempStack != null
+                    && hodgepodge$areItemsEqual(targetSlot.getStack(), tempStack); tempStack = this
                             .transferStackInSlot(player, slotId)) {
-                itemstack = itemstack7.copy();
+                itemstack = tempStack.copy();
             }
 
             return itemstack;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
@@ -1,0 +1,65 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+@Mixin(Container.class)
+public abstract class MixinContainer_FixShiftRecursion {
+
+    @Shadow
+    private int field_94536_g;
+
+    @Shadow
+    public List<Slot> inventorySlots;
+
+    @Shadow
+    public abstract ItemStack transferStackInSlot(EntityPlayer player, int index);
+
+    @WrapMethod(method = "slotClick")
+    public ItemStack hodgepodge$slotClickWrap(int slotId, int clickedButton, int mode, EntityPlayer player,
+            Operation<ItemStack> original) {
+        if (field_94536_g == 0 && mode == 1 && (clickedButton == 0 || clickedButton == 1)) {
+            ItemStack itemstack = null;
+            if (slotId < 0) {
+                return null;
+            }
+
+            Slot slot5 = this.inventorySlots.get(slotId);
+
+            if (slot5 == null || !slot5.canTakeStack(player)) {
+                return null;
+            }
+
+            for (ItemStack itemstack7 = this.transferStackInSlot(player, slotId); itemstack7 != null
+                    && hodgepodge$areItemsEqual(slot5.getStack(), itemstack7); itemstack7 = this
+                            .transferStackInSlot(player, slotId)) {
+                itemstack = itemstack7.copy();
+            }
+
+            return itemstack;
+        }
+
+        return original.call(slotId, clickedButton, mode, player);
+    }
+
+    @Unique
+    private static boolean hodgepodge$areItemsEqual(ItemStack stackA, ItemStack stackB) {
+        if (stackA == stackB) {
+            return true;
+        } else {
+            return stackA != null && stackB != null && stackA.isItemEqual(stackB);
+        }
+    }
+
+}


### PR DESCRIPTION
Backports the 1.12 version instead of recursively calling slotClick
I believe this also fixes the issue where if you shift click a crafting slot and the output changes (from running out of an input) and the craft would continue when it should have stopped.


Test craft: Unstable Ingot  
Latest GTNH Nightly  
Before:
![image](https://github.com/user-attachments/assets/17ee8d73-bd36-45b6-b1ca-2ec2096d4f94)

After:  
![image](https://github.com/user-attachments/assets/53d8f695-0bd0-432e-9780-eb17ec7ef388)
