### PR TITLE
Fix adding Thrower to inventory-dropped items

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityPlayer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityPlayer.java
@@ -8,10 +8,12 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import com.mitchej123.hodgepodge.config.FixesConfig;
@@ -51,5 +53,16 @@ public abstract class MixinEntityPlayer {
             return;
         }
         this.collideWithPlayer(entity);
+    }
+
+    @ModifyArg(
+            method = "dropPlayerItemWithRandomChoice",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraftforge/common/ForgeHooks;onPlayerTossEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Z)Lnet/minecraft/entity/item/EntityItem;"),
+            index = 2,
+            remap = false)
+    public boolean hodgepodge$passThrower(boolean ignored, @Local(argsOnly = true) boolean p_71019_2_) {
+        return p_71019_2_;
     }
 }


### PR DESCRIPTION
EntityItems have a tag (obfuscated name) indicating if a player dropped it which has the player's name, which is useful to check in some circumstances (related https://github.com/GTNewHorizons/Draconic-Evolution/pull/70). For reasons dating back to vanilla, this was not set if the item was dropped from an inventory, even though as far as I can tell _the function has an attribute that indicates this and it is correctly set in all the relevant places_. This PR just changes the underlying call to use this existing attribute in place of an always-false argument to set the thrower.

The vanilla function:
![image](https://github.com/user-attachments/assets/cbf4d700-7f8c-48e4-890f-1db5073a2e9e)
