### PR TITLE
ignore preexisting voxelmap data files when trying to change ext

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/util/VoxelMapCacheMover.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/VoxelMapCacheMover.java
@@ -6,6 +6,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.regex.Pattern;
 
@@ -52,8 +53,12 @@ public class VoxelMapCacheMover {
                             || Files.getLastModifiedTime(newFile).compareTo(Files.getLastModifiedTime(file)) > 0)) {
                         this.ignored++;
                         return FileVisitResult.CONTINUE;
+                    } else {
+                        Files.move(
+                                file,
+                                file.resolveSibling(name.replace(".zip", ".data")),
+                                StandardCopyOption.REPLACE_EXISTING);
                     }
-                    Files.move(file, file.resolveSibling(name.replace(".zip", ".data")));
                     this.renamed++;
                 } catch (IOException e) {
                     Common.log.warn("Failed to change extension of " + file + " to .data", e);

--- a/src/main/java/com/mitchej123/hodgepodge/util/VoxelMapCacheMover.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/VoxelMapCacheMover.java
@@ -47,6 +47,12 @@ public class VoxelMapCacheMover {
             String name = file.getFileName().toString();
             if (PATTERN.matcher(name).matches()) {
                 try {
+                    Path newFile = file.resolveSibling(name.replace(".zip", ".data"));
+                    if (Files.exists(newFile) && (!Files.isSameFile(newFile, file)
+                            || Files.getLastModifiedTime(newFile).compareTo(Files.getLastModifiedTime(file)) > 0)) {
+                        this.ignored++;
+                        return FileVisitResult.CONTINUE;
+                    }
                     Files.move(file, file.resolveSibling(name.replace(".zip", ".data")));
                     this.renamed++;
                 } catch (IOException e) {


### PR DESCRIPTION
Hodgepodge will try to rename voxelmap cache files to .data regardless of whether the resulting file already exists, which can result in some heavy log spam (upwards of 3,000 lines in some cases) due to the resulting FileAlreadyExistsException.

This adds a check to see whether:
- The file exists and either:
- the two files are identical, or
- the source file is newer (which could happen if hodgepodge was temporarily disabled)

If this fails, it will replace the preexisting file