### PR TITLE
correctly remap cofh_at field names

### DIFF
--- a/src/main/resources/META-INF/cofh_at.cfg
+++ b/src/main/resources/META-INF/cofh_at.cfg
@@ -1,5 +1,5 @@
 # Remapped from CoFHCore's CoFH_at.cfg in order to be compatible with Forge AT syntax.
-# CoFHCore took care of mcp -> srg remapping, but forge AT is dumb so we have a copy for every mcp field.
+# CoFHCore took care of mcp -> srg remapping, but forge AT compares fields as-is, so we use both mcp and srg names.
 # This config is being included conditionally by the CoFHCoreAccessTransformer:
 # only when CoFHCore is present and ASM config disableCoFHAccessTransformer is enabled
 


### PR DESCRIPTION
CoFHCore had some logic in its own Access Transformer to remap names, but forge AT compares the names as is