### PR TITLE
[Memory-opti:fix leak] Fix memory leak caused by CommandBase#theAdmin

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -3,6 +3,8 @@ package com.mitchej123.hodgepodge;
 import java.util.Map;
 import java.util.Set;
 
+import net.minecraft.command.CommandBase;
+
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
 import com.mitchej123.hodgepodge.config.FixesConfig;
@@ -119,6 +121,9 @@ public class Hodgepodge {
         if (FixesConfig.fixNetworkChannelsMemoryLeak) {
             cleanChannelsForSide(Side.CLIENT);
             cleanChannelsForSide(Side.SERVER);
+        }
+        if (FixesConfig.fixServerCommandHandlerLeak) {
+            CommandBase.setAdminCommander(null);
         }
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -96,6 +96,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixNetworkChannelsMemoryLeak;
 
+    @Config.Comment("Fix memory leak caused by minecraft's commandBase keeping a static reference to the server command handler")
+    @Config.DefaultBoolean(true)
+    public static boolean fixServerCommandHandlerLeak;
+
     @Config.Comment("Fix vanilla issue where player sounds register as animal sounds")
     @Config.DefaultBoolean(true)
     public static boolean fixFriendlyCreatureSounds;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_ClearServerRef.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/server/MixinMinecraftServer_ClearServerRef.java
@@ -17,11 +17,7 @@ public class MixinMinecraftServer_ClearServerRef {
     @Inject(
             method = "run",
             remap = false,
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V",
-                    shift = At.Shift.BEFORE,
-                    remap = true))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V", remap = true))
     private void clearServerRef(CallbackInfo ci) {
         mcServer = null;
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinExtendedPlayer_EnumValuesSpam.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/witchery/MixinExtendedPlayer_EnumValuesSpam.java
@@ -14,7 +14,7 @@ public class MixinExtendedPlayer_EnumValuesSpam {
     @Unique
     private static final TransformCreature[] hodgepodge$VALUES = TransformCreature.values();
 
-    @Shadow
+    @Shadow(remap = false)
     private int creatureType;
 
     /**


### PR DESCRIPTION
it keeps a static reference to the ServerCommandManager which is instantiated when the server starts and it never clears that reference which causes the whole server to leak because AE's command keeps a reference to the server (not AE2's fault).

<img width="665" height="250" alt="image" src="https://github.com/user-attachments/assets/b21d31a9-c52f-4c40-a126-74977afa6790" />
