### PR TITLE
Allow players in Creative to eat food.

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -196,6 +196,11 @@ public class TweaksConfig {
     @Config.RequiresMcRestart
     public static boolean hideTextureErrors;
 
+    @Config.Comment("Allows players in Creative to eat food.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean allowEatingFoodInCreative;
+
     // NBT String Pooling
 
     @Config.Comment("Enable string pooling for NBT TagCompound Keys")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -785,6 +785,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinMinecraftServer_UpdateClientDifficulty")
             .setApplyIf(() -> FixesConfig.updateClientDifficultyOnServer)
             .setPhase(Phase.EARLY)),
+    EAT_FOOD_IN_CREATIVE(new MixinBuilder("Allow players to eat food in Creative")
+            .addCommonMixins("minecraft.MixinEntityPlayer_EatInCreative", "minecraft.MixinItemFood_DontConsumeCreative")
+            .setApplyIf(() -> TweaksConfig.allowEatingFoodInCreative)
+            .setPhase(Phase.EARLY)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityPlayer_EatInCreative.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityPlayer_EatInCreative.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.PlayerCapabilities;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+@Mixin(EntityPlayer.class)
+public abstract class MixinEntityPlayer_EatInCreative {
+
+    @Shadow
+    public PlayerCapabilities capabilities;
+
+    @ModifyReturnValue(method = "canEat", at = @At("RETURN"))
+    private boolean disableCreativeCheck(boolean returnValue) {
+        return returnValue || this.capabilities.isCreativeMode;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemFood_DontConsumeCreative.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemFood_DontConsumeCreative.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+
+@Mixin(ItemFood.class)
+public abstract class MixinItemFood_DontConsumeCreative {
+
+    @WrapWithCondition(
+            method = "onEaten",
+            at = @At(value = "FIELD", target = "Lnet/minecraft/item/ItemStack;stackSize:I", opcode = Opcodes.PUTFIELD))
+    private boolean shouldReduceStack(ItemStack instance, int value, @Local(argsOnly = true) EntityPlayer player) {
+        return !player.capabilities.isCreativeMode;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemSoup.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemSoup.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.sugar.Local;
+import com.mitchej123.hodgepodge.config.TweaksConfig;
 
 @Mixin(ItemSoup.class)
 public class MixinItemSoup extends ItemFood {
@@ -30,6 +31,8 @@ public class MixinItemSoup extends ItemFood {
     @Inject(at = @At("HEAD"), method = "onEaten")
     private void hodgepodge$fixStackDeletion(ItemStack p_77654_1_, World p_77654_2_, EntityPlayer p_77654_3_,
             CallbackInfoReturnable<ItemStack> cir) {
+        if (TweaksConfig.allowEatingFoodInCreative && p_77654_3_.capabilities.isCreativeMode) return;
+
         ItemStack emptyBowl = new ItemStack(Items.bowl);
 
         if (!p_77654_3_.inventory.addItemStackToInventory(emptyBowl)) {


### PR DESCRIPTION
Closes #688.

(note: there is one mild inconsistency with modern: if the `fixEatingStackedStew` config is disabled, eating Mushroom Stew will consume it in Creative nonetheless. I find this too minor to fix.)