### PR TITLE
Logging for cross thread nbt access

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/LoggingNBTTagMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoggingNBTTagMap.java
@@ -1,5 +1,7 @@
 package com.mitchej123.hodgepodge;
 
+import java.util.HashSet;
+
 import cpw.mods.fml.common.FMLLog;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
@@ -7,34 +9,34 @@ public class LoggingNBTTagMap<K, V> extends Object2ObjectOpenHashMap<K, V> {
 
     Thread thread;
 
+    private static final HashSet<Object> warned = new HashSet<>();
+
     public LoggingNBTTagMap() {
         thread = Thread.currentThread();
     }
 
+    private void check(Object k) {
+        if (thread != Thread.currentThread()) {
+            synchronized (warned) {
+                if (!warned.contains(k)) {
+                    warned.add(k);
+                    FMLLog.warning("Cross thread access in NBTTagCompound!");
+                    Thread.dumpStack();
+                }
+            }
+
+        }
+    }
+
     @Override
     public V put(final K k, final V v) {
-        if (thread != Thread.currentThread()) {
-            FMLLog.warning("Cross thread access in NBTTagCompound!");
-            Thread.dumpStack();
-        }
+        check(k);
         return super.put(k, v);
     }
 
     @Override
     public V remove(Object k) {
-        if (thread != Thread.currentThread()) {
-            FMLLog.warning("Cross thread access in NBTTagCompound!");
-            Thread.dumpStack();
-        }
+        check(k);
         return super.remove(k);
-    }
-
-    @Override
-    public void clear() {
-        if (thread != Thread.currentThread()) {
-            FMLLog.warning("Cross thread access in NBTTagCompound!");
-            Thread.dumpStack();
-        }
-        super.clear();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/LoggingNBTTagMap.java
+++ b/src/main/java/com/mitchej123/hodgepodge/LoggingNBTTagMap.java
@@ -1,0 +1,40 @@
+package com.mitchej123.hodgepodge;
+
+import cpw.mods.fml.common.FMLLog;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+public class LoggingNBTTagMap<K, V> extends Object2ObjectOpenHashMap<K, V> {
+
+    Thread thread;
+
+    public LoggingNBTTagMap() {
+        thread = Thread.currentThread();
+    }
+
+    @Override
+    public V put(final K k, final V v) {
+        if (thread != Thread.currentThread()) {
+            FMLLog.warning("Cross thread access in NBTTagCompound!");
+            Thread.dumpStack();
+        }
+        return super.put(k, v);
+    }
+
+    @Override
+    public V remove(Object k) {
+        if (thread != Thread.currentThread()) {
+            FMLLog.warning("Cross thread access in NBTTagCompound!");
+            Thread.dumpStack();
+        }
+        return super.remove(k);
+    }
+
+    @Override
+    public void clear() {
+        if (thread != Thread.currentThread()) {
+            FMLLog.warning("Cross thread access in NBTTagCompound!");
+            Thread.dumpStack();
+        }
+        super.clear();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/asm/transformers/mc/NBTTagCompoundHashMapTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/asm/transformers/mc/NBTTagCompoundHashMapTransformer.java
@@ -22,7 +22,7 @@ public class NBTTagCompoundHashMapTransformer implements IClassTransformer {
     public static final String INIT = "<init>";
     public static final String EMPTY_DESC = "()V";
     public static final String HASHMAP = "java/util/HashMap";
-    public static final String FASTUTIL_HASHMAP = "it/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMap";
+    public static final String FASTUTIL_HASHMAP = "com/mitchej123/hodgepodge/LoggingNBTTagMap";
     public static final String NBT_TAG_COMPOUND = "net.minecraft.nbt.NBTTagCompound";
 
     @Override


### PR DESCRIPTION
This adds some logging, including stacktrace, if a thread modifies an NBTTagCompound.

The logging is done only once per key to avoid spamming, should still be useful though.
There is a few cases we can't get rid off (better questing, GT), but those look harmless to me.

This helped debugging https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20296 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20139

Maybe worth having in case the issue persists after https://github.com/GTNewHorizons/NotEnoughItems/pull/730, or in case that solution is not accepted. Might be worth hiding behind a config, dunno. Open for suggestions, putting this here for discussion.