### PR TITLE
fix: make the item thrower mixin backward compatible

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS0EPacketSpawnObject_ItemThrower.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS0EPacketSpawnObject_ItemThrower.java
@@ -41,9 +41,11 @@ public class MixinS0EPacketSpawnObject_ItemThrower implements S0EPacketSpawnObje
 
     @Inject(method = "readPacketData", at = @At("TAIL"))
     private void hodgepodge$read(PacketBuffer data, CallbackInfo ci) throws IOException {
-        final String name = data.readStringFromBuffer(16);
-        hodgepodge$itemThrower = name.isEmpty() ? null : name;
-        hodgepodge$pickupDelay = data.readInt();
+        if (data.readableBytes() >= 6) {
+            final String name = data.readStringFromBuffer(16);
+            hodgepodge$itemThrower = name.isEmpty() ? null : name;
+            hodgepodge$pickupDelay = data.readInt();
+        }
     }
 
     @Override


### PR DESCRIPTION
Uses the same logic as the one used with the FixDimensionID mixin.
Closes https://github.com/GTNewHorizons/Hodgepodge/issues/581