### PR TITLE
Fix chunk loading issue in MP/SP

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,7 +14,7 @@ configurations {
 dependencies {
     api("com.github.GTNewHorizons:GTNHLib:0.9.41:dev")
 
-    compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.2") { transitive = false }
+    compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.16") { transitive = false }
     compileOnly("com.mitchej123:supernova:0.0.2:api") { transitive = false }
 
     transformedMod("com.github.GTNewHorizons:NotEnoughItems:2.8.48-GTNH:dev") // force a more up-to-date NEI version

--- a/src/main/java/com/mitchej123/hodgepodge/SimulationDistanceHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/SimulationDistanceHelper.java
@@ -159,7 +159,7 @@ public class SimulationDistanceHelper {
 
         int simulationDistance = getSimulationDistance();
         for (EntityPlayer player : world.playerEntities) {
-            if (player.getEntityWorld() != world) {
+            if (player.getEntityWorld().provider.dimensionId != world.provider.dimensionId) {
                 continue;
             }
             int playerCX = (int) player.posX >> 4;
@@ -230,7 +230,7 @@ public class SimulationDistanceHelper {
 
         // New players, or moved players?
         for (EntityPlayer player : world.playerEntities) {
-            if (player.getEntityWorld() != world) {
+            if (player.getEntityWorld().provider.dimensionId != world.provider.dimensionId) {
                 continue;
             }
             ChunkCoordIntPair playerPos = new ChunkCoordIntPair((int) player.posX >> 4, (int) player.posZ >> 4);


### PR DESCRIPTION
Changed world comparison from reference equality to dimension ID comparison in SimulationDistanceHelper. In multiplayer, World object references can differ even when representing the same dimension, causing players to be incorrectly filtered out when calculating which chunks should be processed. This led to chunks disappearing and players in those chunks becoming invisible to others.

Fixes: https://github.com/GTNewHorizons/Hodgepodge/issues/809