### PR TITLE
Speedup `EnumChatFormatting.getTextWithoutFormattingCodes`

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,6 @@
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,6 +70,10 @@ dependencies {
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:99.0.0:dev") // mavenLocal location
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.1.54:dev") // for the pregenerator
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:1.0.0-beta46:dev") // for TPS graph
+
+    testImplementation(platform('org.junit:junit-bom:5.9.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testImplementation("org.mockito:mockito-core:5.+")
 }
 
 // Replace when RFG support deobfuscation from notch mappings

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -91,6 +91,11 @@ public class SpeedupsConfig {
     @Config.RequiresMcRestart
     public static boolean lavaChunkLoading;
 
+    @Config.Comment("Speed up the vanilla method to remove formatting codes")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean speedupRemoveFormatting;
+
     // Biomes O' Plenty
 
     @Config.Comment("Speedup biome fog rendering in BiomesOPlenty")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -187,6 +187,9 @@ public enum Mixins implements IMixins {
     LONGER_MESSAGES_SERVER(new MixinBuilder("Longer Messages Server Side").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinC01PacketChatMessage_LongerMessages").setApplyIf(() -> true)
             .addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH)),
+    SPEEDUP_REMOVE_FORMATTING_CODES(new MixinBuilder("Speed up the vanilla method to remove formatting codes")
+            .setPhase(Phase.EARLY).setSide(Side.CLIENT).addMixinClasses("minecraft.MixinEnumChatFormatting_FastFormat")
+            .setApplyIf(() -> SpeedupsConfig.speedupRemoveFormatting).addTargetedMod(TargetedMod.VANILLA)),
     SPEEDUP_GRASS_BLOCK_RANDOM_TICKING(new MixinBuilder("Speed up grass block random ticking").setPhase(Phase.EARLY)
             .addMixinClasses("minecraft.MixinBlockGrass").addTargetedMod(TargetedMod.VANILLA).setSide(Side.BOTH)
             .setApplyIf(() -> SpeedupsConfig.speedupGrassBlockRandomTicking)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEnumChatFormatting_FastFormat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEnumChatFormatting_FastFormat.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.util.EnumChatFormatting;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import com.mitchej123.hodgepodge.util.StringUtil;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@Mixin(EnumChatFormatting.class)
+public class MixinEnumChatFormatting_FastFormat {
+
+    /**
+     * @author Alexdoru
+     * @reason It's faster
+     */
+    @Overwrite
+    @SideOnly(Side.CLIENT)
+    public static String getTextWithoutFormattingCodes(String text) {
+        return StringUtil.removeFormattingCodes(text);
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/StringUtil.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/StringUtil.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.util;
+
+public class StringUtil {
+
+    /**
+     * A faster version of {@link net.minecraft.util.EnumChatFormatting#getTextWithoutFormattingCodes(String)}
+     */
+    public static String removeFormattingCodes(String text) {
+        if (text == null || text.length() < 2) return text;
+        final int len = text.length();
+        final char[] chars = text.toCharArray();
+        final char[] newChars = new char[len];
+        int count = 0;
+        for (int i = 0; i < len; i++) {
+            final char c = chars[i];
+            if (c == '§' && i + 1 < len && "0123456789abcdefklmnorABCDEFKLMNOR".indexOf(chars[i + 1]) != -1) {
+                i++;
+                continue;
+            }
+            newChars[count] = c;
+            count++;
+        }
+        return new String(newChars, 0, count);
+    }
+}

--- a/src/test/java/hodgepodge/StringUtilsTest.java
+++ b/src/test/java/hodgepodge/StringUtilsTest.java
@@ -1,0 +1,29 @@
+package hodgepodge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.minecraft.util.EnumChatFormatting;
+
+import org.junit.jupiter.api.Test;
+
+import com.mitchej123.hodgepodge.util.StringUtil;
+
+public class StringUtilsTest {
+
+    @Test
+    void testRemoveFormattingCodes() {
+        String[] testArray = new String[] { null, "", "§", "a", "OZI§bUNvnZV§a auivniuv", "nvuz§e",
+                "n§BnvuZVBzbvpizBVUBZUIbvIPZBVIZbuivbiZBVUI", "§RvjkzVBvVUIOVEUIV VIJVQEUHI", " §f\ud83c\udf89 2",
+                " §2\ud83c\udfc0 5", " ZIUECBPZbc iZUCUN\u26bd rs6", " §1\ud83d\udc7e 9",
+                " Players: §a37/10\ud83d\udc0d §a010", " §0\ud83d\udc7d 12",
+                "§6[Y] §fOncionzC§6\ud83c\udf20§6 HP§7: §61,0008", "§c[R] §fIB85AC§c\ud83d\udc7e§c HP§7: §c1,0009",
+                "§2[G] §fACAZ§2\ud83d\udc0d§2 HP§7: §21,00010", "§1[B] 1470§1 H\ud83d\udd2e§1P§7: §11,00011" };
+
+        for (String text : testArray) {
+            assertEquals(
+                    EnumChatFormatting.getTextWithoutFormattingCodes(text),
+                    StringUtil.removeFormattingCodes(text));
+        }
+    }
+
+}


### PR DESCRIPTION
This method is called during rendering, which makes it interesting to speed it up.

```
Benchmark                                   Mode  Cnt  Score   Error  Units
EnumChatFormattingCode.benchCustomVersion   avgt    5  1,906 � 0,019  us/op
EnumChatFormattingCode.benchVanillaVersion  avgt    5  9,598 � 0,190  us/op
```