### PR TITLE
Fix missing mixin in prod

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlock_LighterWater.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlock_LighterWater.java
@@ -5,7 +5,6 @@ import net.minecraft.block.Block;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
-import org.spongepowered.asm.mixin.injection.Slice;
 
 @Mixin(Block.class)
 public class MixinBlock_LighterWater {
@@ -14,17 +13,19 @@ public class MixinBlock_LighterWater {
             method = "registerBlocks",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/block/Block;setLightOpacity(I)Lnet/minecraft/block/Block;"),
-            slice = @Slice(
-                    from = @At(
-                            value = "INVOKE",
-                            target = "Lnet/minecraft/block/BlockDynamicLiquid;<init>(Lnet/minecraft/block/material/Material;)V",
-                            ordinal = 0),
-                    to = @At(
-                            value = "INVOKE",
-                            target = "Lnet/minecraft/block/BlockDynamicLiquid;<init>(Lnet/minecraft/block/material/Material;)V",
-                            ordinal = 1)))
-    private static int angelica$decraseWaterOpacity(int in) {
+                    target = "Lnet/minecraft/block/Block;setLightOpacity(I)Lnet/minecraft/block/Block;",
+                    ordinal = 0))
+    private static int hodge$decreaseFlowingWaterOpacity(int in) {
+        return 1;
+    }
+
+    @ModifyArg(
+            method = "registerBlocks",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/Block;setLightOpacity(I)Lnet/minecraft/block/Block;",
+                    ordinal = 1))
+    private static int hodge$decreaseWaterOpacity(int in) {
         return 1;
     }
 }


### PR DESCRIPTION
I don't know *why* this slice failed, but hopefully the ordinal-based check is more robust.