### PR TITLE
Refer to Galacticraft by its name instead of an abbreviation

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -516,7 +516,7 @@ public class FixesConfig {
 
     // Galacticraft
 
-    @Config.Comment("Fix time commands with GC")
+    @Config.Comment("Fix time commands with Galacticraft")
     @Config.DefaultBoolean(true)
     public static boolean fixTimeCommandWithGC;
 


### PR DESCRIPTION
This updates the comment of the configuration node `fixes.fixTimeCommandWithGC` to refer to Galacticraft by its full name, instead of using the abbreviation "GC". The motivation behind this is simply to prevent confusion. A user of this mod may not know what "GC" refers to if he doesn't have Galacticraft installed. Personally, I thought it was referring to garbage collection, until I looked at the mixin code.