### PR TITLE
[Memory-opti:runtime allocations] Prevent grass tick from loading nearby chunks

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockGrass.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinBlockGrass.java
@@ -8,6 +8,7 @@ import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(BlockGrass.class)
 public class MixinBlockGrass {
@@ -21,25 +22,36 @@ public class MixinBlockGrass {
     public void updateTick(World worldIn, int x, int y, int z, Random random) {
         if (worldIn.isRemote) return;
 
+        if (!hodgepodge$canGetBlockLightSafely(worldIn, x, z)) {
+            return;
+        }
         int blockLightValue = worldIn.getBlockLightValue(x, y + 1, z);
         if (blockLightValue < 4 && worldIn.getBlockLightOpacity(x, y + 1, z) > 2) {
             worldIn.setBlock(x, y, z, Blocks.dirt);
         } else if (blockLightValue >= 9) {
             for (int i = 0; i < 4; ++i) {
-                int targetX = x + random.nextInt(3) - 1;
-                int targetY = y + random.nextInt(5) - 3;
-                int targetZ = z + random.nextInt(3) - 1;
+                final int targetX = x + random.nextInt(3) - 1;
+                final int targetY = y + random.nextInt(5) - 3;
+                final int targetZ = z + random.nextInt(3) - 1;
 
                 if (targetX == x && targetZ == z && (targetY == y || targetY == y - 1)) continue;
                 if (!worldIn.blockExists(targetX, targetY, targetZ)) continue;
 
                 if (worldIn.getBlock(targetX, targetY, targetZ) == Blocks.dirt
                         && worldIn.getBlockMetadata(targetX, targetY, targetZ) == 0
-                        && worldIn.getBlockLightValue(targetX, targetY + 1, targetZ) >= 4
-                        && worldIn.getBlockLightOpacity(targetX, targetY + 1, targetZ) <= 2) {
+                        && worldIn.getBlockLightOpacity(targetX, targetY + 1, targetZ) <= 2
+                        && hodgepodge$canGetBlockLightSafely(worldIn, targetX, targetZ)
+                        && worldIn.getBlockLightValue(targetX, targetY + 1, targetZ) >= 4) {
                     worldIn.setBlock(targetX, targetY, targetZ, Blocks.grass);
                 }
             }
         }
+    }
+
+    @Unique
+    private static boolean hodgepodge$canGetBlockLightSafely(World worldIn, int x, int z) {
+        return worldIn.blockExists(x + 1, 0, z) && worldIn.blockExists(x, 0, z + 1)
+                && worldIn.blockExists(x - 1, 0, z)
+                && worldIn.blockExists(x, 0, z - 1);
     }
 }


### PR DESCRIPTION
The call to `World#getBlockLightValue` loads the 4 blocks nearby which causes the chunks to load if the grass block is at the edge of the render distance. If fixed it by checking first if the blocks nearby are loaded.

<img width="280" height="523" alt="image" src="https://github.com/user-attachments/assets/22660e94-a0b4-4b76-9fff-4fb06f9b226d" />
