### PR TITLE
Bump priority due to conflict with bugtorch

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/MixinBlock_FastLookup.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/MixinBlock_FastLookup.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.Unique;
 import com.mitchej123.hodgepodge.mixins.hooks.BlockLookupHooks;
 import com.mitchej123.hodgepodge.mixins.interfaces.BlockExt_FastLookup;
 
-@Mixin(Block.class)
+@Mixin(value = Block.class, priority = 1100)
 public class MixinBlock_FastLookup implements BlockExt_FastLookup {
 
     @Unique


### PR DESCRIPTION
Fixes this

```
[23:05:23] [main/WARN] [mixin]: Method overwrite conflict for func_149729_e in mixins.hodgepodge.early.json:minecraft.fastload.MixinBlock_FastLookup from mod hodgepodge, previously written by jss.bugtorch.mixins.early.minecraft.optimization.MixinBlock. Skipping method.
```