### PR TITLE
[Memory-opti:runtime allocations] Fix forge config memory bomb

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/rfb/hooks/ForgeConfigurationHook.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/rfb/hooks/ForgeConfigurationHook.java
@@ -59,4 +59,16 @@ public class ForgeConfigurationHook {
         final TreeMap<String, V> sortedMap = new TreeMap<>(map);
         return sortedMap.values();
     }
+
+    public static String getDefaultValues(String[] values) {
+        final StringBuilder sb = new StringBuilder(32 * values.length);
+        for (int i = 0; i < values.length; i++) {
+            if (i == 0) {
+                sb.append("[").append(values[i]).append("]");
+            } else {
+                sb.append(", [").append(values[i]).append("]");
+            }
+        }
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/rfb/transformers/ForgeConfigurationTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/rfb/transformers/ForgeConfigurationTransformer.java
@@ -3,6 +3,8 @@ package com.mitchej123.hodgepodge.core.rfb.transformers;
 import java.util.ListIterator;
 import java.util.jar.Manifest;
 
+import net.minecraftforge.common.config.Property;
+
 import org.intellij.lang.annotations.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -10,10 +12,12 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
 
 import com.gtnewhorizons.retrofuturabootstrap.api.ClassNodeHandle;
 import com.gtnewhorizons.retrofuturabootstrap.api.ExtensibleClassLoader;
@@ -54,7 +58,11 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer, Opcod
             return;
         }
         switch (className) {
-            case "net.minecraftforge.common.config.Property" -> transformProperty(cn);
+            case "net.minecraftforge.common.config.Property" -> {
+                fixStringConcatenationInLoop(cn);
+                transformProperty(cn);
+                classNode.computeMaxs();
+            }
             case "net.minecraftforge.common.config.Property$Type" -> transformPropertyType(cn);
             case "net.minecraftforge.common.config.ConfigCategory" -> transformConfigCategory(cn);
         }
@@ -114,6 +122,96 @@ public class ForgeConfigurationTransformer implements RfbClassTransformer, Opcod
             }
         }
         // spotless:on
+    }
+
+    /**
+     * In the methods
+     * {@link net.minecraftforge.common.config.Property#Property(String, String[], Property.Type, boolean, String[], String)}
+     * and {@link net.minecraftforge.common.config.Property#setDefaultValues(String[])} we want to replace string
+     * concatenation in a loop with a single StringBuilder.
+     *
+     * <pre>
+     * {@code
+     *  // we want to replace this
+     *  this.defaultValue = "";
+     *  for (String s : values) {
+     *      this.defaultValue += ", [" + s + "]";
+     *  }
+     *  this.defaultValue = this.defaultValue.replaceFirst(", ", "");
+     *  // with
+     *  this.defaultValue = ForgeConfigurationHook.getDefaultValues(defaultValues);
+     * </pre>
+     *
+     */
+    private static void fixStringConcatenationInLoop(ClassNode cn) {
+        // we search at the start for : this.defaultValue = "";
+        // and at the end for : this.defaultValue = this.defaultValue.replaceFirst(", ", "");
+        // ALOAD 0 <- we keep (startNode)
+        // LDC "" <- delete everything from here
+        // PUTFIELD defaultValue
+        // ...
+        // ...
+        // INVOKEVIRTUAL java/lang/String.replaceFirst <- delete up to here
+        // PUTFIELD defaultValue <- we keep and inject our hook right before (endNode)
+
+        for (MethodNode mn : cn.methods) {
+            final boolean isConstructor = mn.name.equals("<init>") && mn.desc.equals(
+                    "(Ljava/lang/String;[Ljava/lang/String;Lnet/minecraftforge/common/config/Property$Type;Z[Ljava/lang/String;Ljava/lang/String;)V");
+            final boolean isSetDefault = mn.name.equals("setDefaultValues")
+                    && mn.desc.equals("([Ljava/lang/String;)Lnet/minecraftforge/common/config/Property;");
+            if (isConstructor || isSetDefault) {
+                AbstractInsnNode startNode = null;
+                AbstractInsnNode endNode = null;
+                final ListIterator<AbstractInsnNode> it = mn.instructions.iterator();
+                while (it.hasNext()) {
+                    final AbstractInsnNode node = it.next();
+                    if (node instanceof VarInsnNode varNode && node.getOpcode() == ALOAD && varNode.var == 0) {
+                        if (node.getNext() instanceof LdcInsnNode ldcNode && "".equals(ldcNode.cst)) {
+                            if (isPutDefaultValueFieldNode(ldcNode.getNext())) {
+                                startNode = node;
+                            }
+                        }
+                    } else if (startNode != null && isReplaceFirstMethodNode(node)) {
+                        if (isPutDefaultValueFieldNode(node.getNext())) {
+                            endNode = node.getNext();
+                            break;
+                        }
+                    }
+                }
+                if (startNode != null && endNode != null) {
+                    AbstractInsnNode node = startNode.getNext();
+                    while (node != endNode) {
+                        AbstractInsnNode next = node.getNext();
+                        mn.instructions.remove(node);
+                        node = next;
+                    }
+                    final InsnList list = new InsnList();
+                    list.add(new VarInsnNode(ALOAD, isConstructor ? 2 : 1));
+                    list.add(
+                            new MethodInsnNode(
+                                    INVOKESTATIC,
+                                    HOOK_CLASS_INTERNAL,
+                                    "getDefaultValues",
+                                    "([Ljava/lang/String;)Ljava/lang/String;",
+                                    false));
+                    mn.instructions.insertBefore(endNode, list);
+                }
+            }
+        }
+    }
+
+    private static boolean isPutDefaultValueFieldNode(AbstractInsnNode node) {
+        return node instanceof FieldInsnNode fNode && fNode.getOpcode() == PUTFIELD
+                && fNode.owner.equals(PROPERTY_INTERNAL)
+                && fNode.name.equals("defaultValue")
+                && fNode.desc.equals("Ljava/lang/String;");
+    }
+
+    private static boolean isReplaceFirstMethodNode(AbstractInsnNode node) {
+        return node instanceof MethodInsnNode mNode && mNode.getOpcode() == INVOKEVIRTUAL
+                && mNode.owner.equals("java/lang/String")
+                && mNode.name.equals("replaceFirst")
+                && mNode.desc.equals("(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
     }
 
     private static void transformConfigCategory(ClassNode cn) {


### PR DESCRIPTION
Forge's config system has this very nice piece of code :

<img width="647" height="99" alt="image" src="https://github.com/user-attachments/assets/50d72d56-886a-41b7-b348-671f8255f1b6" />

If you happen to have lots of values in the same property such as https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/blob/master/config/forestry/backpacks.cfg it results in a memory bomb.

I made a heap sampling profile of the pack boot and the results are hilarious, this single piece of code when parsing the forestry config is responsible for 7GB of allocations which represents 56% of the total allocations and takes ~3s on my pc. After the fix the allocations are gone and parsing the config files takes 30ms.

Also changed the transformer code to not add `String#intern()` on strings from the constant pool.

<img width="1920" height="1080" alt="Capture d’écran (539)" src="https://github.com/user-attachments/assets/648246fe-f122-457a-9f45-ab150494cde4" />

<img width="1392" height="275" alt="Capture" src="https://github.com/user-attachments/assets/d522968c-eeaa-47c1-9c31-da0dc4b01ef3" />