### PR TITLE
Fix Crash Loop with EU Ender Collector

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,6 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:Steve-s-Factory-Manager:1.3.4-GTNH:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:Botania:1.12.10-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.3:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.324:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.2-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.309:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.310:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.2-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.3.0:dev") // Do not update, fixed afterwards
@@ -67,7 +67,7 @@ dependencies {
     // For testing - HP and AF are liable to mixin the same targets
     runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.6:dev")
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:99.0.0:dev") // mavenLocal location
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.1.48:dev") // for the pregenerator
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.1.52:dev") // for the pregenerator
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:1.0.0-beta43:dev") // for TPS graph
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:Steve-s-Factory-Manager:1.3.4-GTNH:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:Botania:1.12.11-GTNH-pre:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:Botania:1.12.10-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.310:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.2-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,6 +20,8 @@ dependencies {
     transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-615-GTNH")
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
+    transformedModCompileOnly("com.github.GTNewHorizons:Steve-s-Factory-Manager:1.3.4-GTNH:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:Botania:1.12.11-GTNH-pre:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.2:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.310:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.2-GTNH:dev")

--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -29,6 +29,8 @@ public class Compat {
     private static boolean isDreamcraftPresent;
     private static boolean isCoreTweaksPresent;
     private static boolean isKleeSlabsPresent;
+    private static boolean isBotaniaPresent;
+    private static boolean isSFMPresent;
 
     static void init(Side side) {
         isClient = side == Side.CLIENT;
@@ -64,6 +66,10 @@ public class Compat {
         isCoreTweaksPresent = Loader.isModLoaded("coretweaks");
 
         isKleeSlabsPresent = Loader.isModLoaded("kleeslabs");
+
+        isBotaniaPresent = Loader.isModLoaded("Botania");
+
+        isSFMPresent = Loader.isModLoaded("StevesFactoryManager");
     }
 
     /**
@@ -144,5 +150,19 @@ public class Compat {
      */
     public static boolean isKleeSlabsPresent() {
         return isKleeSlabsPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isBotaniaPresent() {
+        return isBotaniaPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isSFMPresent() {
+        return isSFMPresent;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -29,7 +29,6 @@ public class Compat {
     private static boolean isDreamcraftPresent;
     private static boolean isCoreTweaksPresent;
     private static boolean isKleeSlabsPresent;
-    private static boolean isBotaniaPresent;
     private static boolean isSFMPresent;
 
     static void init(Side side) {
@@ -66,8 +65,6 @@ public class Compat {
         isCoreTweaksPresent = Loader.isModLoaded("coretweaks");
 
         isKleeSlabsPresent = Loader.isModLoaded("kleeslabs");
-
-        isBotaniaPresent = Loader.isModLoaded("Botania");
 
         isSFMPresent = Loader.isModLoaded("StevesFactoryManager");
     }
@@ -150,13 +147,6 @@ public class Compat {
      */
     public static boolean isKleeSlabsPresent() {
         return isKleeSlabsPresent;
-    }
-
-    /**
-     * Cannot be used before pre-init phase.
-     */
-    public static boolean isBotaniaPresent() {
-        return isBotaniaPresent;
     }
 
     /**

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -497,6 +497,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesEthericSwordUnbreakable;
 
+    @Config.Comment("Prevent Extra Utilities Ender Collector from inserting into auto-dropping Blocks that create a crash-loop")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesEnderCollectorCrash;
+
     // Galacticraft
 
     @Config.Comment("Fix time commands with GC")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -969,6 +969,11 @@ public enum Mixins implements IMixins {
             .addMixinClasses("extrautilities.MixinItemEthericSword").setPhase(Phase.LATE).setSide(Side.BOTH)
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesEthericSwordUnbreakable)
             .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
+    FIX_ENDER_COLLECTOR_CRASH(new MixinBuilder(
+            "Prevent Extra Utilities Ender Collector from inserting into auto-dropping Blocks that create a crash-loop")
+                    .addMixinClasses("extrautilities.MixinTileEnderCollector").setPhase(Phase.LATE).setSide(Side.BOTH)
+                    .setApplyIf(() -> FixesConfig.fixExtraUtilitiesEnderCollectorCrash)
+                    .addTargetedMod(TargetedMod.EXTRA_UTILITIES)),
 
     // Gliby's Voice Chat
     FIX_GLIBYS_VC_THREAD_SHUTDOWN_CLIENT(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
@@ -28,13 +28,6 @@ public class MixinTileEnderCollector {
             }
         }
 
-        if (Compat.isBotaniaPresent()) {
-            if (blockBelow != null
-                    && blockBelow.getClass().getName().equals("vazkii.botania.common.block.BlockOpenCrate")) {
-                return null;
-            }
-        }
-
         if (Compat.isSFMPresent()) {
             if (blockBelow != null
                     && blockBelow.getClass().getName().equals("vswe.stevesfactory.blocks.BlockCableIntake")) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
@@ -26,7 +26,8 @@ public class MixinTileEnderCollector {
         TileEntity tileEntity = world.getTileEntity(x, y, z);
         Block blockBelow = world.getBlock(x, y, z);
 
-        if (tileEntity instanceof TileGrate || blockBelow instanceof BlockCableIntake || blockBelow instanceof BlockOpenCrate) {
+        if (tileEntity instanceof TileGrate || blockBelow instanceof BlockCableIntake
+                || blockBelow instanceof BlockOpenCrate) {
             return null;
         }
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.rwtema.extrautils.tileentity.endercollector.TileEnderCollector;
+
+import thaumcraft.common.tiles.TileGrate;
+import vazkii.botania.common.block.BlockOpenCrate;
+import vswe.stevesfactory.blocks.BlockCableIntake;
+
+@Mixin(TileEnderCollector.class)
+public class MixinTileEnderCollector {
+
+    @Redirect(
+            method = "updateEntity",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/World;getTileEntity(III)Lnet/minecraft/tileentity/TileEntity;"))
+    private TileEntity hodgepodge$blockTransferToBlacklist(World world, int x, int y, int z) {
+        TileEntity tileEntity = world.getTileEntity(x, y, z);
+        Block blockBelow = world.getBlock(x, y, z);
+
+        if (tileEntity instanceof TileGrate || blockBelow instanceof BlockCableIntake || blockBelow instanceof BlockOpenCrate) {
+            return null;
+        }
+
+        return tileEntity;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinTileEnderCollector.java
@@ -8,11 +8,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.mitchej123.hodgepodge.Compat;
 import com.rwtema.extrautils.tileentity.endercollector.TileEnderCollector;
-
-import thaumcraft.common.tiles.TileGrate;
-import vazkii.botania.common.block.BlockOpenCrate;
-import vswe.stevesfactory.blocks.BlockCableIntake;
 
 @Mixin(TileEnderCollector.class)
 public class MixinTileEnderCollector {
@@ -25,10 +22,24 @@ public class MixinTileEnderCollector {
     private TileEntity hodgepodge$blockTransferToBlacklist(World world, int x, int y, int z) {
         TileEntity tileEntity = world.getTileEntity(x, y, z);
         Block blockBelow = world.getBlock(x, y, z);
+        if (Compat.isThaumcraftPresent()) {
+            if (tileEntity != null && tileEntity.getClass().getName().equals("thaumcraft.common.tiles.TileGrate")) {
+                return null;
+            }
+        }
 
-        if (tileEntity instanceof TileGrate || blockBelow instanceof BlockCableIntake
-                || blockBelow instanceof BlockOpenCrate) {
-            return null;
+        if (Compat.isBotaniaPresent()) {
+            if (blockBelow != null
+                    && blockBelow.getClass().getName().equals("vazkii.botania.common.block.BlockOpenCrate")) {
+                return null;
+            }
+        }
+
+        if (Compat.isSFMPresent()) {
+            if (blockBelow != null
+                    && blockBelow.getClass().getName().equals("vswe.stevesfactory.blocks.BlockCableIntake")) {
+                return null;
+            }
         }
 
         return tileEntity;


### PR DESCRIPTION
fixes the crash loop when Ender Collector is placed above auto-dropping Blocks.
Currently included Blocks:
- Open Crate (Botania)
- Item Valve (SFM)
- Rapid Item Valve (SFM)
- Item Grate (Thaumcraft)
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18154

Still working on normal Inventories:
![image](https://github.com/user-attachments/assets/05e92621-e8da-4525-b0a0-89d4e74926ef)

Not working on mentioned Blocks:
![image](https://github.com/user-attachments/assets/e9a3fcbf-df23-4d10-84df-ff4682824f65)
![image](https://github.com/user-attachments/assets/5365fa5a-11a6-4a65-90a3-82f28d780e8e)
![image](https://github.com/user-attachments/assets/216e5911-1c6e-4cfd-aabe-d854399c73c2)
![image](https://github.com/user-attachments/assets/f9e7d5de-a496-4d4d-9114-2f23cd567e21)
