### PR TITLE
Fix Witchery Demon not able to be put in Ender IO Soul Vial

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -740,9 +740,9 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixWitcheryRendering;
 
-    @Config.Comment({"Prevent the Witchery Demon's trading menu from opening when shift-clicking.",
-        "This allows for some item interactions that are otherwise impossible,",
-        "such as capturing the Demon in an EnderIO Soul Vial."})
+    @Config.Comment({ "Prevent the Witchery Demon's trading menu from opening when shift-clicking.",
+            "This allows for some item interactions that are otherwise impossible,",
+            "such as capturing the Demon in an EnderIO Soul Vial." })
     @Config.DefaultBoolean(true)
     public static boolean fixWitcheryDemonShiftClick;
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -740,6 +740,12 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixWitcheryRendering;
 
+    @Config.Comment({"Prevent the Witchery Demon's trading menu from opening when shift-clicking.",
+        "This allows for some item interactions that are otherwise impossible,",
+        "such as capturing the Demon in an EnderIO Soul Vial."})
+    @Config.DefaultBoolean(true)
+    public static boolean fixWitcheryDemonShiftClick;
+
     // Xaero's Minimap
     @Config.Comment("Fixes the player entity dot rendering when arrow is chosen")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1378,6 +1378,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixWitcheryRendering)
             .addRequiredMod(TargetedMod.WITCHERY)
             .setPhase(Phase.LATE)),
+    FIX_WITCHERY_DEMON_SHIFT_CLICK(new MixinBuilder("Prevent the Witchery Demon's trading menu from opening when shift-clicking")
+            .addCommonMixins("witchery.MixinEntityDemon")
+            .setApplyIf(() -> FixesConfig.fixWitcheryDemonShiftClick)
+            .addRequiredMod(TargetedMod.WITCHERY)
+            .setPhase(Phase.LATE)),
 
     // Various Exploits/Fixes
     BIBLIOCRAFT_PACKET_FIX(new MixinBuilder("Packet Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityDemon.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityDemon.java
@@ -1,0 +1,18 @@
+package com.mitchej123.hodgepodge.mixins.late.witchery;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import com.emoniph.witchery.entity.EntityDemon;
+
+@SuppressWarnings("UnusedMixin")
+@Mixin(EntityDemon.class)
+public abstract class MixinEntityDemon {
+
+    @WrapMethod(method = "interact")
+    private boolean hodgepodge$fixDemonShiftClick(EntityPlayer player, Operation<Boolean> original) {
+        if(player.isSneaking()) return false;
+        return original.call(player);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityDemon.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinEntityDemon.java
@@ -1,10 +1,12 @@
 package com.mitchej123.hodgepodge.mixins.late.witchery;
 
+import net.minecraft.entity.player.EntityPlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.emoniph.witchery.entity.EntityDemon;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import net.minecraft.entity.player.EntityPlayer;
-import org.spongepowered.asm.mixin.Mixin;
-import com.emoniph.witchery.entity.EntityDemon;
 
 @SuppressWarnings("UnusedMixin")
 @Mixin(EntityDemon.class)
@@ -12,7 +14,7 @@ public abstract class MixinEntityDemon {
 
     @WrapMethod(method = "interact")
     private boolean hodgepodge$fixDemonShiftClick(EntityPlayer player, Operation<Boolean> original) {
-        if(player.isSneaking()) return false;
+        if (player.isSneaking()) return false;
         return original.call(player);
     }
 }


### PR DESCRIPTION
This PR Adds a Mixin to prevent the Witchery Demon's trading menu from opening when right-clicking while holding shift. This allows for certain items to work on demons, such as the Soul Vial from Ender IO.

A new setting was added to enable/disable this fix (Default: True).

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17040