### PR TITLE
update deps

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,13 +18,13 @@ dependencies {
 
     transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.8.48-GTNH:dev") // force a more up-to-date NEI version
     transformedModCompileOnly("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-775-GTNH")
-    transformedModCompileOnly("com.github.GTNewHorizons:Baubles:1.0.4:dev")
+    transformedModCompileOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
     // Transitive updates to make runClient17 work
     transformedModCompileOnly("com.github.GTNewHorizons:Steve-s-Factory-Manager:1.3.4-GTNH:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:ForgeMultipart:1.7.2:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.190:dev")
     transformedModCompileOnly("com.github.GTNewHorizons:harvestcraft:1.3.6-GTNH:dev")
-    transformedModCompileOnly("com.github.GTNewHorizons:HungerOverhaul:1.1.0-GTNH:dev")
+    transformedModCompileOnly(rfg.deobf("curse.maven:hunger-overhaul-224476:2332505"))
     transformedModCompileOnly("com.github.GTNewHorizons:MrTJPCore:1.3.4:dev") // Do not update, fixed afterwards
     transformedModCompileOnly("com.github.GTNewHorizons:Railcraft:9.17.12:dev") { exclude group: "thaumcraft", module: "Thaumcraft" }
     transformedModCompileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.17-GTNH:dev")


### PR DESCRIPTION
Baubles was moved to museum org so i used Baubles Expanded
HungerOverhaul is linked to curse project since we not use our forked anymore