### PR TITLE
Disable Embed IDs by default

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/ASMConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/ASMConfig.java
@@ -39,7 +39,7 @@ public class ASMConfig {
     public static boolean speedupOreDictionary;
 
     @Config.Comment("Embeds the block ID into Block itself, massively accelerating block ID lookups.")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean embedID;
 }


### PR DESCRIPTION
It's not stable and causes serious issues on leaving/reentering a world.

Needs some work and testing and can be re-enabled by default when stable.