### PR TITLE
Reference correct mod in hotlink text (Javadoc-only change)

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityRenderer_NightVisionFade.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityRenderer_NightVisionFade.java
@@ -14,7 +14,7 @@ public class MixinEntityRenderer_NightVisionFade {
 
     /**
      * Originally from: <a href=
-     * "https://github.com/Tesseract4D/BetterEffects/blob/master/src/main/java/mods/tesseract/bettereffects/FixesEffects.java">exp5core
+     * "https://github.com/Tesseract4D/BetterEffects/blob/master/src/main/java/mods/tesseract/bettereffects/FixesEffects.java">BetterEffects
      * </a>
      *
      * @author Tesseract4D


### PR DESCRIPTION
Updates the hotlink in the Javadoc attached to `MixinEntityRenderer_NightVisionFade#getNightVisionBrightness` to reference the correct mod by name.

This PR does not change any code, but is intended to prevent confusion or even conflict. Personally, I do not want my mod's name leading to an unrelated mod. (For anyone reviewing who doesn't know, the hotlink used to lead to my mod's repository since that's where it was discovered, but #603 forgot to change the hotlink text when putting the original URL).