### PR TITLE
Cache last matching crafting recipe

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,18 +16,18 @@ dependencies {
 
     compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.2") { transitive = false }
 
-    transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.7.66-GTNH:dev") // force a more up-to-date NEI version
-    transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-665-GTNH")
+    transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.7.69-GTNH:dev") // force a more up-to-date NEI version
+    transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-671-GTNH")
     transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:Steve-s-Factory-Manager:1.3.4-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.6.7:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.410:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.422:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.2-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.3.1:dev") // Do not update, fixed afterwards
+    transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.3.2:dev") // Do not update, fixed afterwards
     transformedModCompileOnly("com.github.GTNewHorizons:Railcraft:9.16.32:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
-    transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.46-GTNH:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.48-GTNH:dev")
     transformedModCompileOnly(rfg.deobf("curse.maven:bibliocraft-228027:2423369"))
     transformedModCompileOnly(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612"))
     transformedModCompileOnly("curse.maven:cofh-core-69162:2388751")
@@ -66,9 +66,9 @@ dependencies {
     devOnlyNonPublishable(deobf("https://github.com/makamys/CoreTweaks/releases/download/0.3.3.2/CoreTweaks-1.7.10-0.3.3.2+nomixin.jar"))
 
     // For testing - HP and AF are liable to mixin the same targets
-    runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.6:dev")
+    runtimeOnlyNonPublishable("maven.modrinth:archaicfix:0.7.7:dev")
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ArchaicFix:99.0.0:dev") // mavenLocal location
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.1.55:dev") // for the pregenerator
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.1.57:dev") // for the pregenerator
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Angelica:1.0.0-beta53:dev") // for TPS graph
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -91,10 +91,15 @@ public class SpeedupsConfig {
     @Config.RequiresMcRestart
     public static boolean speedupRemoveFormatting;
 
-    @Config.Comment("Cache last matching recipe in crafting manager")
+    @Config.Comment("Cache last matching recipes in crafting manager")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean cacheLastMatchingRecipe;
+
+    @Config.Comment("Cache size for the last matching recipes in crafting manager")
+    @Config.DefaultInt(64)
+    @Config.RequiresMcRestart
+    public static int recipeCacheSize;
 
     // Biomes O' Plenty
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -91,6 +91,11 @@ public class SpeedupsConfig {
     @Config.RequiresMcRestart
     public static boolean speedupRemoveFormatting;
 
+    @Config.Comment("Cache last matching recipe in crafting manager")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean cacheLastMatchingRecipe;
+
     // Biomes O' Plenty
 
     @Config.Comment("Speedup biome fog rendering in BiomesOPlenty")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -718,6 +718,10 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.getBoolean("hodgepodge.logEventTimes"))
             .addCommonMixins("fml.MixinEventBus_DebugRegistration")),
+    CACHE_LAST_MATCHING_RECIPE(new MixinBuilder()
+            .setPhase(Phase.EARLY)
+            .setApplyIf(() -> SpeedupsConfig.cacheLastMatchingRecipe)
+            .addCommonMixins("minecraft.MixinCraftingManager")),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")
@@ -804,12 +808,12 @@ public enum Mixins implements IMixins {
             .addRequiredMod(TargetedMod.IC2)
             .setPhase(Phase.LATE)),
     IC2_SPEEDUP_REACTOR_SIZE_COMPUTATION(new MixinBuilder()
-        .addCommonMixins(
-            "ic2.MixinTEReactorCacheReactorSize",
-                "ic2.MixinDirection_Memory")
-        .setApplyIf(() -> SpeedupsConfig.speedupIC2ReactorSize)
-        .addRequiredMod(TargetedMod.IC2)
-        .setPhase(Phase.LATE)),
+            .addCommonMixins(
+                    "ic2.MixinTEReactorCacheReactorSize",
+                    "ic2.MixinDirection_Memory")
+            .setApplyIf(() -> SpeedupsConfig.speedupIC2ReactorSize)
+            .addRequiredMod(TargetedMod.IC2)
+            .setPhase(Phase.LATE)),
 
     // Disable update checkers
     COFH_CORE_UPDATE_CHECK(new MixinBuilder("Yeet COFH Core Update Check")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -715,13 +715,13 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> TweaksConfig.hungerGameRule)
             .setPhase(Phase.EARLY)),
     DEBUG_EVENT_REGISTRATION(new MixinBuilder()
-            .setPhase(Phase.EARLY)
+            .addCommonMixins("fml.MixinEventBus_DebugRegistration")
             .setApplyIf(() -> Boolean.getBoolean("hodgepodge.logEventTimes"))
-            .addCommonMixins("fml.MixinEventBus_DebugRegistration")),
+            .setPhase(Phase.EARLY)),
     CACHE_LAST_MATCHING_RECIPES(new MixinBuilder()
-            .setPhase(Phase.EARLY)
+            .addCommonMixins("minecraft.MixinCraftingManager")
             .setApplyIf(() -> SpeedupsConfig.cacheLastMatchingRecipe)
-            .addCommonMixins("minecraft.MixinCraftingManager")),
+            .setPhase(Phase.EARLY)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -718,7 +718,7 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> Boolean.getBoolean("hodgepodge.logEventTimes"))
             .addCommonMixins("fml.MixinEventBus_DebugRegistration")),
-    CACHE_LAST_MATCHING_RECIPE(new MixinBuilder()
+    CACHE_LAST_MATCHING_RECIPES(new MixinBuilder()
             .setPhase(Phase.EARLY)
             .setApplyIf(() -> SpeedupsConfig.cacheLastMatchingRecipe)
             .addCommonMixins("minecraft.MixinCraftingManager")),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCraftingManager.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCraftingManager.java
@@ -1,0 +1,51 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(CraftingManager.class)
+public class MixinCraftingManager {
+
+    @Unique
+    private IRecipe hp$lastMatch = null;
+
+    @Inject(
+            method = "findMatchingRecipe",
+            at = @At(value = "CONSTANT", args = "intValue=0", shift = At.Shift.BEFORE),
+            slice = @Slice(
+                    from = @At(
+                            value = "INVOKE",
+                            target = "Lnet/minecraft/item/ItemStack;<init>(Lnet/minecraft/item/Item;II)V"),
+                    to = @At(value = "INVOKE", target = "Ljava/util/List;size()I", remap = false)),
+            cancellable = true)
+    private void testCachedRecipe(InventoryCrafting inventory, World world, CallbackInfoReturnable<ItemStack> cir) {
+        if (hp$lastMatch != null) {
+            if (hp$lastMatch.matches(inventory, world)) {
+                cir.setReturnValue(hp$lastMatch.getCraftingResult(inventory));
+            }
+        }
+    }
+
+    @Inject(
+            method = "findMatchingRecipe",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/crafting/IRecipe;getCraftingResult(Lnet/minecraft/inventory/InventoryCrafting;)Lnet/minecraft/item/ItemStack;",
+                    shift = At.Shift.BEFORE))
+    private void updateCachedRecipe(InventoryCrafting inventory, World world, CallbackInfoReturnable<ItemStack> cir,
+            @Local IRecipe irecipe) {
+        hp$lastMatch = irecipe;
+    }
+}


### PR DESCRIPTION
Makes recipe matching faster by re-ordering the recipe list when there is a match to move the matched recipe at the start of the list thus making subsequent matches faster.