### PR TITLE
fix thaumcraft check for ee3

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -667,6 +667,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixNullHandlingItemWispEssence;
 
+    @Config.Comment("Fix check for EE3 item in Thaumcraft to prevent issues on modern Java.")
+    @Config.DefaultBoolean(true)
+    public static boolean fixThaumcraftEE3Check;
+
     // Thermal Dynamics
 
     @Config.Comment("Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -976,7 +976,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixNullHandlingItemWispEssence)
             .addRequiredMod(TargetedMod.THAUMCRAFT)
             .setPhase(Phase.LATE)),
-    FIX_THAUMCRAFT_CHECK_FOR_EE3_ITEM(new MixinBuilder("Fix check for EE3 item in Thaumcraft")
+    FIX_THAUMCRAFT_CHECK_FOR_EE3_ITEM(new MixinBuilder()
             .addCommonMixins("thaumcraft.MixinUtils")
             .setApplyIf(() -> FixesConfig.fixThaumcraftEE3Check)
             .addRequiredMod(TargetedMod.THAUMCRAFT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -976,6 +976,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixNullHandlingItemWispEssence)
             .addRequiredMod(TargetedMod.THAUMCRAFT)
             .setPhase(Phase.LATE)),
+    FIX_THAUMCRAFT_CHECK_FOR_EE3_ITEM(new MixinBuilder("Fix check for EE3 item in Thaumcraft")
+            .addCommonMixins("thaumcraft.MixinUtils")
+            .setApplyIf(() -> FixesConfig.fixThaumcraftEE3Check)
+            .addRequiredMod(TargetedMod.THAUMCRAFT)
+            .setPhase(Phase.LATE)),
 
     // BOP
     FIX_QUICKSAND_XRAY(new MixinBuilder("Fix Xray through block without collision boundingBox")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
@@ -3,19 +3,37 @@ package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
 import net.minecraft.item.Item;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
 
 import cpw.mods.fml.common.Loader;
 
 @Mixin(thaumcraft.common.lib.utils.Utils.class)
 public class MixinUtils {
 
-    @Inject(method = "isEETransmutionItem", at = @At("HEAD"), remap = false, cancellable = true)
-    private static void hodgepodge$checkEEModExist(Item item, CallbackInfoReturnable<Boolean> ci) {
-        if (!Loader.isModLoaded("ee")) {
-            ci.cancel();
+    @Unique
+    private static boolean hp$initEECheck;
+
+    @Unique
+    @SuppressWarnings("rawtypes")
+    private static Class hp$classEE;
+
+    @Overwrite(remap = false)
+    @SuppressWarnings("unchecked")
+    public static boolean isEETransmutionItem(Item item) {
+        if (!hp$initEECheck) {
+            if (Loader.isModLoaded("ee")) {
+                try {
+                    hp$classEE = Class.forName("com.pahimar.ee3.item.ITransmutationStone");
+                } catch (Exception var3) {
+                    ;
+                }
+            }
+            hp$initEECheck = true;
         }
+        if (hp$classEE != null && hp$classEE.isAssignableFrom(item.getClass())) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
+
+import net.minecraft.item.Item;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import cpw.mods.fml.common.Loader;
+
+@Mixin(thaumcraft.common.lib.utils.Utils.class)
+public class MixinUtils {
+
+    @Inject(method = "isEETransmutionItem", at = @At("HEAD"), remap = false, cancellable = true)
+    private static void hodgepodge$checkEEModExist(Item item, CallbackInfoReturnable<Boolean> ci) {
+        if (!Loader.isModLoaded("ee")) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
@@ -15,25 +15,22 @@ public class MixinUtils {
     private static boolean hp$initEECheck;
 
     @Unique
-    @SuppressWarnings("rawtypes")
-    private static Class hp$classEE;
+    private static Class<?> hp$classEE;
 
+    /**
+     * @author Pilzinsel64
+     * @reason fix cascading ClassNotFoundException + Cache reflection
+     */
     @Overwrite(remap = false)
-    @SuppressWarnings("unchecked")
     public static boolean isEETransmutionItem(Item item) {
         if (!hp$initEECheck) {
             if (Loader.isModLoaded("ee")) {
                 try {
                     hp$classEE = Class.forName("com.pahimar.ee3.item.ITransmutationStone");
-                } catch (Exception var3) {
-                    ;
-                }
+                } catch (Exception ignored) {}
             }
             hp$initEECheck = true;
         }
-        if (hp$classEE != null && hp$classEE.isAssignableFrom(item.getClass())) {
-            return true;
-        }
-        return false;
+        return hp$classEE != null && hp$classEE.isAssignableFrom(item.getClass());
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinUtils.java
@@ -24,12 +24,12 @@ public class MixinUtils {
     @Overwrite(remap = false)
     public static boolean isEETransmutionItem(Item item) {
         if (!hp$initEECheck) {
+            hp$initEECheck = true;
             if (Loader.isModLoaded("ee")) {
                 try {
                     hp$classEE = Class.forName("com.pahimar.ee3.item.ITransmutationStone");
                 } catch (Exception ignored) {}
             }
-            hp$initEECheck = true;
         }
         return hp$classEE != null && hp$classEE.isAssignableFrom(item.getClass());
     }


### PR DESCRIPTION
Add a check for the mod before trying to get the class to avoid issues on modern java due bad practice.

Ref: https://discord.com/channels/181078474394566657/603348502637969419/1403832924322795632

Original:
```
public static boolean isEETransmutionItem(Item item) {
   try {
      String itemClass = "com.pahimar.ee3.item.ITransmutationStone";
      Class ee = Class.forName(itemClass);
      if(ee.isAssignableFrom(item.getClass())) {
         return true;
      }
   } catch (Exception var3) {
      ;
   }
   return false;
}
```