### PR TITLE
Backport modern tab (1.12.2+ to 1.7.10)

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -13,6 +13,9 @@ import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.Compat;
 import com.mitchej123.hodgepodge.client.handlers.ClientKeyListener;
 import com.mitchej123.hodgepodge.client.handlers.ReloadSoundsGui;
+import com.mitchej123.hodgepodge.client.tab.ModernTabRenderer;
+import com.mitchej123.hodgepodge.client.tab.TabChannelHandler;
+import com.mitchej123.hodgepodge.client.tab.TabSkinCache;
 import com.mitchej123.hodgepodge.commands.AllocationsCommand;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
@@ -85,6 +88,11 @@ public class HodgepodgeClient {
             }
         }
 
+        if (TweaksConfig.modernTabOverlay) {
+            MinecraftForge.EVENT_BUS.register(ModernTabRenderer.INSTANCE);
+            TabChannelHandler.INSTANCE.registerChannel();
+        }
+
         if (Compat.isBiomesOPlentyPresent() && (Compat.isDreamcraftPresent() || FixesConfig.removeBOPWarning)) {
             // removes the popup that BOP shows on first world gen
             MinecraftForge.EVENT_BUS.unregister(WorldTypeMessageEventHandler.instance);
@@ -106,6 +114,8 @@ public class HodgepodgeClient {
     @SubscribeEvent
     public static void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
         AsyncNBTParser.shutdown();
+        TabSkinCache.INSTANCE.clear();
+        TabChannelHandler.INSTANCE.clear();
         if (MemoryConfig.leaks.fixEntityRendererItemRendererLeak) {
             EntityRenderer entityRenderer = Minecraft.getMinecraft().entityRenderer;
             if (entityRenderer != null) {

--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -13,8 +13,8 @@ import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.Compat;
 import com.mitchej123.hodgepodge.client.handlers.ClientKeyListener;
 import com.mitchej123.hodgepodge.client.handlers.ReloadSoundsGui;
-import com.mitchej123.hodgepodge.client.tab.ModernTabRenderer;
 import com.mitchej123.hodgepodge.client.tab.TabChannelHandler;
+import com.mitchej123.hodgepodge.client.tab.TabDisplayHandler;
 import com.mitchej123.hodgepodge.client.tab.TabSkinCache;
 import com.mitchej123.hodgepodge.commands.AllocationsCommand;
 import com.mitchej123.hodgepodge.config.DebugConfig;
@@ -89,8 +89,8 @@ public class HodgepodgeClient {
         }
 
         if (TweaksConfig.modernTabOverlay) {
-            MinecraftForge.EVENT_BUS.register(ModernTabRenderer.INSTANCE);
             TabChannelHandler.INSTANCE.registerChannel();
+            TabDisplayHandler.INSTANCE.registerChannel();
         }
 
         if (Compat.isBiomesOPlentyPresent() && (Compat.isDreamcraftPresent() || FixesConfig.removeBOPWarning)) {
@@ -116,6 +116,7 @@ public class HodgepodgeClient {
         AsyncNBTParser.shutdown();
         TabSkinCache.INSTANCE.clear();
         TabChannelHandler.INSTANCE.clear();
+        TabDisplayHandler.INSTANCE.clear();
         if (MemoryConfig.leaks.fixEntityRendererItemRendererLeak) {
             EntityRenderer entityRenderer = Minecraft.getMinecraft().entityRenderer;
             if (entityRenderer != null) {

--- a/src/main/java/com/mitchej123/hodgepodge/client/tab/ModernTabRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/tab/ModernTabRenderer.java
@@ -148,7 +148,11 @@ public class ModernTabRenderer {
 
         // Column width: name + head + score + ping text + ping icon + padding
         int pingBarSpace = showPingBars ? PING_ICON_WIDTH + 1 : 0;
-        int entryWidth = headSpace + maxNameWidth + maxScoreWidth + maxSuffixWidth + maxPingTextWidth + pingBarSpace
+        int entryWidth = headSpace + maxNameWidth
+                + maxScoreWidth
+                + maxSuffixWidth
+                + maxPingTextWidth
+                + pingBarSpace
                 + 3;
         int totalGridWidth = Math.min(columns * entryWidth, screenWidth - 50);
         int columnWidth = totalGridWidth / columns;

--- a/src/main/java/com/mitchej123/hodgepodge/client/tab/ModernTabRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/tab/ModernTabRenderer.java
@@ -3,12 +3,14 @@ package com.mitchej123.hodgepodge.client.tab;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiPlayerInfo;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.scoreboard.Score;
@@ -17,13 +19,10 @@ import net.minecraft.scoreboard.ScorePlayerTeam;
 import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.event.RenderGameOverlayEvent;
 
 import org.lwjgl.opengl.GL11;
 
 import com.mitchej123.hodgepodge.config.TweaksConfig;
-
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 /**
  * Replaces the vanilla 1.7.10 tab list with a modern-style renderer matching the 1.12.2+ layout algorithm. Features
@@ -48,33 +47,54 @@ public class ModernTabRenderer {
 
     private ModernTabRenderer() {}
 
-    @SubscribeEvent
-    public void onRenderPlayerList(RenderGameOverlayEvent.Pre event) {
-        if (event.type != RenderGameOverlayEvent.ElementType.PLAYER_LIST) return;
-        if (event.isCanceled()) return;
-
-        event.setCanceled(true);
-
+    /**
+     * Renders the modern tab list. Called from the GuiIngameForge mixin, preserving the Pre/Post event lifecycle so
+     * other mods can interact with the player list overlay event normally.
+     */
+    public void render(ScaledResolution resolution) {
         Minecraft mc = Minecraft.getMinecraft();
         FontRenderer font = mc.fontRenderer;
         NetHandlerPlayClient handler = mc.thePlayer.sendQueue;
         Scoreboard scoreboard = mc.theWorld.getScoreboard();
         ScoreObjective objective = scoreboard.func_96539_a(0);
 
-        int screenWidth = event.resolution.getScaledWidth();
+        int screenWidth = resolution.getScaledWidth();
 
         @SuppressWarnings("unchecked")
         List<GuiPlayerInfo> allPlayers = (List<GuiPlayerInfo>) handler.playerInfoList;
         int playerCount = Math.min(allPlayers.size(), MAX_PLAYERS);
         if (playerCount == 0 && objective == null) return;
 
-        List<GuiPlayerInfo> players = allPlayers.subList(0, playerCount);
+        TabDisplayHandler displayHandler = TabDisplayHandler.INSTANCE;
+
+        // Apply custom sort order if provided by HP|TabUD
+        List<GuiPlayerInfo> players;
+        Map<String, Integer> sortMap = displayHandler.getSortIndexMap();
+        if (sortMap != null && !sortMap.isEmpty()) {
+            players = new ArrayList<>(allPlayers.subList(0, playerCount));
+            players.sort((a, b) -> {
+                Integer idxA = sortMap.get(a.name);
+                Integer idxB = sortMap.get(b.name);
+                if (idxA == null && idxB == null) return a.name.compareToIgnoreCase(b.name);
+                if (idxA == null) return 1;
+                if (idxB == null) return -1;
+                return Integer.compare(idxA, idxB);
+            });
+        } else {
+            players = allPlayers.subList(0, playerCount);
+        }
 
         // Measure widest display name
         int maxNameWidth = 0;
         for (GuiPlayerInfo player : players) {
-            ScorePlayerTeam team = scoreboard.getPlayersTeam(player.name);
-            String displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+            String customName = displayHandler.getDisplayName(player.name);
+            String displayName;
+            if (customName != null) {
+                displayName = customName;
+            } else {
+                ScorePlayerTeam team = scoreboard.getPlayersTeam(player.name);
+                displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+            }
             int w = font.getStringWidth(displayName);
             if (w > maxNameWidth) maxNameWidth = w;
         }
@@ -91,6 +111,30 @@ public class ModernTabRenderer {
             maxScoreWidth += 5; // padding between name and score
         }
 
+        // Measure widest ping text if enabled
+        boolean showPingNumber = TweaksConfig.tabShowPingNumber;
+        boolean showPingBars = TweaksConfig.tabShowPingBars;
+        int maxPingTextWidth = 0;
+        if (showPingNumber) {
+            for (GuiPlayerInfo player : players) {
+                String pingText = formatPing(player.responseTime);
+                int w = font.getStringWidth(pingText);
+                if (w > maxPingTextWidth) maxPingTextWidth = w;
+            }
+            maxPingTextWidth += 2; // padding between ping text and bars
+        }
+
+        // Measure widest suffix (from HP|TabUD)
+        int maxSuffixWidth = 0;
+        for (GuiPlayerInfo player : players) {
+            String suffix = displayHandler.getSuffix(player.name);
+            if (suffix != null) {
+                int w = font.getStringWidth(suffix);
+                if (w > maxSuffixWidth) maxSuffixWidth = w;
+            }
+        }
+        if (maxSuffixWidth > 0) maxSuffixWidth += 5; // padding (same as scoreboard score)
+
         // Calculate column layout
         int columns = 1;
         int rows = playerCount;
@@ -102,8 +146,10 @@ public class ModernTabRenderer {
         boolean showHeads = TweaksConfig.tabShowPlayerHeads;
         int headSpace = showHeads ? HEAD_PADDING : 0;
 
-        // Column width: name + head + score + ping icon + padding
-        int entryWidth = headSpace + maxNameWidth + maxScoreWidth + 13;
+        // Column width: name + head + score + ping text + ping icon + padding
+        int pingBarSpace = showPingBars ? PING_ICON_WIDTH + 1 : 0;
+        int entryWidth = headSpace + maxNameWidth + maxScoreWidth + maxSuffixWidth + maxPingTextWidth + pingBarSpace
+                + 3;
         int totalGridWidth = Math.min(columns * entryWidth, screenWidth - 50);
         int columnWidth = totalGridWidth / columns;
         int gridLeft = (screenWidth - (columnWidth * columns + (columns - 1) * 5)) / 2;
@@ -164,8 +210,14 @@ public class ModernTabRenderer {
             GuiPlayerInfo player = players.get(i);
             activeNames.add(player.name);
 
-            ScorePlayerTeam team = scoreboard.getPlayersTeam(player.name);
-            String displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+            String customName = displayHandler.getDisplayName(player.name);
+            String displayName;
+            if (customName != null) {
+                displayName = customName;
+            } else {
+                ScorePlayerTeam team = scoreboard.getPlayersTeam(player.name);
+                displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+            }
 
             // Entry background
             Gui.drawRect(x, y, x + columnWidth, y + 8, ENTRY_BG_COLOR);
@@ -194,7 +246,7 @@ public class ModernTabRenderer {
             // Scoreboard score
             if (objective != null) {
                 int nameEndX = textX + font.getStringWidth(displayName) + 5;
-                int scoreEndX = x + columnWidth - PING_ICON_WIDTH - 2 - 5;
+                int scoreEndX = x + columnWidth - pingBarSpace - 2 - 5;
                 if (scoreEndX - nameEndX > 5) {
                     Score score = objective.getScoreboard().func_96529_a(player.name, objective);
                     String scoreStr = EnumChatFormatting.YELLOW + "" + score.getScorePoints();
@@ -202,19 +254,36 @@ public class ModernTabRenderer {
                 }
             }
 
+            // Suffix (from HP|TabUD)
+            String suffix = displayHandler.getSuffix(player.name);
+            if (suffix != null) {
+                int suffixRight = x + columnWidth - pingBarSpace - maxPingTextWidth - 2;
+                font.drawStringWithShadow(suffix, suffixRight - font.getStringWidth(suffix), y, -1);
+            }
+
+            // Ping number
+            if (showPingNumber) {
+                String pingText = formatPing(player.responseTime);
+                int pingColor = getPingColor(player.responseTime);
+                int pingTextX = x + columnWidth - pingBarSpace - font.getStringWidth(pingText) - 2;
+                font.drawStringWithShadow(pingText, pingTextX, y, pingColor);
+            }
+
             // Ping bars
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-            Minecraft.getMinecraft().getTextureManager().bindTexture(Gui.icons);
-            int pingLevel = getPingLevel(player.responseTime);
-            Gui.func_146110_a(
-                    x + columnWidth - PING_ICON_WIDTH - 1,
-                    y,
-                    0,
-                    176 + pingLevel * 8,
-                    PING_ICON_WIDTH,
-                    PING_ICON_HEIGHT,
-                    256,
-                    256);
+            if (showPingBars) {
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+                Minecraft.getMinecraft().getTextureManager().bindTexture(Gui.icons);
+                int pingLevel = getPingLevel(player.responseTime);
+                Gui.func_146110_a(
+                        x + columnWidth - PING_ICON_WIDTH - 1,
+                        y,
+                        0,
+                        176 + pingLevel * 8,
+                        PING_ICON_WIDTH,
+                        PING_ICON_HEIGHT,
+                        256,
+                        256);
+            }
         }
 
         // Footer
@@ -258,7 +327,7 @@ public class ModernTabRenderer {
         List<String> lines = new ArrayList<>();
         if (text == null || text.isEmpty()) return lines;
 
-        for (String segment : text.split("\n")) {
+        for (String segment : text.split("\n", -1)) {
             if (segment.isEmpty()) {
                 lines.add("");
                 continue;
@@ -290,5 +359,18 @@ public class ModernTabRenderer {
         if (ping < 600) return 2;
         if (ping < 1000) return 3;
         return 4;
+    }
+
+    private static String formatPing(int ping) {
+        return ping < 0 ? "?" : ping + "ms";
+    }
+
+    private static int getPingColor(int ping) {
+        if (ping < 0) return 0xAAAAAA;
+        if (ping < 150) return 0x55FF55;
+        if (ping < 300) return 0xAAFF55;
+        if (ping < 600) return 0xFFFF55;
+        if (ping < 1000) return 0xFF5555;
+        return 0xAA0000;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/client/tab/ModernTabRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/tab/ModernTabRenderer.java
@@ -1,0 +1,294 @@
+package com.mitchej123.hodgepodge.client.tab;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiPlayerInfo;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.scoreboard.Score;
+import net.minecraft.scoreboard.ScoreObjective;
+import net.minecraft.scoreboard.ScorePlayerTeam;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+
+import org.lwjgl.opengl.GL11;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Replaces the vanilla 1.7.10 tab list with a modern-style renderer matching the 1.12.2+ layout algorithm. Features
+ * dynamic column sizing, player head icons, header/footer text, and scoreboard score display.
+ */
+public class ModernTabRenderer {
+
+    public static final ModernTabRenderer INSTANCE = new ModernTabRenderer();
+
+    private static final int MAX_PLAYERS = 80;
+    private static final int MAX_ROWS = 20;
+    private static final int ENTRY_HEIGHT = 9;
+    private static final int HEAD_SIZE = 8;
+    private static final int HEAD_PADDING = 9;
+    private static final int PING_ICON_WIDTH = 10;
+    private static final int PING_ICON_HEIGHT = 8;
+
+    /** 0x20FFFFFF - semi-transparent white for entry background */
+    private static final int ENTRY_BG_COLOR = 553648127;
+    /** 0x80000000 - semi-transparent black for overall/header/footer background */
+    private static final int OVERLAY_BG_COLOR = Integer.MIN_VALUE;
+
+    private ModernTabRenderer() {}
+
+    @SubscribeEvent
+    public void onRenderPlayerList(RenderGameOverlayEvent.Pre event) {
+        if (event.type != RenderGameOverlayEvent.ElementType.PLAYER_LIST) return;
+        if (event.isCanceled()) return;
+
+        event.setCanceled(true);
+
+        Minecraft mc = Minecraft.getMinecraft();
+        FontRenderer font = mc.fontRenderer;
+        NetHandlerPlayClient handler = mc.thePlayer.sendQueue;
+        Scoreboard scoreboard = mc.theWorld.getScoreboard();
+        ScoreObjective objective = scoreboard.func_96539_a(0);
+
+        int screenWidth = event.resolution.getScaledWidth();
+
+        @SuppressWarnings("unchecked")
+        List<GuiPlayerInfo> allPlayers = (List<GuiPlayerInfo>) handler.playerInfoList;
+        int playerCount = Math.min(allPlayers.size(), MAX_PLAYERS);
+        if (playerCount == 0 && objective == null) return;
+
+        List<GuiPlayerInfo> players = allPlayers.subList(0, playerCount);
+
+        // Measure widest display name
+        int maxNameWidth = 0;
+        for (GuiPlayerInfo player : players) {
+            ScorePlayerTeam team = scoreboard.getPlayersTeam(player.name);
+            String displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+            int w = font.getStringWidth(displayName);
+            if (w > maxNameWidth) maxNameWidth = w;
+        }
+
+        // Measure widest score string if objective active
+        int maxScoreWidth = 0;
+        if (objective != null) {
+            for (GuiPlayerInfo player : players) {
+                Score score = objective.getScoreboard().func_96529_a(player.name, objective);
+                String scoreStr = EnumChatFormatting.YELLOW + "" + score.getScorePoints();
+                int w = font.getStringWidth(scoreStr);
+                if (w > maxScoreWidth) maxScoreWidth = w;
+            }
+            maxScoreWidth += 5; // padding between name and score
+        }
+
+        // Calculate column layout
+        int columns = 1;
+        int rows = playerCount;
+        while (rows > MAX_ROWS) {
+            columns++;
+            rows = (playerCount + columns - 1) / columns;
+        }
+
+        boolean showHeads = TweaksConfig.tabShowPlayerHeads;
+        int headSpace = showHeads ? HEAD_PADDING : 0;
+
+        // Column width: name + head + score + ping icon + padding
+        int entryWidth = headSpace + maxNameWidth + maxScoreWidth + 13;
+        int totalGridWidth = Math.min(columns * entryWidth, screenWidth - 50);
+        int columnWidth = totalGridWidth / columns;
+        int gridLeft = (screenWidth - (columnWidth * columns + (columns - 1) * 5)) / 2;
+        int startY = 10;
+
+        // Resolve header/footer text
+        String headerText = resolveHeaderFooter(true);
+        String footerText = resolveHeaderFooter(false);
+
+        // Word-wrap header/footer
+        List<String> headerLines = wrapText(font, headerText, screenWidth - 50);
+        List<String> footerLines = wrapText(font, footerText, screenWidth - 50);
+
+        // Calculate widths for background sizing
+        int headerMaxWidth = getMaxLineWidth(font, headerLines);
+        int footerMaxWidth = getMaxLineWidth(font, footerLines);
+        int gridWidth = columnWidth * columns + (columns - 1) * 5;
+        int bgWidth = Math.max(gridWidth, Math.max(headerMaxWidth, footerMaxWidth));
+
+        int centerX = screenWidth / 2;
+
+        // Adjust startY for header
+        if (!headerLines.isEmpty()) {
+            int headerHeight = headerLines.size() * font.FONT_HEIGHT;
+            // Draw header background
+            Gui.drawRect(
+                    centerX - bgWidth / 2 - 1,
+                    startY - 1,
+                    centerX + bgWidth / 2 + 1,
+                    startY + headerHeight,
+                    OVERLAY_BG_COLOR);
+            for (String line : headerLines) {
+                int lineWidth = font.getStringWidth(line);
+                font.drawStringWithShadow(line, centerX - lineWidth / 2, startY, -1);
+                startY += font.FONT_HEIGHT;
+            }
+            startY += 1; // 1px gap between header and grid
+        }
+
+        // Draw overall grid background
+        Gui.drawRect(
+                centerX - bgWidth / 2 - 1,
+                startY - 1,
+                centerX + bgWidth / 2 + 1,
+                startY + rows * ENTRY_HEIGHT,
+                OVERLAY_BG_COLOR);
+
+        // Collect active player names for skin cache cleanup
+        Set<String> activeNames = new HashSet<>();
+
+        // Render each entry
+        for (int i = 0; i < playerCount; i++) {
+            int col = i / rows;
+            int row = i % rows;
+            int x = gridLeft + col * (columnWidth + 5);
+            int y = startY + row * ENTRY_HEIGHT;
+
+            GuiPlayerInfo player = players.get(i);
+            activeNames.add(player.name);
+
+            ScorePlayerTeam team = scoreboard.getPlayersTeam(player.name);
+            String displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+
+            // Entry background
+            Gui.drawRect(x, y, x + columnWidth, y + 8, ENTRY_BG_COLOR);
+
+            GL11.glEnable(GL11.GL_ALPHA_TEST);
+            GL11.glEnable(GL11.GL_BLEND);
+            OpenGlHelper.glBlendFunc(770, 771, 1, 0);
+
+            int textX = x;
+
+            // Player head
+            if (showHeads) {
+                ResourceLocation skinLoc = TabSkinCache.INSTANCE.getOrLoadSkin(player.name);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+                Minecraft.getMinecraft().getTextureManager().bindTexture(skinLoc);
+                // Face layer: UV (8,8) to (16,16) on 64x32 skin (1.7.10 skins are always 64x32)
+                Gui.func_152125_a(x, y, 8.0F, 8.0F, 8, 8, HEAD_SIZE, HEAD_SIZE, 64.0F, 32.0F);
+                // Hat overlay layer: UV (40,8) to (48,16) on 64x32 skin
+                Gui.func_152125_a(x, y, 40.0F, 8.0F, 8, 8, HEAD_SIZE, HEAD_SIZE, 64.0F, 32.0F);
+                textX += HEAD_PADDING;
+            }
+
+            // Display name
+            font.drawStringWithShadow(displayName, textX, y, -1);
+
+            // Scoreboard score
+            if (objective != null) {
+                int nameEndX = textX + font.getStringWidth(displayName) + 5;
+                int scoreEndX = x + columnWidth - PING_ICON_WIDTH - 2 - 5;
+                if (scoreEndX - nameEndX > 5) {
+                    Score score = objective.getScoreboard().func_96529_a(player.name, objective);
+                    String scoreStr = EnumChatFormatting.YELLOW + "" + score.getScorePoints();
+                    font.drawStringWithShadow(scoreStr, scoreEndX - font.getStringWidth(scoreStr), y, -1);
+                }
+            }
+
+            // Ping bars
+            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            Minecraft.getMinecraft().getTextureManager().bindTexture(Gui.icons);
+            int pingLevel = getPingLevel(player.responseTime);
+            Gui.func_146110_a(
+                    x + columnWidth - PING_ICON_WIDTH - 1,
+                    y,
+                    0,
+                    176 + pingLevel * 8,
+                    PING_ICON_WIDTH,
+                    PING_ICON_HEIGHT,
+                    256,
+                    256);
+        }
+
+        // Footer
+        if (!footerLines.isEmpty()) {
+            int footerY = startY + rows * ENTRY_HEIGHT + 1;
+            int footerHeight = footerLines.size() * font.FONT_HEIGHT;
+            Gui.drawRect(
+                    centerX - bgWidth / 2 - 1,
+                    footerY - 1,
+                    centerX + bgWidth / 2 + 1,
+                    footerY + footerHeight,
+                    OVERLAY_BG_COLOR);
+            for (String line : footerLines) {
+                int lineWidth = font.getStringWidth(line);
+                font.drawStringWithShadow(line, centerX - lineWidth / 2, footerY, -1);
+                footerY += font.FONT_HEIGHT;
+            }
+        }
+
+        // Cleanup stale skin cache entries
+        TabSkinCache.INSTANCE.cleanup(activeNames);
+
+        // Restore GL state
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+    }
+
+    private static String resolveHeaderFooter(boolean isHeader) {
+        String text;
+        TabChannelHandler ch = TabChannelHandler.INSTANCE;
+        if (ch.hasServerData()) {
+            text = isHeader ? ch.getHeader() : ch.getFooter();
+        } else {
+            text = isHeader ? TweaksConfig.tabHeaderText : TweaksConfig.tabFooterText;
+        }
+        if (text == null || text.isEmpty()) return "";
+        return text.replace("\\n", "\n").replaceAll("&([0-9a-fk-or])", "\u00A7$1");
+    }
+
+    private static List<String> wrapText(FontRenderer font, String text, int maxWidth) {
+        List<String> lines = new ArrayList<>();
+        if (text == null || text.isEmpty()) return lines;
+
+        for (String segment : text.split("\n")) {
+            if (segment.isEmpty()) {
+                lines.add("");
+                continue;
+            }
+            // Simple word wrap
+            @SuppressWarnings("unchecked")
+            List<String> wrapped = font.listFormattedStringToWidth(segment, maxWidth);
+            lines.addAll(wrapped);
+        }
+        return lines;
+    }
+
+    private static int getMaxLineWidth(FontRenderer font, List<String> lines) {
+        int max = 0;
+        for (String line : lines) {
+            int w = font.getStringWidth(line);
+            if (w > max) max = w;
+        }
+        return max;
+    }
+
+    /**
+     * Returns the ping bar icon level (0-5) based on response time in ms. Matches modern Minecraft thresholds.
+     */
+    private static int getPingLevel(int ping) {
+        if (ping < 0) return 5;
+        if (ping < 150) return 0;
+        if (ping < 300) return 1;
+        if (ping < 600) return 2;
+        if (ping < 1000) return 3;
+        return 4;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/client/tab/TabChannelHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/tab/TabChannelHandler.java
@@ -1,0 +1,89 @@
+package com.mitchej123.hodgepodge.client.tab;
+
+import java.nio.charset.StandardCharsets;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mitchej123.hodgepodge.Common;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.network.FMLEventChannel;
+import cpw.mods.fml.common.network.FMLNetworkEvent;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Holds tab header/footer text from two sources:
+ * <ul>
+ * <li>MessageConfigSync on login (Hodgepodge server config)</li>
+ * <li>Plugin channel HP|TabHF (proxy/external server, overrides config sync)</li>
+ * </ul>
+ * A proxy like Velocity can send a S3FPacketCustomPayload on channel "HP|TabHF" with a JSON body
+ * {"header":"...","footer":"..."} to set the tab header/footer for 1.7.10 clients. Cleared on disconnect.
+ */
+public class TabChannelHandler {
+
+    public static final String CHANNEL_NAME = "HP|TabHF";
+    public static final TabChannelHandler INSTANCE = new TabChannelHandler();
+
+    private String header = "";
+    private String footer = "";
+    private boolean hasServerData = false;
+
+    private TabChannelHandler() {}
+
+    /**
+     * Registers the HP|TabHF plugin channel for proxy/external server support.
+     */
+    public void registerChannel() {
+        FMLEventChannel channel = NetworkRegistry.INSTANCE.newEventDrivenChannel(CHANNEL_NAME);
+        channel.register(this);
+    }
+
+    @SubscribeEvent
+    public void onClientPacket(FMLNetworkEvent.ClientCustomPacketEvent event) {
+        try {
+            ByteBuf payload = event.packet.payload();
+            byte[] bytes = new byte[payload.readableBytes()];
+            payload.readBytes(bytes);
+            String json = new String(bytes, StandardCharsets.UTF_8);
+
+            JsonObject obj = new JsonParser().parse(json).getAsJsonObject();
+            String h = obj.has("header") ? obj.get("header").getAsString() : "";
+            String f = obj.has("footer") ? obj.get("footer").getAsString() : "";
+            setServerData(h, f);
+        } catch (Exception e) {
+            Common.log.warn("Failed to parse HP|TabHF packet", e);
+        }
+    }
+
+    /**
+     * Sets the header/footer from server config sync or plugin channel.
+     */
+    public void setServerData(String header, String footer) {
+        this.header = header != null ? header : "";
+        this.footer = footer != null ? footer : "";
+        this.hasServerData = true;
+    }
+
+    /**
+     * Clears server-sent header/footer data. Called on disconnect.
+     */
+    public void clear() {
+        header = "";
+        footer = "";
+        hasServerData = false;
+    }
+
+    public String getHeader() {
+        return header;
+    }
+
+    public String getFooter() {
+        return footer;
+    }
+
+    public boolean hasServerData() {
+        return hasServerData;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/client/tab/TabDisplayHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/tab/TabDisplayHandler.java
@@ -1,0 +1,125 @@
+package com.mitchej123.hodgepodge.client.tab;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mitchej123.hodgepodge.Common;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.network.FMLEventChannel;
+import cpw.mods.fml.common.network.FMLNetworkEvent;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Handles the HP|TabUD plugin channel for display name overrides, suffixes, and custom sort order. When a proxy sends
+ * HP|TabUD data, the modern tab renderer uses it instead of team-based formatting. Falls back to team-based display for
+ * players without overrides.
+ */
+public class TabDisplayHandler {
+
+    public static final String CHANNEL_NAME = "HP|TabUD";
+    public static final TabDisplayHandler INSTANCE = new TabDisplayHandler();
+
+    private final Map<String, String> displayNames = new ConcurrentHashMap<>();
+    private final Map<String, String> suffixes = new ConcurrentHashMap<>();
+    private volatile Map<String, Integer> sortIndexMap;
+
+    private TabDisplayHandler() {}
+
+    public void registerChannel() {
+        FMLEventChannel channel = NetworkRegistry.INSTANCE.newEventDrivenChannel(CHANNEL_NAME);
+        channel.register(this);
+    }
+
+    @SubscribeEvent
+    public void onClientPacket(FMLNetworkEvent.ClientCustomPacketEvent event) {
+        try {
+            ByteBuf payload = event.packet.payload();
+            byte[] bytes = new byte[payload.readableBytes()];
+            payload.readBytes(bytes);
+            String json = new String(bytes, StandardCharsets.UTF_8);
+
+            JsonObject obj = new JsonParser().parse(json).getAsJsonObject();
+            String action = obj.get("action").getAsString();
+
+            switch (action) {
+                case "update":
+                    handleUpdate(obj);
+                    break;
+                case "remove":
+                    handleRemove(obj);
+                    break;
+                case "sort":
+                    handleSort(obj);
+                    break;
+                default:
+                    Common.log.warn("Unknown HP|TabUD action: {}", action);
+            }
+        } catch (Exception e) {
+            Common.log.warn("Failed to parse HP|TabUD packet", e);
+        }
+    }
+
+    private void handleUpdate(JsonObject obj) {
+        JsonObject players = obj.getAsJsonObject("players");
+        for (Map.Entry<String, JsonElement> entry : players.entrySet()) {
+            String name = entry.getKey();
+            JsonObject data = entry.getValue().getAsJsonObject();
+            if (data.has("displayName")) {
+                displayNames.put(name, data.get("displayName").getAsString());
+            }
+            if (data.has("suffix")) {
+                suffixes.put(name, data.get("suffix").getAsString());
+            } else {
+                suffixes.remove(name);
+            }
+        }
+    }
+
+    private void handleRemove(JsonObject obj) {
+        JsonArray players = obj.getAsJsonArray("players");
+        for (JsonElement elem : players) {
+            String name = elem.getAsString();
+            displayNames.remove(name);
+            suffixes.remove(name);
+        }
+    }
+
+    private void handleSort(JsonObject obj) {
+        JsonArray order = obj.getAsJsonArray("order");
+        Map<String, Integer> indexMap = new HashMap<>();
+        for (int i = 0; i < order.size(); i++) {
+            indexMap.put(order.get(i).getAsString(), i);
+        }
+        sortIndexMap = indexMap;
+    }
+
+    public String getDisplayName(String playerName) {
+        return displayNames.get(playerName);
+    }
+
+    public String getSuffix(String playerName) {
+        return suffixes.get(playerName);
+    }
+
+    /**
+     * Returns the sort index map, or null if no custom sort order has been set. Players not in the map should sort
+     * after all listed players.
+     */
+    public Map<String, Integer> getSortIndexMap() {
+        return sortIndexMap;
+    }
+
+    public void clear() {
+        displayNames.clear();
+        suffixes.clear();
+        sortIndexMap = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/client/tab/TabSkinCache.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/tab/TabSkinCache.java
@@ -1,0 +1,55 @@
+package com.mitchej123.hodgepodge.client.tab;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * Caches skin ResourceLocations for tab list players. Triggers async download via
+ * AbstractClientPlayer.getDownloadImageSkin and returns the location (steve until loaded).
+ */
+public class TabSkinCache {
+
+    public static final TabSkinCache INSTANCE = new TabSkinCache();
+
+    private final Map<String, ResourceLocation> cache = new HashMap<>();
+
+    private TabSkinCache() {}
+
+    /**
+     * Returns the skin ResourceLocation for the given player name. If the skin hasn't been requested yet, triggers an
+     * async download. Returns the location immediately - it will resolve to steve.png until the real skin loads.
+     */
+    public ResourceLocation getOrLoadSkin(String playerName) {
+        ResourceLocation loc = cache.get(playerName);
+        if (loc == null) {
+            loc = AbstractClientPlayer.getLocationSkin(playerName);
+            AbstractClientPlayer.getDownloadImageSkin(loc, playerName);
+            cache.put(playerName, loc);
+        }
+        return loc;
+    }
+
+    /**
+     * Removes entries for players no longer in the tab list.
+     */
+    public void cleanup(Collection<String> activePlayers) {
+        Iterator<String> it = cache.keySet().iterator();
+        while (it.hasNext()) {
+            if (!activePlayers.contains(it.next())) {
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Clears all cached skins. Called on disconnect.
+     */
+    public void clear() {
+        cache.clear();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -464,4 +464,21 @@ public class TweaksConfig {
     @Config.Comment("Allow creative tab gui title color via localization key")
     @Config.DefaultBoolean(true)
     public static boolean creativeTabLocalizationOverrides;
+
+    @Config.Comment("Replaces the vanilla player list (TAB overlay) with a modern-style tab list featuring player heads, dynamic columns, and header/footer support")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean modernTabOverlay;
+
+    @Config.Comment("Show player head icons in the modern tab overlay")
+    @Config.DefaultBoolean(true)
+    public static boolean tabShowPlayerHeads;
+
+    @Config.Comment("Static header text for the modern tab overlay. Use & for color/format codes (e.g. &b = aqua, &l = bold, &r = reset). Use \\n for line breaks. Overridden by server plugin channel data if present.")
+    @Config.DefaultString("&b&lHodgepodge Server\\n&7A modern tab list for 1.7.10")
+    public static String tabHeaderText;
+
+    @Config.Comment("Static footer text for the modern tab overlay. Use & for color/format codes (e.g. &e = yellow, &o = italic, &r = reset). Use \\n for line breaks. Overridden by server plugin channel data if present.")
+    @Config.DefaultString("&7Ping: &a< 150ms &e< 300ms &c< 600ms &4< 1000ms &8>= 1000ms\\n&8Powered by &dHodgepodge")
+    public static String tabFooterText;
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -474,6 +474,14 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean tabShowPlayerHeads;
 
+    @Config.Comment("Show numeric ping value (e.g. 42ms) next to the signal bars in the modern tab overlay")
+    @Config.DefaultBoolean(true)
+    public static boolean tabShowPingNumber;
+
+    @Config.Comment("Show signal bars in the modern tab overlay. Can be disabled independently of the numeric ping display.")
+    @Config.DefaultBoolean(true)
+    public static boolean tabShowPingBars;
+
     @Config.Comment("Static header text for the modern tab overlay. Use & for color/format codes (e.g. &b = aqua, &l = bold, &r = reset). Use \\n for line breaks. Overridden by server plugin channel data if present.")
     @Config.DefaultString("&b&lHodgepodge Server\\n&7A modern tab list for 1.7.10")
     public static String tabHeaderText;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -515,6 +515,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("forge.MixinGuiIngameForge_CrosshairInvertColors")
             .setApplyIf(() -> TweaksConfig.dontInvertCrosshairColor)
             .setPhase(Phase.EARLY)),
+    MODERN_TAB_OVERLAY(new MixinBuilder("Modern tab overlay")
+            .addClientMixins("forge.MixinGuiIngameForge_ModernTab")
+            .setApplyIf(() -> TweaksConfig.modernTabOverlay)
+            .setPhase(Phase.EARLY)),
     FIX_OPENGUIHANDLER_WINDOWID(new MixinBuilder("Fix OpenGuiHandler")
             .addCommonMixins("fml.MixinOpenGuiHandler")
             .setApplyIf(() -> FixesConfig.fixForgeOpenGuiHandlerWindowId)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_ModernTab.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_ModernTab.java
@@ -1,0 +1,56 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.scoreboard.ScoreObjective;
+import net.minecraftforge.client.GuiIngameForge;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.common.MinecraftForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.client.tab.ModernTabRenderer;
+
+/**
+ * Replaces the vanilla player list rendering in GuiIngameForge with the modern tab renderer while preserving the
+ * Pre/Post event lifecycle so other mods can still interact with the PLAYER_LIST overlay event.
+ */
+@Mixin(GuiIngameForge.class)
+public class MixinGuiIngameForge_ModernTab extends GuiIngame {
+
+    @Shadow(remap = false)
+    private ScaledResolution res;
+
+    @Shadow(remap = false)
+    private RenderGameOverlayEvent eventParent;
+
+    private MixinGuiIngameForge_ModernTab(Minecraft mc) {
+        super(mc);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Inject(method = "renderPlayerList", at = @At("HEAD"), cancellable = true, remap = false)
+    private void hodgepodge$modernTab(int width, int height, CallbackInfo ci) {
+        ci.cancel();
+
+        ScoreObjective scoreobjective = mc.theWorld.getScoreboard().func_96539_a(0);
+        NetHandlerPlayClient handler = mc.thePlayer.sendQueue;
+
+        if (mc.gameSettings.keyBindPlayerList.getIsKeyPressed()
+                && (!mc.isIntegratedServerRunning() || handler.playerInfoList.size() > 1 || scoreobjective != null)) {
+            if (MinecraftForge.EVENT_BUS
+                    .post(new RenderGameOverlayEvent.Pre(eventParent, RenderGameOverlayEvent.ElementType.PLAYER_LIST)))
+                return;
+            mc.mcProfiler.startSection("playerList");
+            ModernTabRenderer.INSTANCE.render(res);
+            MinecraftForge.EVENT_BUS
+                    .post(new RenderGameOverlayEvent.Post(eventParent, RenderGameOverlayEvent.ElementType.PLAYER_LIST));
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
@@ -1,7 +1,9 @@
 package com.mitchej123.hodgepodge.net;
 
+import com.mitchej123.hodgepodge.client.tab.TabChannelHandler;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
+import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
@@ -11,10 +13,14 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
 
     private boolean longerSentMessages;
     private boolean fastBlockPlacingServerSide;
+    private String tabHeaderText = "";
+    private String tabFooterText = "";
 
     public MessageConfigSync() {
         longerSentMessages = TweaksConfig.longerSentMessages;
         fastBlockPlacingServerSide = TweaksConfig.fastBlockPlacingServerSide;
+        tabHeaderText = TweaksConfig.tabHeaderText != null ? TweaksConfig.tabHeaderText : "";
+        tabFooterText = TweaksConfig.tabFooterText != null ? TweaksConfig.tabFooterText : "";
     }
 
     @Override
@@ -27,12 +33,18 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
         } else {
             fastBlockPlacingServerSide = buf.readBoolean();
         }
+        if (buf.readableBytes() > 0) {
+            tabHeaderText = ByteBufUtils.readUTF8String(buf);
+            tabFooterText = ByteBufUtils.readUTF8String(buf);
+        }
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeBoolean(longerSentMessages);
         buf.writeBoolean(fastBlockPlacingServerSide);
+        ByteBufUtils.writeUTF8String(buf, tabHeaderText);
+        ByteBufUtils.writeUTF8String(buf, tabFooterText);
     }
 
     public boolean isFastBlockPlacingServerSide() {
@@ -51,6 +63,8 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
             TweaksConfig.fastBlockPlacing = false;
             TweaksConfig.fastBlockPlacingServerSide = false;
         }
+
+        TabChannelHandler.INSTANCE.setServerData(message.tabHeaderText, message.tabFooterText);
 
         return null;
     }

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageConfigSync.java
@@ -15,12 +15,18 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
     private boolean fastBlockPlacingServerSide;
     private String tabHeaderText = "";
     private String tabFooterText = "";
+    private boolean tabShowPlayerHeads = true;
+    private boolean tabShowPingNumber = true;
+    private boolean tabShowPingBars = true;
 
     public MessageConfigSync() {
         longerSentMessages = TweaksConfig.longerSentMessages;
         fastBlockPlacingServerSide = TweaksConfig.fastBlockPlacingServerSide;
         tabHeaderText = TweaksConfig.tabHeaderText != null ? TweaksConfig.tabHeaderText : "";
         tabFooterText = TweaksConfig.tabFooterText != null ? TweaksConfig.tabFooterText : "";
+        tabShowPlayerHeads = TweaksConfig.tabShowPlayerHeads;
+        tabShowPingNumber = TweaksConfig.tabShowPingNumber;
+        tabShowPingBars = TweaksConfig.tabShowPingBars;
     }
 
     @Override
@@ -37,6 +43,13 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
             tabHeaderText = ByteBufUtils.readUTF8String(buf);
             tabFooterText = ByteBufUtils.readUTF8String(buf);
         }
+        if (buf.readableBytes() > 0) {
+            tabShowPlayerHeads = buf.readBoolean();
+            tabShowPingNumber = buf.readBoolean();
+        }
+        if (buf.readableBytes() > 0) {
+            tabShowPingBars = buf.readBoolean();
+        }
     }
 
     @Override
@@ -45,6 +58,9 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
         buf.writeBoolean(fastBlockPlacingServerSide);
         ByteBufUtils.writeUTF8String(buf, tabHeaderText);
         ByteBufUtils.writeUTF8String(buf, tabFooterText);
+        buf.writeBoolean(tabShowPlayerHeads);
+        buf.writeBoolean(tabShowPingNumber);
+        buf.writeBoolean(tabShowPingBars);
     }
 
     public boolean isFastBlockPlacingServerSide() {
@@ -65,6 +81,10 @@ public class MessageConfigSync implements IMessage, IMessageHandler<MessageConfi
         }
 
         TabChannelHandler.INSTANCE.setServerData(message.tabHeaderText, message.tabFooterText);
+
+        TweaksConfig.tabShowPlayerHeads = message.tabShowPlayerHeads;
+        TweaksConfig.tabShowPingNumber = message.tabShowPingNumber;
+        TweaksConfig.tabShowPingBars = message.tabShowPingBars;
 
         return null;
     }


### PR DESCRIPTION
I decided to fix the horrible tab layout by backporting 1.12.2 feature. 

TDLR : 

- Replaces the vanilla 1.7.10 player list (TAB) with a modern-style                                                                                                                               
- Player head icons (face + hat overlay) with async skin loading
- Dynamic column sizing based on player count and name widths (up to 80 players, 20 rows max)                                                                                                                     
- Header/footer text with & color code support and \n line breaks                                                                                                                                                                                 
- Server config sync on player login                                                                                                                                                                                        
- Plugin channel HP|TabHF for proxy support (Velocity, BungeeCord, etc.), it does accept JSON `{"header":"...","footer":"..."}`                                                                                                           

Pictures :
<img width="593" height="144" alt="image" src="https://github.com/user-attachments/assets/50222f3b-27d3-4009-a010-8a09c004f785" />
<img width="2444" height="1374" alt="image" src="https://github.com/user-attachments/assets/fc0ce12d-4f9c-4d36-93fc-7df67e32ce69" />
<img width="1435" height="169" alt="image" src="https://github.com/user-attachments/assets/ef053cb0-edc3-4ce7-b03e-91ddec6c7eb7" />


P.S: Is compatible with on/off feature, it does not impact client that much.