### PR TITLE
Emit a `KeyInputEvent` when a mouse button is pressed

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -390,6 +390,10 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixMinecraftServerLeak;
 
+    @Config.Comment("Fire a keyboard event when mouse buttons are pressed (makes mouse button bindings work across all mods that only check for keyboard input)")
+    @Config.DefaultBoolean(true)
+    public static boolean fixMouseButtonBindings;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -773,6 +773,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinHideDeprecatedIdNotice")
             .setApplyIf(() -> TweaksConfig.hideDeprecatedIdNotice)
             .setPhase(Phase.EARLY)),
+    FIX_MOUSE_BUTTON_BINDINGS(new MixinBuilder()
+            .addClientMixins("minecraft.MixinMinecraft_KeyInputEventOnMouseButton")
+            .setApplyIf(() -> FixesConfig.fixMouseButtonBindings)
+            .setPhase(Phase.EARLY)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_KeyInputEventOnMouseButton.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_KeyInputEventOnMouseButton.java
@@ -1,0 +1,28 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+
+import org.lwjgl.input.Mouse;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft_KeyInputEventOnMouseButton {
+
+    @Inject(
+            method = "runTick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcpw/mods/fml/common/FMLCommonHandler;fireMouseInput()V",
+                    shift = At.Shift.AFTER))
+    public void hodgepodge$fireMouseButtonPressAsKeyInputEvent(CallbackInfo ci) {
+        if (Mouse.getEventButton() != -1) {
+            FMLCommonHandler.instance().fireKeyInput();
+        }
+    }
+
+}


### PR DESCRIPTION
This is a proof of concept that emerged after the discussion on https://github.com/GTNewHorizons/TinkersConstruct/pull/205 where I fixed TC's keybindings not working on mouse buttons.

Handling keybinding in Forge for 1.7.10 seems a bit bare-bones: if a mod wants to associate an action with a keypress on the keyboard, it sets up a `KeyBinding` and listens for the `KeyInputEvent`. However, the event is sent every time *any* key is pressed on the keyboard, regardless of which specific key a mod is interested in. So each mod has to check all its own keybindings upon receiving the event to see if it's even relevant.

While Minecraft allows to easily configure keybindings on mouse buttons, these are not delivered by the `KeyInputEvent`, but by the `MouseInputEvent`.  This is probably rooted in how lwjgl represents mouse and keyboard buttons separately. This means each mod that registers a keybinding has to explicitly check for mouse events as well to see if a mouse button has been pressed. Unsurprisingly, many mods don't implement that. See the discussion in https://github.com/GTNewHorizons/TinkersConstruct/pull/205, which mentions Tinker's Construct, TravellersGearNeo, and EnderIO as examples that needed fixing. This leads to a bit of whack-a-mole trying to fix these issues (annoying with ARR mods of course...).

Moreover, the `MouseInputEvent` is also emitted on mouse movement, which needs additional care to avoid overhead if a mod wants to support mouse buttons explicitly, but is not interested in mouse movement.

My proposed solution modifies Minecraft's gameloop to also emit a `KeyInputEvent` (in addition to a `MouseInputEvent`) if it detects that a mouse button has been pressed. This should free us from having to make each mod individually compatible with mouse buttons. I have no idea if this is sufficiently robust. Brief testing with GTNH fully loaded hasn't given me any issues so far. I don't think doubled events (a mouse button press will now emit both a `MouseInputEvent` and a `KeyInputEvent`) will be an issue here as all the mods are already doing their own keybind checking as mentioned above anyway. Though, I can imagine this could interfere with other mods that modify input or keybind handling (it seems to work fine with GTNH, but consider hodgepodge's relevance outside of that modpack).

I'd very much appreciate feedback here.

/cc @sisyphussy 