### PR TITLE
Remove numeric ID deprecation notice

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -429,4 +429,7 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static double netherPortalRatio;
 
+    @Config.Comment("Remove the notice about numeric ID deprecation that appears when a command uses them")
+    @Config.DefaultBoolean(true)
+    public static boolean hideDeprecatedIdNotice;
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -761,14 +761,17 @@ public enum Mixins implements IMixins {
     REMOVE_INVALID_ENTITES(new MixinBuilder()
             .addCommonMixins("minecraft.MixinChunk_FixInvalidEntity")
             .setApplyIf(() -> FixesConfig.removeInvalidChunkEntites)
-            .setPhase(Phase.EARLY)
-    ),
+            .setPhase(Phase.EARLY)),
     SPEEDUP_TILE_DESCRIPTION_PACKETS(new MixinBuilder("Batch S35PacketUpdateTileEntity Packets")
             .addCommonMixins(
                     "minecraft.tiledescriptions.MixinEntityPlayerMP",
                     "minecraft.tiledescriptions.MixinPlayerInstance",
                     "forge.tiledescriptions.MixinForgeHooks")
             .setApplyIf(() -> SpeedupsConfig.batchDescriptionPacketsMixins)
+            .setPhase(Phase.EARLY)),
+    HIDE_DEPRECATED_ID_NOTICE(new MixinBuilder()
+            .addClientMixins("minecraft.MixinHideDeprecatedIdNotice")
+            .setApplyIf(() -> TweaksConfig.hideDeprecatedIdNotice)
             .setPhase(Phase.EARLY)),
 
     // Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinHideDeprecatedIdNotice.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinHideDeprecatedIdNotice.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.IChatComponent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(CommandBase.class)
+public class MixinHideDeprecatedIdNotice {
+
+    @Redirect(
+            method = "getBlockByText",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/command/ICommandSender;addChatMessage(Lnet/minecraft/util/IChatComponent;)V"))
+    private static void hodgepodge$doNotAddChatMessageBlock(ICommandSender sender, IChatComponent message) {}
+
+    @Redirect(
+            method = "getItemByText",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/command/ICommandSender;addChatMessage(Lnet/minecraft/util/IChatComponent;)V"))
+    private static void hodgepodge$doNotAddChatMessageItem(ICommandSender sender, IChatComponent message) {}
+}


### PR DESCRIPTION
Makes warning messages such as the one below no longer appear. Applies to both blocks and items.

<img src="https://github.com/user-attachments/assets/4c29afea-6747-4444-88da-520c9308365c" />

Tested in full pack and dev env with /setblock and /give