### PR TITLE
Improve pick block

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinForgeHooks_ModernPickBlock.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinForgeHooks_ModernPickBlock.java
@@ -8,12 +8,12 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 
 @Mixin(value = ForgeHooks.class, remap = false)
 public class MixinForgeHooks_ModernPickBlock {
@@ -21,13 +21,14 @@ public class MixinForgeHooks_ModernPickBlock {
     // credit for original mixin: bearsdotzone
     @Inject(method = "onPickBlock", at = @At(value = "RETURN", ordinal = 4), cancellable = true)
     private static void hodgepodge$onPickBlock(MovingObjectPosition target, EntityPlayer player, World world,
-            CallbackInfoReturnable<Boolean> cir, @Local(name = "result") LocalRef<ItemStack> result) {
+            CallbackInfoReturnable<Boolean> cir, @Local(name = "result") ItemStack result) {
         Minecraft clientObject = Minecraft.getMinecraft();
         for (int x = 9; x < 36; x++) {
             ItemStack stack = player.inventory.getStackInSlot(x);
-            if (stack != null && stack.isItemEqual(result.get())
-                    && ItemStack.areItemStackTagsEqual(stack, result.get())) {
-                int moveSlot = player.inventory.currentItem;
+            if (stack != null && stack.isItemEqual(result)
+                    && ItemStack.areItemStackTagsEqual(stack, result)) {
+                int moveSlot = hodgepodge$getSuitableHotbarSlot(player);
+                player.inventory.currentItem = moveSlot;
                 moveSlot = 36 + moveSlot;
 
                 clientObject.playerController.windowClick(player.inventoryContainer.windowId, x, 0, 0, player);
@@ -37,5 +38,28 @@ public class MixinForgeHooks_ModernPickBlock {
                 return;
             }
         }
+    }
+
+    @Unique
+    private static int hodgepodge$getSuitableHotbarSlot(EntityPlayer player) {
+        int currentItem = player.inventory.currentItem;
+
+        // Look for an empty slot
+        for (int i = 0; i < 9; i++) {
+            int slot = (currentItem + i) % 9;
+            if (player.inventory.mainInventory[slot] == null) {
+                return slot;
+            }
+        }
+
+        // Look for a slot with an item that is not enchanted
+        for (int i = 0; i < 9; i++) {
+            int slot = (currentItem + i) % 9;
+            if (!player.inventory.mainInventory[slot].isItemEnchanted()) {
+                return slot;
+            }
+        }
+
+        return currentItem;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinForgeHooks_ModernPickBlock.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinForgeHooks_ModernPickBlock.java
@@ -25,8 +25,7 @@ public class MixinForgeHooks_ModernPickBlock {
         Minecraft clientObject = Minecraft.getMinecraft();
         for (int x = 9; x < 36; x++) {
             ItemStack stack = player.inventory.getStackInSlot(x);
-            if (stack != null && stack.isItemEqual(result)
-                    && ItemStack.areItemStackTagsEqual(stack, result)) {
+            if (stack != null && stack.isItemEqual(result) && ItemStack.areItemStackTagsEqual(stack, result)) {
                 int moveSlot = hodgepodge$getSuitableHotbarSlot(player);
                 player.inventory.currentItem = moveSlot;
                 moveSlot = 36 + moveSlot;


### PR DESCRIPTION
This should now match the modern vanilla behaviour.
When picking a block it will first try to find an empty slot, then one with an item that is not enchanted, then the current slot.