### PR TITLE
Don't apply mixins for IC2 classic

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -41,7 +41,7 @@ public enum TargetedMod implements ITargetMod {
     HUNGER_OVERHAUL("HungerOverhaul"),
     // Target only IC2, not IC2 Classic. Both have the same mod id.
     IC2(new TargetModBuilder().setTargetClass("ic2.core.IC2")
-            .testModAnnotation(null, name -> !name.contains("Classic"), null)),
+            .testModAnnotation(modId -> modId.equals("IC2"), name -> !name.contains("Classic"), null)),
     IMMERSIVE_ENGINENEERING("ImmersiveEngineering"),
     JOURNEYMAP("journeymap"),
     LOTR("lotr.common.coremod.LOTRLoadingPlugin", "lotr"),


### PR DESCRIPTION
Those mixins won't work with IC2 classic, but they both have the same modId. That's why I oped to check the mod name itself.

I checked that the mixins don't get applied for IC2 Classic, and using IC2 they get applied, verified by debugging my logic and the output inside `.mixin.out`