### PR TITLE
Disable simulation distance by default

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/SimulationDistanceHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/SimulationDistanceHelper.java
@@ -45,7 +45,7 @@ public class SimulationDistanceHelper {
      * Mark a chunk as no to be simulated, or reset that state. Not thread safe!
      */
     public static void preventChunkSimulation(World world, long packedChunkPos, boolean prevent) {
-        if (!FixesConfig.addSimulationDistance) {
+        if (!FixesConfig.addSimulationDistance_WIP) {
             return;
         }
         ISimulationDistanceWorld mixin = (ISimulationDistanceWorld) world;

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -200,9 +200,9 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixTooManyAllocationsChunkPositionIntPair;
 
-    @Config.Comment("Add option to separate simulation distance from rendering distance (Incompatible with optifine, will automatically be disabled)")
-    @Config.DefaultBoolean(true)
-    public static boolean addSimulationDistance;
+    @Config.Comment("[Experimental] Add option to separate simulation distance from rendering distance (Incompatible with optifine, will automatically be disabled). WARNING: May lead to TPS issues")
+    @Config.DefaultBoolean(false)
+    public static boolean addSimulationDistance_WIP;
 
     @Config.Comment("Fix RCON Threading by forcing it to run on the main thread")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -400,7 +400,7 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean avoidDroppingItemsWhenClosing;
 
-    @Config.Comment("Simulation distance (needs addSimulationDistance to be active)")
+    @Config.Comment("Simulation distance (needs addSimulationDistance_WIP to be active)")
     @Config.DefaultInt(32)
     public static int simulationDistance;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -42,7 +42,7 @@ public enum Mixins implements IMixins {
                     "minecraft.MixinWorld_SimulationDistance",
                     "minecraft.MixinWorldServer_SimulationDistance",
                     "minecraft.MixinChunk_SimulationDistance")
-            .setApplyIf(() -> FixesConfig.addSimulationDistance)
+            .setApplyIf(() -> FixesConfig.addSimulationDistance_WIP)
             .setPhase(Phase.EARLY)),
     FIX_RCON_THREADING(new MixinBuilder("Fix RCON Threading by forcing it to run on the main thread")
             .addServerMixins("minecraft.MixinMinecraftServer_RconThreadingFix")
@@ -53,7 +53,7 @@ public enum Mixins implements IMixins {
             .addExcludedMod(TargetedMod.OPTIFINE)
             .addExcludedMod(TargetedMod.ULTRAMINE)
             .addCommonMixins("minecraft.MixinWorldServer_SimulationDistanceThermosFix")
-            .setApplyIf(() -> FixesConfig.addSimulationDistance)
+            .setApplyIf(() -> FixesConfig.addSimulationDistance_WIP)
             .setPhase(Phase.EARLY)),
     FIX_RESOURCEPACK_FOLDER_OPENING(new MixinBuilder("Fix resource pack folder sometimes not opening on windows")
             .addClientMixins("minecraft.MixinGuiScreenResourcePacks")


### PR DESCRIPTION
From my understanding, this solves the TPS issues + weird ticking stuff. (Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21612)

This changes the config's name so that it gets disabled by default for everyone.

NEEDS TO BE IN 2.8.1