### PR TITLE
Improved redstone wire hitbox from 1.12

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -103,6 +103,10 @@ public class TweaksConfig {
     @Config.DefaultBoolean(false)
     public static boolean fastBlockPlacing;
 
+    @Config.Comment("Add a accurate hitbox to the redstone wire")
+    @Config.DefaultBoolean(true)
+    public static boolean improvedRedstoneWireHitbox;
+
     @Config.Comment("Allow players on your server to use fast block placement")
     @Config.DefaultBoolean(true)
     public static boolean fastBlockPlacingServerSide;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -804,6 +804,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinTileEntityPiston", "minecraft.MixinBlockPistonBase")
             .setApplyIf(() -> FixesConfig.fixInvalidPistonCrashes)
             .setPhase(Phase.EARLY)),
+    IMPROVE_REDSTONE_HITBOX(new MixinBuilder("Add a accurate hitbox to the redstone wire")
+            .addCommonMixins("minecraft.MixinBlockRedstoneWire_Hitbox")
+            .setApplyIf(() -> TweaksConfig.improvedRedstoneWireHitbox)
+            .setPhase(Phase.EARLY)),
     FIX_INSTANT_HAND_ITEM_TEXTURE_SWITCH(new MixinBuilder()
             .addClientMixins("minecraft.MixinItemRenderer_FixInstantItemSwitch")
             .setApplyIf(() -> FixesConfig.fixInstantHandItemTextureSwitch)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockRedstoneWire_Hitbox.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockRedstoneWire_Hitbox.java
@@ -1,0 +1,84 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockRedstoneWire;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.IBlockAccess;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(BlockRedstoneWire.class)
+public abstract class MixinBlockRedstoneWire_Hitbox extends Block {
+
+    protected MixinBlockRedstoneWire_Hitbox(Material material) {
+        super(material);
+    }
+
+    /**
+     * @author John
+     * @reason Make Block Bounds of Redstone more accurate depending on state.
+     */
+    public void setBlockBoundsBasedOnState(IBlockAccess blockAccess, int x, int y, int z) {
+        boolean flag = BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x - 1, y, z, 1)
+                || !blockAccess.getBlock(x - 1, y, z).isBlockNormalCube()
+                        && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x - 1, y - 1, z, -1);
+        boolean flag1 = BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x + 1, y, z, 3)
+                || !blockAccess.getBlock(x + 1, y, z).isBlockNormalCube()
+                        && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x + 1, y - 1, z, -1);
+        boolean flag2 = BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x, y, z - 1, 2)
+                || !blockAccess.getBlock(x, y, z - 1).isBlockNormalCube()
+                        && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x, y - 1, z - 1, -1);
+        boolean flag3 = BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x, y, z + 1, 0)
+                || !blockAccess.getBlock(x, y, z + 1).isBlockNormalCube()
+                        && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x, y - 1, z + 1, -1);
+
+        if (!blockAccess.getBlock(x, y + 1, z).isBlockNormalCube()) {
+            if (blockAccess.getBlock(x - 1, y, z).isBlockNormalCube()
+                    && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x - 1, y + 1, z, -1)) {
+                flag = true;
+            }
+
+            if (blockAccess.getBlock(x + 1, y, z).isBlockNormalCube()
+                    && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x + 1, y + 1, z, -1)) {
+                flag1 = true;
+            }
+
+            if (blockAccess.getBlock(x, y, z - 1).isBlockNormalCube()
+                    && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x, y + 1, z - 1, -1)) {
+                flag2 = true;
+            }
+
+            if (blockAccess.getBlock(x, y, z + 1).isBlockNormalCube()
+                    && BlockRedstoneWire.isPowerProviderOrWire(blockAccess, x, y + 1, z + 1, -1)) {
+                flag3 = true;
+            }
+        }
+
+        float gap = 0.2F;
+        float gap2 = gap;
+        float gap3 = gap;
+        float gap4 = gap2;
+        if (flag) {
+            gap = 0.0F;
+        }
+        if (flag1) {
+            gap2 = 0.0F;
+        }
+        if (flag2) {
+            gap3 = 0.0F;
+        }
+        if (flag3) {
+            gap4 = 0.0F;
+        }
+        if ((flag || flag1) && !flag2 && !flag3) {
+            gap = 0.0F;
+            gap2 = 0.0F;
+        }
+        if ((flag2 || flag3) && !flag && !flag1) {
+            gap3 = 0.0F;
+            gap4 = 0.0F;
+        }
+        this.setBlockBounds(gap, 0.0F, gap3, 1 - gap2, 0.0625F, 1 - gap4);
+
+    }
+}


### PR DESCRIPTION
Backported the redstone wire from 1.12, where it is more accurate instead of just a flat plane.
Since it doesn't have any function, I don't need to do any Overwrite or inject, and i can just the function in the block.

<img width="1600" height="837" alt="2026-02-14_23 16 48" src="https://github.com/user-attachments/assets/74ec96f8-55cb-4c48-991b-5c0697d7b090" />
