### PR TITLE
Delete unnecessary invoker interface for MixinNBTTagList_speedup

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNBTTagList_speedup.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNBTTagList_speedup.java
@@ -13,10 +13,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.sugar.Local;
-import com.mitchej123.hodgepodge.mixins.interfaces.NBTTagListExt;
 
 @Mixin(NBTTagList.class)
-public class MixinNBTTagList_speedup implements NBTTagListExt {
+public class MixinNBTTagList_speedup {
 
     @Shadow
     private List tagList;
@@ -27,16 +26,11 @@ public class MixinNBTTagList_speedup implements NBTTagListExt {
                     value = "INVOKE",
                     target = "Ljava/util/List;iterator()Ljava/util/Iterator;",
                     shift = At.Shift.AFTER))
-    public void copyEnsureCapacity(CallbackInfoReturnable<NBTBase> cir, @Local NBTTagList nbttaglist) {
-        // Ensure the capacity of the new tag list is the same as the old one so we don't need to resize it later
-        ((NBTTagListExt) nbttaglist).ensureCapacity(tagList.size());
-
-    }
-
-    @Override
-    public void ensureCapacity(int capacity) {
-        if (tagList instanceof ArrayList tagArrayList) {
-            tagArrayList.ensureCapacity(capacity);
+    public void copyEnsureCapacity(CallbackInfoReturnable<NBTBase> cir, @Local NBTTagList newTagList) {
+        // Ensure the capacity of the new tag list is the same as the old one,
+        // so we don't need to resize (multiple times) during the copy
+        if (((MixinNBTTagList_speedup) (Object) (newTagList)).tagList instanceof ArrayList list) {
+            list.ensureCapacity(tagList.size());
         }
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/NBTTagListExt.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/NBTTagListExt.java
@@ -1,6 +1,0 @@
-package com.mitchej123.hodgepodge.mixins.interfaces;
-
-public interface NBTTagListExt {
-
-    void ensureCapacity(int capacity);
-}


### PR DESCRIPTION
Works the same

![image](https://github.com/user-attachments/assets/396ea7dc-482b-4787-8d70-82559c161f59)