### PR TITLE
Fix night vision mixin crash with forge AT

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityRenderer_NightVisionFade.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityRenderer_NightVisionFade.java
@@ -14,21 +14,23 @@ public class MixinEntityRenderer_NightVisionFade {
 
     /**
      * Originally from: <a href=
-     * "https://git.sr.ht/~nnnotcharsy/exp5core/tree/master/item/src/main/java/dev/charsy/exp5core/mixins/early/minecraft/MixinEntityRenderer.java">exp5core</a>
-     * 
-     * @author Charsy89
+     * "https://github.com/Tesseract4D/BetterEffects/blob/master/src/main/java/mods/tesseract/bettereffects/FixesEffects.java">exp5core
+     * </a>
+     *
+     * @author Tesseract4D
      * @reason When the Night Vision effect is wearing off, the surrounding light is made dark and bright in a sine-wave
      *         pattern. This can be disorienting for some users, so here we make it "fade out" instead.
      */
+    // we intentionally widen the visibility of the method to avoid
+    // crashing if a forge AT also widens the visibility of this method
+    @SuppressWarnings("visibility")
     @Overwrite
-    private float getNightVisionBrightness(EntityPlayer plr, float renderPartialTicks) {
-        int potionDuration = plr.getActivePotionEffect(Potion.nightVision).getDuration();
-        float effectiveDuration = potionDuration - renderPartialTicks;
-
-        if (effectiveDuration > TweaksConfig.fadeNightVisionDuration) {
+    public float getNightVisionBrightness(EntityPlayer player, float partialTicks) {
+        final int i = player.getActivePotionEffect(Potion.nightVision).getDuration();
+        if (i > TweaksConfig.fadeNightVisionDuration) {
             return 1f;
         } else {
-            return effectiveDuration / (float) TweaksConfig.fadeNightVisionDuration;
+            return ((float) i - partialTicks) / (float) TweaksConfig.fadeNightVisionDuration;
         }
     }
 }


### PR DESCRIPTION
If a forge AT widens the visibility of the method, when we overwrite it to make it private it will cause a crash because it is not allowed to decrease visibility. Making the overwrite public directly solves that issue.

fix crash : https://github.com/GTNewHorizons/Hodgepodge/pull/598#issuecomment-3172963964