### PR TITLE
[Memory-opti:runtime allocations] Prevent entity pathfinding from loading chunks on the server

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -36,6 +36,10 @@ public class SpeedupsConfig {
     @Config.DefaultBoolean(true)
     public static boolean speedupGrassBlockRandomTicking;
 
+    @Config.Comment("Prevents Vanilla entities from loading chunks when pathfinding")
+    @Config.DefaultBoolean(true)
+    public static boolean preventLoadingChunksWhenPathfinding;
+
     @Config.Comment("Speedup Vanilla Furnace recipe lookup")
     @Config.DefaultBoolean(true)
     public static boolean speedupVanillaFurnace;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -214,6 +214,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinBlockGrass")
             .setApplyIf(() -> SpeedupsConfig.speedupGrassBlockRandomTicking)
             .setPhase(Phase.EARLY)),
+    PREVENT_LOADING_CHUNKS_WHEN_PATH_FINDING(new MixinBuilder()
+            .addCommonMixins("minecraft.chunkloading.pathfinding.MixinPathNavigate")
+            .setApplyIf(() -> SpeedupsConfig.preventLoadingChunksWhenPathfinding)
+            .setPhase(Phase.EARLY)),
     SPEEDUP_CHUNK_PROVIDER_CLIENT(new MixinBuilder("Speed up ChunkProviderClient")
             .addClientMixins("minecraft.MixinChunkProviderClient_RemoveChunkListing")
             .addExcludedMod(TargetedMod.FASTCRAFT)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRandomPositionGenerator.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRandomPositionGenerator.java
@@ -1,5 +1,7 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import java.util.Random;
+
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.ai.RandomPositionGenerator;
 import net.minecraft.util.MathHelper;
@@ -7,8 +9,6 @@ import net.minecraft.util.Vec3;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
-
-import com.mitchej123.hodgepodge.Common;
 
 @Mixin(RandomPositionGenerator.class)
 public class MixinRandomPositionGenerator {
@@ -18,7 +18,8 @@ public class MixinRandomPositionGenerator {
      * @reason Backported fix north/west bias
      */
     @Overwrite
-    private static Vec3 findRandomTargetBlock(EntityCreature entityCreature, int hor, int ver, Vec3 facing) {
+    private static Vec3 findRandomTargetBlock(EntityCreature entityCreature, int deltaXZ, int deltaY, Vec3 facing) {
+        Random random = entityCreature.getRNG();
         boolean found = false;
         double tx = 0, ty = 0, tz = 0;
         float bestValue = -99999.0F;
@@ -29,20 +30,20 @@ public class MixinRandomPositionGenerator {
                     MathHelper.floor_double(entityCreature.posX),
                     MathHelper.floor_double(entityCreature.posY),
                     MathHelper.floor_double(entityCreature.posZ)) + 4.0F;
-            final double d1 = entityCreature.func_110174_bM() /* getMaximumHomeDistance() */ + (double) hor;
+            final double d1 = entityCreature.func_110174_bM() /* getMaximumHomeDistance() */ + (double) deltaXZ;
             tooFar = d0 < d1 * d1;
         }
 
         for (int i = 0; i < 10; ++i) {
-            final int x1 = Common.RNG.nextInt(2 * hor + 1) - hor;
-            final int y1 = Common.RNG.nextInt(2 * ver + 1) - ver;
-            final int z1 = Common.RNG.nextInt(2 * hor + 1) - hor;
+            final int randX = random.nextInt(2 * deltaXZ + 1) - deltaXZ;
+            final int randY = random.nextInt(2 * deltaY + 1) - deltaY;
+            final int randZ = random.nextInt(2 * deltaXZ + 1) - deltaXZ;
 
-            if (facing == null || (double) x1 * facing.xCoord + (double) z1 * facing.zCoord >= 0.0D) {
+            if (facing == null || (double) randX * facing.xCoord + (double) randZ * facing.zCoord >= 0.0D) {
                 // Use the rounded coordinates for comparision since `isWithinHomeDistance` takes int params
-                final int x2 = x1 + MathHelper.floor_double(entityCreature.posX);
-                final int y2 = y1 + MathHelper.floor_double(entityCreature.posY);
-                final int z2 = z1 + MathHelper.floor_double(entityCreature.posZ);
+                final int x2 = randX + MathHelper.floor_double(entityCreature.posX);
+                final int y2 = randY + MathHelper.floor_double(entityCreature.posY);
+                final int z2 = randZ + MathHelper.floor_double(entityCreature.posZ);
 
                 if (!tooFar || entityCreature.isWithinHomeDistance(x2, y2, z2)) {
                     final float blockPathWeight = entityCreature.getBlockPathWeight(x2, y2, z2);
@@ -51,12 +52,12 @@ public class MixinRandomPositionGenerator {
                         bestValue = blockPathWeight;
                         // But use the un-rounded coordinates for moving (so we avoid chopping off fractional
                         // coordinates and biasing to the NW)
-                        tx = entityCreature.posX + x1;
-                        ty = entityCreature.posY + y1;
-                        tz = entityCreature.posZ + z1;
+                        tx = entityCreature.posX + randX;
+                        ty = entityCreature.posY + randY;
+                        tz = entityCreature.posZ + randZ;
                         found = true;
                         if (blockPathWeight == 0.0F) {
-                            // Don't keep searching if the black path weight function isn't implemented
+                            // Don't keep searching if the block path weight function isn't implemented
                             break;
                         }
                     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/chunkloading/pathfinding/MixinPathNavigate.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/chunkloading/pathfinding/MixinPathNavigate.java
@@ -1,0 +1,57 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.chunkloading.pathfinding;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.pathfinding.PathEntity;
+import net.minecraft.pathfinding.PathNavigate;
+import net.minecraft.util.MathHelper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PathNavigate.class)
+public abstract class MixinPathNavigate {
+
+    @Shadow
+    public abstract float getPathSearchRange();
+
+    @Shadow
+    private EntityLiving theEntity;
+
+    @Inject(
+            method = "getPathToXYZ",
+            cancellable = true,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/World;getEntityPathToXYZ(Lnet/minecraft/entity/Entity;IIIFZZZZ)Lnet/minecraft/pathfinding/PathEntity;"))
+    private void checkExist(double x, double y, double z, CallbackInfoReturnable<PathEntity> cir) {
+        final int x1 = MathHelper.floor_double(this.theEntity.posX);
+        final int y1 = MathHelper.floor_double(this.theEntity.posY);
+        final int z1 = MathHelper.floor_double(this.theEntity.posZ);
+        final int range = (int) (this.getPathSearchRange() + 8.0F);
+        if (!this.theEntity.worldObj
+                .checkChunksExist(x1 - range, y1 - range, z1 - range, x1 + range, y1 + range, z1 + range)) {
+            cir.setReturnValue(null);
+        }
+    }
+
+    @Inject(
+            method = "getPathToEntityLiving",
+            cancellable = true,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/World;getPathEntityToEntity(Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/Entity;FZZZZ)Lnet/minecraft/pathfinding/PathEntity;"))
+    private void checkExist(Entity other, CallbackInfoReturnable<PathEntity> cir) {
+        final int x1 = MathHelper.floor_double(this.theEntity.posX);
+        final int y1 = MathHelper.floor_double(this.theEntity.posY + 1.0D);
+        final int z1 = MathHelper.floor_double(this.theEntity.posZ);
+        final int range = (int) (this.getPathSearchRange() + 16.0F);
+        if (!this.theEntity.worldObj
+                .checkChunksExist(x1 - range, y1 - range, z1 - range, x1 + range, y1 + range, z1 + range)) {
+            cir.setReturnValue(null);
+        }
+    }
+}


### PR DESCRIPTION
More than 50% of the server load for entities is just loading chunks when pathfinding

<img width="1672" height="913" alt="image" src="https://github.com/user-attachments/assets/fdbf4a18-7911-442c-8bd4-796c395c94ba" />
