### PR TITLE
stop disabling the creative search bar if archaix fix is present

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -516,6 +516,7 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiContainerCreative")
             .setApplyIf(() -> FixesConfig.removeCreativeSearchTab)
             .addRequiredMod(TargetedMod.NOTENOUGHITEMS)
+            .addExcludedMod(TargetedMod.ARCHAICFIX)
             .setPhase(Phase.EARLY)),
     FIX_CHAT_COLOR_WRAPPING(new MixinBuilder("Fix wrapped chat lines missing colors")
             .addClientMixins("minecraft.MixinGuiNewChat_FixColorWrapping")


### PR DESCRIPTION
archaix fix is optimizing the creative tab search so we don't need to disable it to prevent crashing anymore