### PR TITLE
compare NBT when switching item in hand

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemRenderer_FixInstantItemSwitch.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemRenderer_FixInstantItemSwitch.java
@@ -3,34 +3,59 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.item.Item;
 
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ItemRenderer.class)
 public class MixinItemRenderer_FixInstantItemSwitch {
 
+    @Shadow
+    private ItemStack itemToRender;
+
     /**
      * @author danyadev
      * @reason When a player switches an item in their hand, there's an animation that hides the previous item and shows
-     *         the new item. The problem is that when the items have the same id and meta but different NBT, this
-     *         animation breaks: at the beginning of the hiding animation the item is already new. For example, this
+     *         the new item. The problem is that when the items have the same id and meta but different NBT, the
+     *         animation breaks: at the beginning of the hiding animation the item is already new. For example, it
      *         happens when you switch from a normal sword to an enchanted sword
      * @see <a href="https://github.com/GTNewHorizons/Hodgepodge/pull/666">PR with a demo</a>
      */
-    @ModifyExpressionValue(
+    @Redirect(
             method = "updateEquippedItem",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/item/ItemStack;getItem()Lnet/minecraft/item/Item;",
                     ordinal = 0))
-    private Item hodgepodge$setItemNull(Item original) {
-        // The problem is that the method checks if the items are the same-ish, but the check
-        // ignores any differences in NBT.
-        // In order to fix it we're just making this check to never pass, so we're always seeing
-        // the animation. We're setting newItemStack.getItem() to null (just inside the condition,
-        // not really) when usually it's never null
+    private Item hodgepodge$compareNBT(ItemStack newItemToRender) {
+        // This is the only part of the condition we can change to control the results, because ItemStack.getItem()
+        // under normal circumstances is not null, so returning null here should prevent the condition from passing.
+
+        // Copy the original checks here because it's cheaper to run them twice than to compare NBTs for nothing
+        if (itemToRender.getItem() != newItemToRender.getItem()) {
+            return null;
+        }
+        if (itemToRender.getItemDamage() != newItemToRender.getItemDamage()) {
+            return null;
+        }
+
+        NBTTagCompound oldTag = itemToRender.getTagCompound();
+        NBTTagCompound newTag = newItemToRender.getTagCompound();
+
+        if (oldTag == null || newTag == null) {
+            if (oldTag == newTag) {
+                return newItemToRender.getItem();
+            }
+            return null;
+        }
+
+        if (oldTag.equals(newTag)) {
+            return newItemToRender.getItem();
+        }
         return null;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemRenderer_FixInstantItemSwitch.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItemRenderer_FixInstantItemSwitch.java
@@ -1,14 +1,14 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.item.Item;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ItemRenderer.class)
@@ -16,6 +16,8 @@ public class MixinItemRenderer_FixInstantItemSwitch {
 
     @Shadow
     private ItemStack itemToRender;
+    @Shadow
+    private int equippedItemSlot;
 
     /**
      * @author danyadev
@@ -34,6 +36,11 @@ public class MixinItemRenderer_FixInstantItemSwitch {
     private Item hodgepodge$compareNBT(ItemStack newItemToRender) {
         // This is the only part of the condition we can change to control the results, because ItemStack.getItem()
         // under normal circumstances is not null, so returning null here should prevent the condition from passing.
+
+        // If slot hasn't changed, do not compare NBT: for example, TinkersConstruct's tools use NBT extensively
+        if (this.equippedItemSlot == Minecraft.getMinecraft().thePlayer.inventory.currentItem) {
+            return newItemToRender.getItem();
+        }
 
         // Copy the original checks here because it's cheaper to run them twice than to compare NBTs for nothing
         if (itemToRender.getItem() != newItemToRender.getItem()) {


### PR DESCRIPTION
fixes #714, improves mixin from #666

also fixes bounces when holding an item that its changes NBT, for example Tinkers Construct's crossbow when it's recharging or any other TC tool when it takes damage

my initial lazy solution didn't work out well....

https://github.com/user-attachments/assets/835c4d13-09af-4851-8a37-c81a05f38460

a counter of mentions of this issue on discord: 2 [bump](https://discord.com/channels/181078474394566657/603348502637969419/1461537548429033659) [bump](https://discord.com/channels/181078474394566657/522098956491030558/1469236806628278418)