### PR TITLE
FixShiftRecursion: Check slot every iteration

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinContainer_FixShiftRecursion.java
@@ -44,7 +44,8 @@ public abstract class MixinContainer_FixShiftRecursion {
             ItemStack tempStack = this.transferStackInSlot(player, slotId);
             if (tempStack == null) return null;
             ItemStack itemstack = tempStack.copy();
-            while (tempStack != null && hodgepodge$areItemsEqual(targetSlot.getStack(), tempStack)) {
+            while (tempStack != null && hodgepodge$areItemsEqual(targetSlot.getStack(), tempStack)
+                    && targetSlot.canTakeStack(player)) {
                 tempStack = this.transferStackInSlot(player, slotId);
             }
 


### PR DESCRIPTION
No idea how 1.12 where this comes from handles this, but in 1.7.10 the slot gets checked each iteration. I brought back that behavior to mimic vanilla behavior as closely as possible.