### PR TITLE
[Memory-opti:runtime allocations] Replace Enum.values() calls in forge configuration Property$Type

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/rfb/transformers/EnumASMHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/rfb/transformers/EnumASMHelper.java
@@ -1,5 +1,7 @@
 package com.mitchej123.hodgepodge.core.rfb.transformers;
 
+import java.util.ListIterator;
+
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
@@ -19,7 +21,9 @@ public class EnumASMHelper implements Opcodes {
     }
 
     public static String findInternalArrayName(String classname, MethodNode valuesMethod) {
-        for (AbstractInsnNode node : valuesMethod.instructions.toArray()) {
+        final ListIterator<AbstractInsnNode> it = valuesMethod.instructions.iterator();
+        while (it.hasNext()) {
+            final AbstractInsnNode node = it.next();
             if (node.getOpcode() == INVOKEVIRTUAL && node instanceof MethodInsnNode mNode
             // && mNode.owner.equals("[L" + classname + ";") // in kotlin the owner is Object
                     && mNode.name.equals("clone")

--- a/src/main/java/com/mitchej123/hodgepodge/core/rfb/transformers/ForgeConfigurationTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/rfb/transformers/ForgeConfigurationTransformer.java
@@ -1,5 +1,6 @@
 package com.mitchej123.hodgepodge.core.rfb.transformers;
 
+import java.util.ListIterator;
 import java.util.jar.Manifest;
 
 import org.intellij.lang.annotations.Pattern;
@@ -168,13 +169,14 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer, Opcod
 
         for (MethodNode mn : cn.methods) {
             if (mn.name.equals("tryParse") && mn.desc.equals("(C)Lnet/minecraftforge/common/config/Property$Type;")) {
-                for (AbstractInsnNode node : mn.instructions.toArray()) {
+                final ListIterator<AbstractInsnNode> it = mn.instructions.iterator();
+                while (it.hasNext()) {
+                    final AbstractInsnNode node = it.next();
                     if (node instanceof MethodInsnNode mNode && node.getOpcode() == INVOKESTATIC
                             && mNode.owner.equals("net/minecraftforge/common/config/Property$Type")
                             && mNode.name.equals("values")
                             && mNode.desc.equals("()[Lnet/minecraftforge/common/config/Property$Type;")) {
-                        mn.instructions.set(
-                                node,
+                        it.set(
                                 new FieldInsnNode(
                                         GETSTATIC,
                                         "net/minecraftforge/common/config/Property$Type",
@@ -182,6 +184,7 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer, Opcod
                                         "[Lnet/minecraftforge/common/config/Property$Type;"));
                     }
                 }
+                return;
             }
         }
     }


### PR DESCRIPTION
This method results in `values()` getting called 1 060 000 times during boot which results in lots of unnecessary memory allocations.

<img width="959" height="245" alt="image" src="https://github.com/user-attachments/assets/7c7cc6d4-42d9-43ea-8a52-21ab6a5c5b03" />
