### PR TITLE
Remove unregistered events from MixinEventBus.listenerOwners

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -631,7 +631,8 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixEggParticles).addTargetedMod(TargetedMod.VANILLA)),
     FIX_EVENTBUS_MEMORY_LEAK(
             new MixinBuilder("Fix EventBus keeping object references after unregistering event handlers.")
-                    .setPhase(Phase.EARLY).setSide(Side.BOTH).addMixinClasses("fml.MixinListenerListInst")
+                    .setPhase(Phase.EARLY).setSide(Side.BOTH)
+                    .addMixinClasses("fml.MixinListenerListInst", "fml.MixinEventBus")
                     .setApplyIf(() -> FixesConfig.fixEventBusMemoryLeak).addTargetedMod(TargetedMod.VANILLA)),
 
     // Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEventBus.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEventBus.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.early.fml;
+
+import java.util.Map;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.ModContainer;
+import cpw.mods.fml.common.eventhandler.EventBus;
+
+@Mixin(value = EventBus.class, remap = false)
+public class MixinEventBus {
+
+    @Shadow
+    private Map<Object, ModContainer> listenerOwners;
+
+    @Inject(method = "unregister", at = @At(value = "HEAD"))
+    private void hodgepodge$removeListenerOwners(Object object, CallbackInfo ci) {
+        listenerOwners.remove(object);
+    }
+}


### PR DESCRIPTION
while this isn't a memory leak because the map has weak keys and values. This map keeps growing with potentially thousands of events