### PR TITLE
add debug flag to log time to register forge event handlers

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
@@ -35,6 +35,7 @@ import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 @IFMLLoadingPlugin.DependsOn("cofh.asm.LoadingPlugin")
 public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
+    private static File mcLocation;
     private static boolean isObf;
     private String[] transformerClasses;
 
@@ -113,8 +114,9 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
 
     @Override
     public void injectData(Map<String, Object> data) {
-        VoxelMapCacheMover.changeFileExtensions((File) data.get("mcLocation"));
+        mcLocation = (File) data.get("mcLocation");
         isObf = (boolean) data.get("runtimeDeobfuscationEnabled");
+        VoxelMapCacheMover.changeFileExtensions(mcLocation);
     }
 
     @Override
@@ -124,6 +126,10 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
             CoreCompat.disableCoretweaksConflictingMixins();
         } catch (ClassNotFoundException e) {}
         return null;
+    }
+
+    public static File getMcLocation() {
+        return mcLocation;
     }
 
     public static boolean isObf() {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -713,6 +713,10 @@ public enum Mixins implements IMixins {
                     "minecraft.MixinGameRules_HungerRule")
             .setApplyIf(() -> TweaksConfig.hungerGameRule)
             .setPhase(Phase.EARLY)),
+    DEBUG_EVENT_REGISTRATION(new MixinBuilder()
+            .setPhase(Phase.EARLY)
+            .setApplyIf(() -> Boolean.getBoolean("hodgepodge.logEventTimes"))
+            .addCommonMixins("fml.MixinEventBus_DebugRegistration")),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEventBus_DebugRegistration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEventBus_DebugRegistration.java
@@ -1,0 +1,73 @@
+package com.mitchej123.hodgepodge.mixins.early.fml;
+
+import net.minecraft.launchwrapper.Launch;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.util.FileLogger;
+
+import cpw.mods.fml.common.eventhandler.EventBus;
+
+@Mixin(value = EventBus.class, remap = false)
+public class MixinEventBus_DebugRegistration {
+
+    @Unique
+    private static final FileLogger debug$log = new FileLogger(Launch.minecraftHome, "DebugEventRegistration.txt");
+    @Unique
+    private static long debug$totalTime;
+
+    @Unique
+    private int debug$countMethods;
+    @Unique
+    private int debug$countHandlers;
+    @Unique
+    private long debug$timeStart;
+
+    @Inject(method = "register(Ljava/lang/Object;)V", at = @At("HEAD"))
+    private void debug$atHead(Object target, CallbackInfo ci) {
+        debug$countMethods = 0;
+        debug$countHandlers = 0;
+        debug$timeStart = System.nanoTime();
+    }
+
+    @Inject(
+            method = "register(Ljava/lang/Object;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/lang/Class;getDeclaredMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
+                    shift = At.Shift.BEFORE))
+    private void debug$CountMethods(Object target, CallbackInfo ci) {
+        debug$countMethods++;
+    }
+
+    @Inject(
+            method = "register(Ljava/lang/Object;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/eventhandler/EventBus;register(Ljava/lang/Class;Ljava/lang/Object;Ljava/lang/reflect/Method;Lcpw/mods/fml/common/ModContainer;)V",
+                    shift = At.Shift.BEFORE))
+    private void debug$CountHandlers(Object target, CallbackInfo ci) {
+        debug$countHandlers++;
+    }
+
+    @Inject(method = "register(Ljava/lang/Object;)V", at = @At(value = "TAIL"))
+    private void debug$atBottom(Object target, CallbackInfo ci) {
+        final long timeElapsed = System.nanoTime() - debug$timeStart;
+        synchronized (debug$log) {
+            debug$totalTime += timeElapsed;
+            debug$log.log("Registered event class : " + target.getClass().getName());
+            debug$log.log("Methods Visited : " + debug$countMethods);
+            debug$log.log("Handlers found : " + debug$countHandlers);
+            debug$log.log("Time elapsed : " + (timeElapsed / 1_000_000) + "ms");
+            debug$log.log("Total Time elapsed : " + (debug$totalTime / 1_000_000) + "ms");
+            if (debug$countHandlers == 0) {
+                debug$log.log("No handlers have been found in the registered class!!!");
+                debug$log.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEventBus_DebugRegistration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEventBus_DebugRegistration.java
@@ -1,7 +1,5 @@
 package com.mitchej123.hodgepodge.mixins.early.fml;
 
-import net.minecraft.launchwrapper.Launch;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,7 +14,7 @@ import cpw.mods.fml.common.eventhandler.EventBus;
 public class MixinEventBus_DebugRegistration {
 
     @Unique
-    private static final FileLogger debug$log = new FileLogger(Launch.minecraftHome, "DebugEventRegistration.txt");
+    private static final FileLogger debug$log = new FileLogger("EventRegistrationTime.txt");
     @Unique
     private static long debug$totalTime;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinLoadController_logModTimes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinLoadController_logModTimes.java
@@ -3,8 +3,6 @@ package com.mitchej123.hodgepodge.mixins.preinit;
 import java.util.ArrayList;
 import java.util.Map;
 
-import net.minecraft.launchwrapper.Launch;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -51,7 +49,7 @@ public class MixinLoadController_logModTimes {
             at = @At(value = "TAIL"))
     public void printResults(LoaderState state, Object[] eventData, CallbackInfo ci) {
         if (hodgepodge$results == null || state != LoaderState.AVAILABLE) return;
-        try (FileLogger logger = new FileLogger(Launch.minecraftHome, "modtimes.csv", null)) {
+        try (FileLogger logger = new FileLogger("modtimes.csv")) {
             logger.log("event;modid;modname;time");
             hodgepodge$results.forEach((type, results) -> {
                 results.sort(null);
@@ -59,7 +57,6 @@ public class MixinLoadController_logModTimes {
                     final String modid = result.mod.getModId();
                     logger.log(type + ";" + modid + ";" + result.mod.getName() + ";" + result.time / 1000000);
                 });
-
             });
         }
         hodgepodge$results = null;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinLoadController_logModTimes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinLoadController_logModTimes.java
@@ -1,21 +1,20 @@
 package com.mitchej123.hodgepodge.mixins.preinit;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Map;
 
+import net.minecraft.launchwrapper.Launch;
+
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.mixins.hooks.ModProfileResult;
+import com.mitchej123.hodgepodge.util.FileLogger;
 
 import cpw.mods.fml.common.LoadController;
 import cpw.mods.fml.common.LoaderState;
@@ -26,7 +25,8 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 @Mixin(value = LoadController.class, remap = false)
 public class MixinLoadController_logModTimes {
 
-    private static Map<String, ArrayList<ModProfileResult>> results = new Object2ObjectOpenHashMap<>();
+    @Unique
+    private static Map<String, ArrayList<ModProfileResult>> hodgepodge$results = new Object2ObjectOpenHashMap<>();
 
     @WrapOperation(
             method = "propogateStateMessage",
@@ -39,10 +39,10 @@ public class MixinLoadController_logModTimes {
         final long start = System.nanoTime();
 
         original.call(instance, event, modContainer);
-        if (results == null) return;
+        if (hodgepodge$results == null) return;
 
         final long timeTaken = System.nanoTime() - start;
-        results.computeIfAbsent(event.getEventType(), k -> new ArrayList<>())
+        hodgepodge$results.computeIfAbsent(event.getEventType(), k -> new ArrayList<>())
                 .add(new ModProfileResult(timeTaken, modContainer));
     }
 
@@ -50,24 +50,19 @@ public class MixinLoadController_logModTimes {
             method = "Lcpw/mods/fml/common/LoadController;distributeStateMessage(Lcpw/mods/fml/common/LoaderState;[Ljava/lang/Object;)V",
             at = @At(value = "TAIL"))
     public void printResults(LoaderState state, Object[] eventData, CallbackInfo ci) {
-        if (results == null || state != LoaderState.AVAILABLE) return;
-        try {
-            PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter("modtimes.csv", false)));
-
-            writer.println("event;modid;modname;time");
-            results.forEach((type, results) -> {
+        if (hodgepodge$results == null || state != LoaderState.AVAILABLE) return;
+        try (FileLogger logger = new FileLogger(Launch.minecraftHome, "modtimes.csv", null)) {
+            logger.log("event;modid;modname;time");
+            hodgepodge$results.forEach((type, results) -> {
                 results.sort(null);
                 results.forEach(result -> {
                     final String modid = result.mod.getModId();
-                    writer.println(type + ";" + modid + ";" + result.mod.getName() + ";" + result.time / 1000000);
+                    logger.log(type + ";" + modid + ";" + result.mod.getName() + ";" + result.time / 1000000);
                 });
 
             });
-            writer.close();
-        } catch (IOException e) {
-            Common.log.error("Failed to write modtimes.csv", e);
         }
-        results = null;
+        hodgepodge$results = null;
     }
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/FileLogger.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FileLogger.java
@@ -1,0 +1,67 @@
+package com.mitchej123.hodgepodge.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.SimpleDateFormat;
+
+public class FileLogger {
+
+    private final SimpleDateFormat dateFormat;
+    private PrintStream printStream = null;
+
+    public FileLogger(File logFolder, String filename) {
+        this(logFolder, filename, "HH:mm:ss");
+    }
+
+    public FileLogger(File logFolder, String filename, String timeFormat) {
+        if (timeFormat == null) {
+            dateFormat = null;
+        } else {
+            dateFormat = new SimpleDateFormat(timeFormat);
+        }
+        if (logFolder == null) {
+            throw new IllegalStateException("FileLogger logFolder cannot be null!");
+        }
+        if (filename == null) {
+            throw new IllegalStateException("FileLogger file name cannot be null!");
+        }
+        // noinspection ResultOfMethodCallIgnored
+        logFolder.mkdirs();
+        final File logFile = new File(logFolder, filename);
+        if (logFile.exists()) {
+            // noinspection ResultOfMethodCallIgnored
+            logFile.delete();
+        }
+        if (!logFile.exists()) {
+            try {
+                // noinspection ResultOfMethodCallIgnored
+                logFile.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        try {
+            printStream = new PrintStream(new FileOutputStream(logFile, true));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void log(String message) {
+        if (printStream == null) return;
+        if (dateFormat == null) {
+            printStream.println(message);
+            return;
+        }
+        final String time = dateFormat.format(System.currentTimeMillis());
+        printStream.println("[" + time + "] " + message);
+    }
+
+    public void printStackTrace() {
+        if (printStream == null) return;
+        new Exception().printStackTrace(printStream);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/FileLogger.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FileLogger.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 
-public class FileLogger {
+public class FileLogger implements AutoCloseable {
 
     private final SimpleDateFormat dateFormat;
     private PrintStream printStream = null;
@@ -63,5 +63,10 @@ public class FileLogger {
     public void printStackTrace() {
         if (printStream == null) return;
         new Exception().printStackTrace(printStream);
+    }
+
+    public void close() {
+        if (printStream == null) return;
+        printStream.close();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/FileLogger.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FileLogger.java
@@ -7,15 +7,22 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 
+import com.mitchej123.hodgepodge.core.HodgepodgeCore;
+
 public class FileLogger implements AutoCloseable {
 
     private final SimpleDateFormat dateFormat;
     private PrintStream printStream = null;
 
-    public FileLogger(File logFolder, String filename) {
-        this(logFolder, filename, "HH:mm:ss");
+    public FileLogger(String filename) {
+        this(HodgepodgeCore.getMcLocation(), filename);
     }
 
+    public FileLogger(File logFolder, String filename) {
+        this(logFolder, filename, null);
+    }
+
+    // timeFormat "HH:mm:ss"
     public FileLogger(File logFolder, String filename, String timeFormat) {
         if (timeFormat == null) {
             dateFormat = null;


### PR DESCRIPTION
`-Dhodgepodge.logEventTimes=true`


spits out a file that looks like this :
```
Registered event class : logisticspipes.commands.chathelper.LPChatListener
Methods Visited : 32
Handlers found : 2
Time elapsed : 3ms
Total Time elapsed : 1700ms
Registered event class : net.malisis.doors.event.DoorEventHandlerClient
Methods Visited : 20
Handlers found : 2
Time elapsed : 0ms
Total Time elapsed : 1700ms
Registered event class : modtweaker2.ClientEvents
Methods Visited : 19
Handlers found : 1
Time elapsed : 0ms
Total Time elapsed : 1701ms
Registered event class : net.bdew.neiaddons.network.ServerHandler
Methods Visited : 170
Handlers found : 2
Time elapsed : 4ms
Total Time elapsed : 1705ms
```