### PR TITLE
Fix shift clicking leading to ghost items

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
@@ -41,11 +41,10 @@ public abstract class MixinContainer_FixShiftRecursion {
                 return null;
             }
 
-            ItemStack itemstack = null;
-            for (ItemStack tempStack = this.transferStackInSlot(player, slotId); tempStack != null
-                    && hodgepodge$areItemsEqual(targetSlot.getStack(), tempStack); tempStack = this
-                            .transferStackInSlot(player, slotId)) {
-                itemstack = tempStack.copy();
+            ItemStack tempStack = this.transferStackInSlot(player, slotId);
+            ItemStack itemstack = tempStack.copy();
+            while (tempStack != null && hodgepodge$areItemsEqual(targetSlot.getStack(), tempStack)) {
+                tempStack = this.transferStackInSlot(player, slotId);
             }
 
             return itemstack;


### PR DESCRIPTION
https://github.com/GTNewHorizons/Hodgepodge/pull/521 created a new regression:
When using the GTNH "Energy Infuser", you can use an "Input Bus" to charge batteries. When you shift click an item out of the bus while it's charging, it will leave behind a ghost item.

NetHandlerPlayServer.java has
```
    public void processClickWindow(C0EPacketClickWindow packetIn)
    {
        this.playerEntity.func_143004_u();

        if (this.playerEntity.openContainer.windowId == packetIn.func_149548_c() && this.playerEntity.openContainer.isPlayerNotUsingContainer(this.playerEntity))
        {
            ItemStack itemstack = this.playerEntity.openContainer.slotClick(packetIn.func_149544_d(), packetIn.func_149543_e(), packetIn.func_149542_h(), this.playerEntity);

            if (ItemStack.areItemStacksEqual(packetIn.func_149546_g(), itemstack))
```

However, where Minecraft normally returns a valid `ItemStack` from `slotClick`, the HodgePodge function returns `null`.
This leads to `areItemStacksEqual(null, null)`, taking the `true` branch where before it took the `false` branch.

```
this.playerEntity.isChangingQuantityOnly = true;
this.playerEntity.openContainer.detectAndSendChanges();
this.playerEntity.updateHeldItem();
this.playerEntity.isChangingQuantityOnly = false;
```
This `isChangingQuantityOnly` flag leads to no updates being sent down in EntityPlayerMP.

Not 100% sure if that's the correct  fix or if that breaks more things. Can the original authors please take a look?