### PR TITLE
Namespace injected method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,10 @@ tasks.jar {
 }
 minecraft {
     extraRunJvmArguments.add("-Dhodgepodge.logModTimes=true")
+    /*extraRunJvmArguments.addAll(
+        "-Dlegacy.debugClassLoading=true",
+        "-Dlegacy.debugClassLoadingFiner=true",
+        "-Dlegacy.debugClassLoadingSave=true")*/
     // extraRunJvmArguments.addAll("-Drfb.dumpLoadedClasses=true", "-Drfb.dumpLoadedClassesPerTransformer=true")
 }
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/flatid/MixinBlock.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/flatid/MixinBlock.java
@@ -16,15 +16,13 @@ public class MixinBlock implements BlockExt_ID {
     @Unique
     private int hodgepodge$id = -1;
 
-    @SuppressWarnings("AddedMixinMembersNamePattern")
     @Override
-    public int getID() {
+    public int hodgepodge$getID() {
         return hodgepodge$id;
     }
 
-    @SuppressWarnings("AddedMixinMembersNamePattern")
     @Override
-    public void setID(int id) {
+    public void hodgepodge$setID(int id) {
         hodgepodge$id = id;
     }
 
@@ -35,6 +33,6 @@ public class MixinBlock implements BlockExt_ID {
                     target = "Lnet/minecraft/util/RegistryNamespaced;getIDForObject(Ljava/lang/Object;)I"))
     private static int hodgepodge$getID(RegistryNamespaced instance, Object object) {
         if (!(object instanceof BlockExt_ID block)) return -1;
-        return block.getID();
+        return block.hodgepodge$getID();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/flatid/MixinFMLControlledNamespacedRegistry.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/flatid/MixinFMLControlledNamespacedRegistry.java
@@ -16,6 +16,6 @@ public class MixinFMLControlledNamespacedRegistry {
     private <I> void hodgepodge$captureID(int id, String name, I thing, CallbackInfo ci) {
         if (!(thing instanceof BlockExt_ID block)) return;
 
-        block.setID(id);
+        block.hodgepodge$setID(id);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/BlockExt_ID.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/BlockExt_ID.java
@@ -2,7 +2,7 @@ package com.mitchej123.hodgepodge.mixins.interfaces;
 
 public interface BlockExt_ID {
 
-    int getID();
+    int hodgepodge$getID();
 
-    void setID(int id);
+    void hodgepodge$setID(int id);
 }


### PR DESCRIPTION
Namespace the injected method for embedding block IDs, to avoid collisions with other mods.
I probably should have predicted this would be an issue...

Fixes #529 