### PR TITLE
Make Etheric Sword truly Unbreakble

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -493,6 +493,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesChestComparatorUpdate;
 
+    @Config.Comment("Make Etheric Sword truly unbreakable")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesEthericSwordUnbreakable;
+
     // Galacticraft
 
     @Config.Comment("Fix time commands with GC")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -965,6 +965,10 @@ public enum Mixins implements IMixins {
                     .addMixinClasses("extrautilities.MixinExtraUtilsChest").setPhase(Phase.LATE).setSide(Side.BOTH)
                     .setApplyIf(() -> FixesConfig.fixExtraUtilitiesChestComparatorUpdate)
                     .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_ETHERIC_SWORD_UNBREAKABLE(new MixinBuilder("Make Etheric Sword truly unbreakable")
+            .addMixinClasses("extrautilities.MixinItemEthericSword").setPhase(Phase.LATE).setSide(Side.BOTH)
+            .setApplyIf(() -> FixesConfig.fixExtraUtilitiesEthericSwordUnbreakable)
+            .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Gliby's Voice Chat
     FIX_GLIBYS_VC_THREAD_SHUTDOWN_CLIENT(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinItemEthericSword.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinItemEthericSword.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.rwtema.extrautils.item.ItemEthericSword;
+
+@Mixin(ItemEthericSword.class)
+public abstract class MixinItemEthericSword {
+
+    @Redirect(
+            method = "onBlockDestroyed",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/ItemStack;damageItem(ILnet/minecraft/entity/EntityLivingBase;)V"))
+    private void hodgepodge$preventDurabilityLoss(ItemStack stack, int amount, EntityLivingBase entity) {}
+}


### PR DESCRIPTION
Prevents the Etheric Sword from losing Durability when breaking Blocks (like Cobweb)
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19756

Before (After breaking a Block):
![image](https://github.com/user-attachments/assets/b4d948c3-c17b-4f7c-ab27-8b7a5ce85ee6)

After (After breaking a Block):
![image](https://github.com/user-attachments/assets/35420cd6-4bae-4e02-937a-9ad15d704f24)
