### PR TITLE
disable GT-like IC2 cells behavior by default

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -317,7 +317,7 @@ public class TweaksConfig {
     public static boolean hideIc2ReactorSlots;
 
     @Config.Comment("Give IC2 cells containers like GregTech cells do")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     public static boolean ic2CellWithContainer;
 
     @Config.Comment("IC2 seed max stack size")


### PR DESCRIPTION
fixes #537
see https://github.com/GTNewHorizons/Hodgepodge/pull/256#issuecomment-1762741750