### PR TITLE
Return items stored in Travellers Gear slots after the mod is uninstalled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Hodgepodge is LGPL-3.
 - Thaumcraft: Aspects are sorted by localized name instead of internal tag.
 - Thaumcraft: Golems function in dimensions higher than 255.
 - Thaumcraft: Wand Recharge Pedestals accept Centivis.
+- Traveller's Gear: Return items that were placed in TG slots after the mod is removed.
 - VoxelMap: The file extension is changed from .zip to .data to stop an adverse reaction with the Technic launcher.
 - VoxelMap: The Y coordinate is no longer off by one.
 - Witchery: Inhabited mirrors have fixed player skin reflections.

--- a/src/main/java/com/mitchej123/hodgepodge/Compat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Compat.java
@@ -30,6 +30,7 @@ public class Compat {
     private static boolean isCoreTweaksPresent;
     private static boolean isKleeSlabsPresent;
     private static boolean isSFMPresent;
+    private static boolean isTravellersGearPresent;
 
     static void init(Side side) {
         isClient = side == Side.CLIENT;
@@ -67,6 +68,8 @@ public class Compat {
         isKleeSlabsPresent = Loader.isModLoaded("kleeslabs");
 
         isSFMPresent = Loader.isModLoaded("StevesFactoryManager");
+
+        isTravellersGearPresent = Loader.isModLoaded("TravellersGear");
     }
 
     /**
@@ -154,5 +157,12 @@ public class Compat {
      */
     public static boolean isSFMPresent() {
         return isSFMPresent;
+    }
+
+    /**
+     * Cannot be used before pre-init phase.
+     */
+    public static boolean isTravellersGearPresent() {
+        return isTravellersGearPresent;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -4,10 +4,12 @@ import java.util.Map;
 
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
+import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.net.NetworkHandler;
 import com.mitchej123.hodgepodge.util.AnchorAlarm;
 import com.mitchej123.hodgepodge.util.StatHandler;
+import com.mitchej123.hodgepodge.util.TravellersGear;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.ICrashCallable;
@@ -94,6 +96,10 @@ public class Hodgepodge {
     public void onServerStarted(FMLServerStartedEvent event) {
         if (TweaksConfig.addModEntityStats) {
             StatHandler.addEntityStats();
+        }
+
+        if (FixesConfig.returnTravellersGearItems && !Compat.isTravellersGearPresent()) {
+            TravellersGear.initialize();
         }
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/HodgepodgeEventHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/HodgepodgeEventHandler.java
@@ -11,6 +11,7 @@ import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.net.MessageConfigSync;
 import com.mitchej123.hodgepodge.net.NetworkHandler;
+import com.mitchej123.hodgepodge.util.TravellersGear;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.Event;
@@ -44,6 +45,9 @@ public class HodgepodgeEventHandler {
     @SubscribeEvent
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
         NetworkHandler.instance.sendTo(new MessageConfigSync(), (EntityPlayerMP) event.player);
+        if (FixesConfig.returnTravellersGearItems && !Compat.isTravellersGearPresent()) {
+            TravellersGear.returnTGItems(event.player);
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -677,6 +677,16 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean preventFluidGridCrash;
 
+    // Travellers' Gear
+
+    @Config.Comment({ "Return items placed in Traveller's Gear slots after the mod is removed when players log in.",
+            "Sends messages to the log that start with \"[Hodgepodge]: [TG Recovery]\".",
+            "Removes players from the TG items file after returning items. Deletes it if it's empty.",
+            "Automatically disables itself on servers after deleting the TG items file.",
+            "Clients leave it on to allow for joining multiple SP worlds with TG items." })
+    @Config.DefaultBoolean(true)
+    public static boolean returnTravellersGearItems;
+
     // VoxelMap
 
     @Config.Comment("Fix some NullPointerExceptions")

--- a/src/main/java/com/mitchej123/hodgepodge/util/TravellersGear.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/TravellersGear.java
@@ -1,0 +1,133 @@
+package com.mitchej123.hodgepodge.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.config.FixesConfig;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+
+public class TravellersGear {
+
+    private static NBTTagCompound cachedRoot;
+    private static NBTTagCompound cachedData;
+    private static NBTTagList cachedPlayerList;
+    private static File dataFile;
+    private static boolean dirty;
+
+    public static void returnTGItems(EntityPlayer player) {
+        if (cachedPlayerList == null) {
+            Common.log.info("[TG Recovery] No player data loaded.");
+            return;
+        }
+
+        UUID playerUUID = player.getUniqueID();
+        boolean found = false;
+        NBTTagList updatedList = new NBTTagList();
+
+        for (int i = 0; i < cachedPlayerList.tagCount(); i++) {
+            NBTTagCompound playerTag = cachedPlayerList.getCompoundTagAt(i);
+            UUID tagUUID = new UUID(playerTag.getLong("UUIDMost"), playerTag.getLong("UUIDLeast"));
+
+            if (playerUUID.equals(tagUUID)) {
+                restoreInventory(player, playerTag);
+                found = true;
+            } else {
+                updatedList.appendTag(playerTag);
+            }
+        }
+
+        if (found) {
+            cachedPlayerList = updatedList;
+            dirty = true;
+            saveIfDirty();
+        }
+    }
+
+    private static void restoreInventory(EntityPlayer player, NBTTagCompound playerTag) {
+        if (!playerTag.hasKey("Inventory", 9)) return;
+
+        NBTTagList inventory = playerTag.getTagList("Inventory", 10);
+        for (int j = 0; j < inventory.tagCount(); j++) {
+            ItemStack stack = ItemStack.loadItemStackFromNBT(inventory.getCompoundTagAt(j));
+            if (stack != null) {
+                if (!player.inventory.addItemStackToInventory(stack)) {
+                    player.entityDropItem(stack, 0);
+                }
+            }
+        }
+        player.inventoryContainer.detectAndSendChanges();
+        Common.log.info("[TG Recovery] Restored items to {}.", player.getCommandSenderName());
+    }
+
+    public static void initialize() {
+        WorldServer world = DimensionManager.getWorld(0);
+        dataFile = new File(world.getSaveHandler().getWorldDirectory(), "data/TG-SaveData.dat");
+
+        if (!dataFile.exists() || dataFile.length() == 0) {
+            Common.log.info("[TG Recovery] No TG-SaveData.dat file found.");
+            clearCache();
+            return;
+        }
+
+        try (FileInputStream in = new FileInputStream(dataFile)) {
+            cachedRoot = CompressedStreamTools.readCompressed(in);
+            cachedData = cachedRoot.getCompoundTag("data");
+            cachedPlayerList = cachedData.getTagList("playerList", 10);
+            Common.log.info("[TG Recovery] Loaded TG-SaveData.dat with {} entries.", cachedPlayerList.tagCount());
+        } catch (Exception e) {
+            Common.log.error("[TG Recovery] Failed to load TG-SaveData.dat.", e);
+            clearCache();
+        }
+    }
+
+    private static void saveIfDirty() {
+        if (!dirty || dataFile == null) return;
+
+        if (cachedPlayerList.tagCount() == 0) {
+            deleteFile();
+            return;
+        }
+
+        try {
+            CompressedStreamTools.write(cachedRoot, dataFile);
+            dirty = false;
+            Common.log.info("[TG Recovery] Saved updated TG-SaveData.dat.");
+        } catch (IOException e) {
+            Common.log.error("[TG Recovery] Failed to save TG-SaveData.dat.", e);
+        }
+    }
+
+    private static void deleteFile() {
+        if (dataFile.delete()) {
+            Common.log.info("[TG Recovery] TG-SaveData.dat is empty, file deleted.");
+        } else {
+            Common.log.warn("[TG Recovery] Failed to delete empty TG-SaveData.dat.");
+        }
+
+        clearCache();
+
+        if (FMLCommonHandler.instance().getSide().isServer()) {
+            FixesConfig.returnTravellersGearItems = false;
+            Common.log.info("[TG Recovery] Automatically disabled recovery config on server with no TG-SaveData.dat.");
+        }
+    }
+
+    private static void clearCache() {
+        cachedRoot = new NBTTagCompound();
+        cachedData = new NBTTagCompound();
+        cachedPlayerList = new NBTTagList();
+        dirty = false;
+    }
+}


### PR DESCRIPTION
Return items placed in Traveller's Gear slots after the mod is removed when players log in.
Sends messages to the log that start with "[Hodgepodge]: [TG Recovery]".
Removes players from the TG items file after returning items. Deletes it if it's empty.
Automatically disables itself on servers after deleting the TG items file.
Clients leave it on to allow for joining multiple SP worlds with TG items.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20458