### PR TITLE
Disable some patches when ultramine present

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/asm/AsmTransformers.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/AsmTransformers.java
@@ -63,7 +63,7 @@ public enum AsmTransformers {
             () -> ASMConfig.speedupOreDictionary,
             Side.BOTH,
             null,
-            ImmutableList.of(TargetedMod.FASTCRAFT, TargetedMod.BUKKIT),
+            ImmutableList.of(TargetedMod.FASTCRAFT, TargetedMod.BUKKIT, TargetedMod.ULTRAMINE),
             "com.mitchej123.hodgepodge.asm.transformers.mc.SpeedupOreDictionaryTransformer"
     ),
     FIX_BOGUS_INTEGRATED_SERVER_NPE(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -48,7 +48,7 @@ public enum Mixins implements IMixins {
                     .setApplyIf(() -> FixesConfig.fixTooManyAllocationsChunkPositionIntPair)),
     ADD_SIMULATION_DISTANCE_OPTION(new MixinBuilder("Add option to separate simulation distance from render distance")
             .addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH).setPhase(Phase.EARLY)
-            .addExcludedMod(TargetedMod.OPTIFINE)
+            .addExcludedMod(TargetedMod.OPTIFINE).addExcludedMod(TargetedMod.ULTRAMINE)
             .addMixinClasses(
                     "minecraft.MixinWorld_SimulationDistance",
                     "minecraft.MixinWorldServer_SimulationDistance",
@@ -57,7 +57,7 @@ public enum Mixins implements IMixins {
     ADD_SIMULATION_DISTANCE_OPTION_THERMOS_FIX(
             new MixinBuilder("Add option to separate simulation distance from render distance (Thermos fix)")
                     .addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH).setPhase(Phase.EARLY)
-                    .addExcludedMod(TargetedMod.OPTIFINE)
+                    .addExcludedMod(TargetedMod.OPTIFINE).addExcludedMod(TargetedMod.ULTRAMINE)
                     .addMixinClasses("minecraft.MixinWorldServer_SimulationDistanceThermosFix")
                     .setApplyIf(() -> FixesConfig.addSimulationDistance && Common.thermosTainted)),
     FIX_RESOURCEPACK_FOLDER_OPENING(new MixinBuilder("Fix resource pack folder sometimes not opening on windows")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -53,6 +53,7 @@ public enum TargetedMod implements ITargetedMod {
     THERMALEXPANSION("Thermal Expansion", null, "ThermalExpansion"),
     TINKERSCONSTRUCT("TConstruct", null, "TConstruct"),
     TRAVELLERSGEAR("TravellersGear", null, "TravellersGear"),
+    ULTRAMINE("Ultramine Server", "org.ultramine.server.UltraminePlugin", "UltramineServer"),
     VANILLA("Minecraft", null),
     VOXELMAP("VoxelMap", "com.thevoxelbox.voxelmap.litemod.VoxelMapTransformer", "voxelmap"),
     WITCHERY("Witchery", null, "witchery"),


### PR DESCRIPTION
Disable SPEEDUP_ORE_DICTIONARY and ADD_SIMULATION_DISTANCE which doesn't work properly on ultramine

Also closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19924