### PR TITLE
Create Memory config category

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -8,6 +8,7 @@ import net.minecraft.command.CommandBase;
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
 import com.mitchej123.hodgepodge.config.FixesConfig;
+import com.mitchej123.hodgepodge.config.MemoryConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.net.NetworkHandler;
 import com.mitchej123.hodgepodge.util.AnchorAlarm;
@@ -115,14 +116,14 @@ public class Hodgepodge {
     @EventHandler
     public void onServerStopped(FMLServerStoppedEvent event) {
         ServerThreadLongHashMap.clearSnapshots();
-        if (FixesConfig.fixCoFHWorldLeak && Loader.isModLoaded("CoFHCore")) {
+        if (MemoryConfig.leaks.fixCoFHWorldLeak && Loader.isModLoaded("CoFHCore")) {
             clearCoFhServerInstance();
         }
-        if (FixesConfig.fixNetworkChannelsMemoryLeak) {
+        if (MemoryConfig.leaks.fixNetworkChannelsMemoryLeak) {
             cleanChannelsForSide(Side.CLIENT);
             cleanChannelsForSide(Side.SERVER);
         }
-        if (FixesConfig.fixServerCommandHandlerLeak) {
+        if (MemoryConfig.leaks.fixServerCommandHandlerLeak) {
             CommandBase.setAdminCommander(null);
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -1,14 +1,10 @@
 package com.mitchej123.hodgepodge;
 
 import java.util.Map;
-import java.util.Set;
-
-import net.minecraft.command.CommandBase;
 
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
 import com.mitchej123.hodgepodge.config.FixesConfig;
-import com.mitchej123.hodgepodge.config.MemoryConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.net.NetworkHandler;
 import com.mitchej123.hodgepodge.util.AnchorAlarm;
@@ -16,13 +12,10 @@ import com.mitchej123.hodgepodge.util.ServerThreadLongHashMap;
 import com.mitchej123.hodgepodge.util.StatHandler;
 import com.mitchej123.hodgepodge.util.TravellersGear;
 
-import cofh.CoFHCore;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.ICrashCallable;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
-import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLModIdMappingEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -30,11 +23,7 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartedEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppedEvent;
-import cpw.mods.fml.common.network.FMLEmbeddedChannel;
-import cpw.mods.fml.common.network.FMLOutboundHandler;
 import cpw.mods.fml.common.network.NetworkCheckHandler;
-import cpw.mods.fml.common.network.NetworkRegistry;
-import cpw.mods.fml.common.network.handshake.NetworkDispatcher;
 import cpw.mods.fml.common.versioning.ArtifactVersion;
 import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
 import cpw.mods.fml.relauncher.Side;
@@ -116,32 +105,7 @@ public class Hodgepodge {
     @EventHandler
     public void onServerStopped(FMLServerStoppedEvent event) {
         ServerThreadLongHashMap.clearSnapshots();
-        if (MemoryConfig.leaks.fixCoFHWorldLeak && Loader.isModLoaded("CoFHCore")) {
-            clearCoFhServerInstance();
-        }
-        if (MemoryConfig.leaks.fixNetworkChannelsMemoryLeak) {
-            cleanChannelsForSide(Side.CLIENT);
-            cleanChannelsForSide(Side.SERVER);
-        }
-        if (MemoryConfig.leaks.fixServerCommandHandlerLeak) {
-            CommandBase.setAdminCommander(null);
-        }
-    }
-
-    private static void cleanChannelsForSide(Side side) {
-        final Set<String> channels = NetworkRegistry.INSTANCE.channelNamesFor(side);
-        for (String name : channels) {
-            final FMLEmbeddedChannel channel = NetworkRegistry.INSTANCE.getChannel(name, side);
-            channel.attr(FMLOutboundHandler.FML_MESSAGETARGET).remove();
-            channel.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).remove();
-            channel.attr(NetworkDispatcher.FML_DISPATCHER).remove();
-            channel.attr(NetworkRegistry.NET_HANDLER).remove();
-        }
-    }
-
-    @Optional.Method(modid = "CoFHCore")
-    private static void clearCoFhServerInstance() {
-        CoFHCore.server = null;
+        // run memory cleaning for other mods in AfterServerStoppedHook
     }
 
     @EventHandler

--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -18,7 +18,7 @@ import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.MemoryConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
-import com.mitchej123.hodgepodge.mixins.early.minecraft.ItemRendererAccessor;
+import com.mitchej123.hodgepodge.mixins.early.memory.ItemRendererAccessor;
 import com.mitchej123.hodgepodge.util.ManagedEnum;
 
 import biomesoplenty.common.eventhandler.client.gui.WorldTypeMessageEventHandler;

--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -16,6 +16,7 @@ import com.mitchej123.hodgepodge.client.handlers.ReloadSoundsGui;
 import com.mitchej123.hodgepodge.commands.AllocationsCommand;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
+import com.mitchej123.hodgepodge.config.MemoryConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.mixins.early.minecraft.ItemRendererAccessor;
 import com.mitchej123.hodgepodge.util.ManagedEnum;
@@ -105,7 +106,7 @@ public class HodgepodgeClient {
     @SubscribeEvent
     public static void onClientDisconnect(FMLNetworkEvent.ClientDisconnectionFromServerEvent event) {
         AsyncNBTParser.shutdown();
-        if (FixesConfig.fixEntityRendererItemRendererLeak) {
+        if (MemoryConfig.leaks.fixEntityRendererItemRendererLeak) {
             EntityRenderer entityRenderer = Minecraft.getMinecraft().entityRenderer;
             if (entityRenderer != null) {
                 ((ItemRendererAccessor) entityRenderer.itemRenderer).setItemToRender(null);

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -92,14 +92,6 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixForgeUpdateChecker;
 
-    @Config.Comment("Fix memory leak caused by FML network channels attributes")
-    @Config.DefaultBoolean(true)
-    public static boolean fixNetworkChannelsMemoryLeak;
-
-    @Config.Comment("Fix memory leak caused by minecraft's commandBase keeping a static reference to the server command handler")
-    @Config.DefaultBoolean(true)
-    public static boolean fixServerCommandHandlerLeak;
-
     @Config.Comment("Fix vanilla issue where player sounds register as animal sounds")
     @Config.DefaultBoolean(true)
     public static boolean fixFriendlyCreatureSounds;
@@ -192,14 +184,6 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixPotionLimit;
 
-    @Config.Comment("Fix redstone torch leaking world")
-    @Config.DefaultBoolean(true)
-    public static boolean fixRedstoneTorchWorldLeak;
-
-    @Config.Comment("Fix EffectRenderer and RenderGlobal leaking world instance when leaving world")
-    @Config.DefaultBoolean(true)
-    public static boolean fixRenderersWorldLeak;
-
     @Config.Comment("Fix game window becoming not resizable after toggling fullscrean in any way")
     @Config.DefaultBoolean(true)
     public static boolean fixResizableFullscreen;
@@ -235,18 +219,6 @@ public class FixesConfig {
     @Config.Comment("Fixes village unchecked getBlock() calls")
     @Config.DefaultBoolean(true)
     public static boolean fixVillageUncheckedGetBlock;
-
-    @Config.Comment("Fix WorldServer leaking entities when no players are present in a dimension")
-    @Config.DefaultBoolean(true)
-    public static boolean fixWorldServerLeakingUnloadedEntities;
-
-    @Config.Comment("Fix skin manager leaking client world")
-    @Config.DefaultBoolean(true)
-    public static boolean fixSkinManagerLeakingClientWorld;
-
-    @Config.Comment("Fix ItemRenderer keeping a reference to the last rendered item when leaving a world")
-    @Config.DefaultBoolean(true)
-    public static boolean fixEntityRendererItemRendererLeak;
 
     @Config.Comment("Increase the maximum network packet size from the default of 2MiB")
     @Config.DefaultBoolean(true)
@@ -406,11 +378,6 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixEntityGravity;
 
-    @Config.Comment("Fix EventBus keeping object references after unregistering event handlers.")
-    @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
-    public static boolean fixEventBusMemoryLeak;
-
     @Config.Comment("Render the house character (\u2302 - Unicode index 2302) in the Minecraft font.")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
@@ -432,11 +399,6 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean removeInvalidChunkEntites;
-
-    @Config.Comment("Clears the reference to the minecraft server once it has stopped")
-    @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
-    public static boolean fixMinecraftServerLeak;
 
     @Config.Comment("Fixes pistons with metadata over 5 from crashing worlds when powered.")
     @Config.DefaultBoolean(true)
@@ -502,10 +464,6 @@ public class FixesConfig {
     @Config.Comment("Remove old/stale/outdated update checks.")
     @Config.DefaultBoolean(true)
     public static boolean removeUpdateChecks;
-
-    @Config.Comment("Clear FML Texture Errors to free memory")
-    @Config.DefaultBoolean(true)
-    public static boolean clearFMLTextureErrors;
 
     @Config.Comment("Fix broken modlist entries due to wrong mcmod.info files")
     @Config.DefaultBoolean(true)
@@ -580,10 +538,6 @@ public class FixesConfig {
     @Config.Comment("Fix logic of /cofh tpx")
     @Config.DefaultBoolean(true)
     public static boolean fixCofhTpxCommand;
-
-    @Config.Comment("Fix CoFH WorldServer leak in main mod class")
-    @Config.DefaultBoolean(true)
-    public static boolean fixCoFHWorldLeak;
 
     @Config.Comment("Fix NBTTagSmartByteArray sending null to NBTTagByteArray causing NPE when saving chunks")
     @Config.DefaultBoolean(true)
@@ -886,11 +840,6 @@ public class FixesConfig {
             "such as capturing the Demon in an EnderIO Soul Vial." })
     @Config.DefaultBoolean(true)
     public static boolean fixWitcheryDemonShiftClick;
-
-    @Config.Comment("Stops witchery from spamming Enum#values()")
-    @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
-    public static boolean fixWitcheryEnumValuesSpam;
 
     // Xaero's Minimap
     @Config.Comment("Fixes the player entity dot rendering when arrow is chosen")

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -503,9 +503,9 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean removeUpdateChecks;
 
-    @Config.Comment("Enable multiple fixes to reduce RAM usage")
+    @Config.Comment("Clear FML Texture Errors to free memory")
     @Config.DefaultBoolean(true)
-    public static boolean enableMemoryFixes;
+    public static boolean clearFMLTextureErrors;
 
     @Config.Comment("Fix broken modlist entries due to wrong mcmod.info files")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -3,7 +3,6 @@ package com.mitchej123.hodgepodge.config;
 import com.gtnewhorizon.gtnhlib.config.Config;
 
 @Config(modid = "hodgepodge", category = "memory")
-@Config.RequiresMcRestart
 public class MemoryConfig {
 
     @Config.Comment("Memory leak fixes")
@@ -16,6 +15,7 @@ public class MemoryConfig {
 
         @Config.Comment("Fix ItemRenderer keeping a reference to the last rendered item when leaving a world")
         @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
         public boolean fixEntityRendererItemRendererLeak;
 
         @Config.Comment("Fix EventBus keeping object references after unregistering event handlers.")
@@ -42,18 +42,22 @@ public class MemoryConfig {
 
         @Config.Comment("Fix redstone torch leaking world")
         @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
         public boolean fixRedstoneTorchWorldLeak;
 
         @Config.Comment("Fix EffectRenderer and RenderGlobal leaking world instance when leaving world")
         @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
         public boolean fixRenderersWorldLeak;
 
         @Config.Comment("Fix WorldServer leaking entities when no players are present in a dimension")
         @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
         public boolean fixWorldServerLeakingUnloadedEntities;
 
         @Config.Comment("Fix skin manager leaking client world")
         @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
         public boolean fixSkinManagerLeakingClientWorld;
     }
 
@@ -61,6 +65,7 @@ public class MemoryConfig {
 
         @Config.Comment("Clear FML Texture Errors to free memory")
         @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
         public boolean clearFMLTextureErrors;
 
         @Config.Comment("Stops witchery from spamming Enum#values()")

--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -1,0 +1,71 @@
+package com.mitchej123.hodgepodge.config;
+
+import com.gtnewhorizon.gtnhlib.config.Config;
+
+@Config(modid = "hodgepodge", category = "memory")
+@Config.RequiresMcRestart
+public class MemoryConfig {
+
+    @Config.Comment("Memory leak fixes")
+    public static final MemoryLeakFixes leaks = new MemoryLeakFixes();
+
+    @Config.Comment("Memory allocation fixes")
+    public static final AllocationFixes allocs = new AllocationFixes();
+
+    public static class MemoryLeakFixes {
+
+        @Config.Comment("Fix ItemRenderer keeping a reference to the last rendered item when leaving a world")
+        @Config.DefaultBoolean(true)
+        public boolean fixEntityRendererItemRendererLeak;
+
+        @Config.Comment("Fix EventBus keeping object references after unregistering event handlers.")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixEventBusMemoryLeak;
+
+        @Config.Comment("Clears the reference to the minecraft server once it has stopped")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixMinecraftServerLeak;
+
+        @Config.Comment("Fix CoFH WorldServer leak in main mod class")
+        @Config.DefaultBoolean(true)
+        public boolean fixCoFHWorldLeak;
+
+        @Config.Comment("Fix memory leak caused by FML network channels attributes")
+        @Config.DefaultBoolean(true)
+        public boolean fixNetworkChannelsMemoryLeak;
+
+        @Config.Comment("Fix memory leak caused by minecraft's commandBase keeping a static reference to the server command handler")
+        @Config.DefaultBoolean(true)
+        public boolean fixServerCommandHandlerLeak;
+
+        @Config.Comment("Fix redstone torch leaking world")
+        @Config.DefaultBoolean(true)
+        public boolean fixRedstoneTorchWorldLeak;
+
+        @Config.Comment("Fix EffectRenderer and RenderGlobal leaking world instance when leaving world")
+        @Config.DefaultBoolean(true)
+        public boolean fixRenderersWorldLeak;
+
+        @Config.Comment("Fix WorldServer leaking entities when no players are present in a dimension")
+        @Config.DefaultBoolean(true)
+        public boolean fixWorldServerLeakingUnloadedEntities;
+
+        @Config.Comment("Fix skin manager leaking client world")
+        @Config.DefaultBoolean(true)
+        public boolean fixSkinManagerLeakingClientWorld;
+    }
+
+    public static class AllocationFixes {
+
+        @Config.Comment("Clear FML Texture Errors to free memory")
+        @Config.DefaultBoolean(true)
+        public boolean clearFMLTextureErrors;
+
+        @Config.Comment("Stops witchery from spamming Enum#values()")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixWitcheryEnumValuesSpam;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
@@ -19,6 +19,7 @@ import com.mitchej123.hodgepodge.config.ASMConfig;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.GeneralConfig;
+import com.mitchej123.hodgepodge.config.MemoryConfig;
 import com.mitchej123.hodgepodge.config.SpeedupsConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.core.fml.AsmTransformers;
@@ -49,6 +50,7 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
             ConfigurationManager.registerConfig(DebugConfig.class);
             ConfigurationManager.registerConfig(FixesConfig.class);
             ConfigurationManager.registerConfig(GeneralConfig.class);
+            ConfigurationManager.registerConfig(MemoryConfig.class);
             ConfigurationManager.registerConfig(SpeedupsConfig.class);
             ConfigurationManager.registerConfig(TweaksConfig.class);
             if (TweaksConfig.enableTagCompoundStringPooling || TweaksConfig.enableNBTStringPooling) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -7,6 +7,7 @@ import com.gtnewhorizon.gtnhmixins.builders.MixinBuilder;
 import com.mitchej123.hodgepodge.config.ASMConfig;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
+import com.mitchej123.hodgepodge.config.MemoryConfig;
 import com.mitchej123.hodgepodge.config.SpeedupsConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
@@ -16,7 +17,7 @@ public enum Mixins implements IMixins {
     // Vanilla Fixes
     FIX_MINECRAFT_SERVER_LEAK(new MixinBuilder()
             .addCommonMixins("minecraft.server.MixinMinecraftServer_ClearServerRef")
-            .setApplyIf(() -> FixesConfig.fixMinecraftServerLeak)
+            .setApplyIf(() -> MemoryConfig.leaks.fixMinecraftServerLeak)
             .setPhase(Phase.EARLY)),
     ONLY_LOAD_LANGUAGES_ONCE_PER_FILE(new MixinBuilder()
             .addCommonMixins("minecraft.MixinLanguageRegistry")
@@ -359,19 +360,19 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES(new MixinBuilder()
             .addCommonMixins("minecraft.MixinWorldServerUpdateEntities")
-            .setApplyIf(() -> FixesConfig.fixWorldServerLeakingUnloadedEntities)
+            .setApplyIf(() -> MemoryConfig.leaks.fixWorldServerLeakingUnloadedEntities)
             .setPhase(Phase.EARLY)),
     FIX_SKIN_MANAGER_CLIENT_WORLD_LEAK(new MixinBuilder()
             .addClientMixins("minecraft.MixinSkinManager$2")
-            .setApplyIf(() -> FixesConfig.fixSkinManagerLeakingClientWorld)
+            .setApplyIf(() -> MemoryConfig.leaks.fixSkinManagerLeakingClientWorld)
             .setPhase(Phase.EARLY)),
     FIX_ITEM_RENDERER_ITEM_LEAK(new MixinBuilder()
             .addClientMixins("minecraft.ItemRendererAccessor")
-            .setApplyIf(() -> FixesConfig.fixEntityRendererItemRendererLeak)
+            .setApplyIf(() -> MemoryConfig.leaks.fixEntityRendererItemRendererLeak)
             .setPhase(Phase.EARLY)),
     FIX_REDSTONE_TORCH_WORLD_LEAK(new MixinBuilder("Fix world leak in redstone torch")
             .addCommonMixins("minecraft.MixinBlockRedstoneTorch")
-            .setApplyIf(() -> FixesConfig.fixRedstoneTorchWorldLeak)
+            .setApplyIf(() -> MemoryConfig.leaks.fixRedstoneTorchWorldLeak)
             .addExcludedMod(TargetedMod.BUGTORCH)
             .setPhase(Phase.EARLY)),
     FIX_ARROW_WRONG_LIGHTING(new MixinBuilder()
@@ -391,7 +392,7 @@ public enum Mixins implements IMixins {
             .addClientMixins(
                     "minecraft.MixinMinecraft_ClearRenderersWorldLeak",
                     "minecraft.MixinRenderGlobal_FixWordLeak")
-            .setApplyIf(() -> FixesConfig.fixRenderersWorldLeak)
+            .setApplyIf(() -> MemoryConfig.leaks.fixRenderersWorldLeak)
             .setPhase(Phase.EARLY)),
     FIX_OPTIFINE_CHUNKLOADING_CRASH(new MixinBuilder()
             .setApplyIf(() -> FixesConfig.fixOptifineChunkLoadingCrash)
@@ -714,7 +715,7 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     MEMORY_FIXES_CLIENT(new MixinBuilder()
             .addClientMixins("memory.MixinFMLClientHandler")
-            .setApplyIf(() -> FixesConfig.clearFMLTextureErrors)
+            .setApplyIf(() -> MemoryConfig.allocs.clearFMLTextureErrors)
             .setPhase(Phase.EARLY)),
     FAST_RANDOM(new MixinBuilder("Replaces uses of stdlib Random with a faster one")
             .addCommonMixins(
@@ -863,7 +864,7 @@ public enum Mixins implements IMixins {
             .addCommonMixins(
                     "fml.MixinListenerListInst",
                     "fml.MixinEventBus")
-            .setApplyIf(() -> FixesConfig.fixEventBusMemoryLeak)
+            .setApplyIf(() -> MemoryConfig.leaks.fixEventBusMemoryLeak)
             .setPhase(Phase.EARLY)),
     ADD_HUNGER_GAMERULE(new MixinBuilder()
             .addCommonMixins(
@@ -1664,7 +1665,7 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.LATE)),
     FIX_WITCHERY_ENUM_VALUES_SPAM(new MixinBuilder()
             .addCommonMixins("witchery.MixinExtendedPlayer_EnumValuesSpam")
-            .setApplyIf(() -> FixesConfig.fixWitcheryEnumValuesSpam)
+            .setApplyIf(() -> MemoryConfig.allocs.fixWitcheryEnumValuesSpam)
             .addRequiredMod(TargetedMod.WITCHERY)
             .setPhase(Phase.LATE)),
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -16,7 +16,7 @@ public enum Mixins implements IMixins {
     // spotless:off
     // Vanilla Fixes
     FIX_MINECRAFT_SERVER_LEAK(new MixinBuilder()
-            .addCommonMixins("minecraft.server.MixinMinecraftServer_ClearServerRef")
+            .addCommonMixins("memory.MixinMinecraftServer_ClearServerRef")
             .setApplyIf(() -> MemoryConfig.leaks.fixMinecraftServerLeak)
             .setPhase(Phase.EARLY)),
     ONLY_LOAD_LANGUAGES_ONCE_PER_FILE(new MixinBuilder()
@@ -362,19 +362,19 @@ public enum Mixins implements IMixins {
             .addCommonMixins("memory.MixinMinecraftServer_ShutdownHook")
             .setPhase(Phase.EARLY)),
     FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES(new MixinBuilder()
-            .addCommonMixins("minecraft.MixinWorldServerUpdateEntities")
+            .addCommonMixins("memory.MixinWorldServerUpdateEntities")
             .setApplyIf(() -> MemoryConfig.leaks.fixWorldServerLeakingUnloadedEntities)
             .setPhase(Phase.EARLY)),
     FIX_SKIN_MANAGER_CLIENT_WORLD_LEAK(new MixinBuilder()
-            .addClientMixins("minecraft.MixinSkinManager$2")
+            .addClientMixins("memory.MixinSkinManager$2")
             .setApplyIf(() -> MemoryConfig.leaks.fixSkinManagerLeakingClientWorld)
             .setPhase(Phase.EARLY)),
     FIX_ITEM_RENDERER_ITEM_LEAK(new MixinBuilder()
-            .addClientMixins("minecraft.ItemRendererAccessor")
+            .addClientMixins("memory.ItemRendererAccessor")
             .setApplyIf(() -> MemoryConfig.leaks.fixEntityRendererItemRendererLeak)
             .setPhase(Phase.EARLY)),
     FIX_REDSTONE_TORCH_WORLD_LEAK(new MixinBuilder("Fix world leak in redstone torch")
-            .addCommonMixins("minecraft.MixinBlockRedstoneTorch")
+            .addCommonMixins("memory.MixinBlockRedstoneTorch")
             .setApplyIf(() -> MemoryConfig.leaks.fixRedstoneTorchWorldLeak)
             .addExcludedMod(TargetedMod.BUGTORCH)
             .setPhase(Phase.EARLY)),
@@ -393,8 +393,8 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     FIX_RENDERERS_WORLD_LEAK(new MixinBuilder()
             .addClientMixins(
-                    "minecraft.MixinMinecraft_ClearRenderersWorldLeak",
-                    "minecraft.MixinRenderGlobal_FixWordLeak")
+                    "memory.MixinMinecraft_ClearRenderersWorldLeak",
+                    "memory.MixinRenderGlobal_FixWordLeak")
             .setApplyIf(() -> MemoryConfig.leaks.fixRenderersWorldLeak)
             .setPhase(Phase.EARLY)),
     FIX_OPTIFINE_CHUNKLOADING_CRASH(new MixinBuilder()
@@ -865,8 +865,8 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     FIX_EVENTBUS_MEMORY_LEAK(new MixinBuilder("Fix EventBus keeping object references after unregistering event handlers.")
             .addCommonMixins(
-                    "fml.MixinListenerListInst",
-                    "fml.MixinEventBus")
+                    "memory.MixinListenerListInst",
+                    "memory.MixinEventBus")
             .setApplyIf(() -> MemoryConfig.leaks.fixEventBusMemoryLeak)
             .setPhase(Phase.EARLY)),
     ADD_HUNGER_GAMERULE(new MixinBuilder()

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -712,9 +712,9 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinBlockFireSpread")
             .setApplyIf(() -> FixesConfig.fixFireSpread)
             .setPhase(Phase.EARLY)),
-    MEMORY_FIXES_CLIENT(new MixinBuilder("Memory fixes")
+    MEMORY_FIXES_CLIENT(new MixinBuilder()
             .addClientMixins("memory.MixinFMLClientHandler")
-            .setApplyIf(() -> FixesConfig.enableMemoryFixes)
+            .setApplyIf(() -> FixesConfig.clearFMLTextureErrors)
             .setPhase(Phase.EARLY)),
     FAST_RANDOM(new MixinBuilder("Replaces uses of stdlib Random with a faster one")
             .addCommonMixins(

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -358,6 +358,9 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.packets.MixinS01PacketJoinGame_FixDimensionID")
             .setApplyIf(() -> FixesConfig.fixLoginDimensionIDOverflow)
             .setPhase(Phase.EARLY)),
+    ADD_AFTER_SERVER_STOPPED_HOOK(new MixinBuilder()
+            .addCommonMixins("memory.MixinMinecraftServer_ShutdownHook")
+            .setPhase(Phase.EARLY)),
     FIX_WORLD_SERVER_LEAKING_UNLOADED_ENTITIES(new MixinBuilder()
             .addCommonMixins("minecraft.MixinWorldServerUpdateEntities")
             .setApplyIf(() -> MemoryConfig.leaks.fixWorldServerLeakingUnloadedEntities)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/ItemRendererAccessor.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/ItemRendererAccessor.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinBlockRedstoneTorch.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinBlockRedstoneTorch.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinEventBus.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinEventBus.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.fml;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import java.util.Map;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinListenerListInst.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinListenerListInst.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.fml;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinMinecraftServer_ClearServerRef.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinMinecraftServer_ClearServerRef.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft.server;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import net.minecraft.server.MinecraftServer;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinMinecraftServer_ShutdownHook.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinMinecraftServer_ShutdownHook.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.memory;
+
+import net.minecraft.server.MinecraftServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.mixins.hooks.AfterServerStoppedHook;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer_ShutdownHook {
+
+    @Inject(
+            method = "run",
+            remap = false,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V", remap = true))
+    private void runShutdownHook(CallbackInfo ci) {
+        AfterServerStoppedHook.run();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinMinecraft_ClearRenderersWorldLeak.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinMinecraft_ClearRenderersWorldLeak.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinRenderGlobal_FixWordLeak.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinRenderGlobal_FixWordLeak.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import java.util.List;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinSkinManager$2.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinSkinManager$2.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import net.minecraft.client.resources.SkinManager;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinWorldServerUpdateEntities.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinWorldServerUpdateEntities.java
@@ -1,4 +1,4 @@
-package com.mitchej123.hodgepodge.mixins.early.minecraft;
+package com.mitchej123.hodgepodge.mixins.early.memory;
 
 import net.minecraft.profiler.Profiler;
 import net.minecraft.world.World;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/shutup/MixinFMLClientHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/shutup/MixinFMLClientHandler.java
@@ -57,7 +57,7 @@ public class MixinFMLClientHandler {
                 missingCount,
                 brokenCount);
         logger.error(Strings.repeat("+=", 25));
-        if (FixesConfig.enableMemoryFixes) {
+        if (FixesConfig.clearFMLTextureErrors) {
             missingTextures = HashMultimap.create();
             badTextureDomains = Sets.newHashSet();
             brokenTextures = HashBasedTable.create();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/shutup/MixinFMLClientHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/shutup/MixinFMLClientHandler.java
@@ -19,7 +19,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
-import com.mitchej123.hodgepodge.config.FixesConfig;
+import com.mitchej123.hodgepodge.config.MemoryConfig;
 
 import cpw.mods.fml.client.FMLClientHandler;
 
@@ -57,7 +57,7 @@ public class MixinFMLClientHandler {
                 missingCount,
                 brokenCount);
         logger.error(Strings.repeat("+=", 25));
-        if (FixesConfig.clearFMLTextureErrors) {
+        if (MemoryConfig.allocs.clearFMLTextureErrors) {
             missingTextures = HashMultimap.create();
             badTextureDomains = Sets.newHashSet();
             brokenTextures = HashBasedTable.create();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/AfterServerStoppedHook.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/AfterServerStoppedHook.java
@@ -1,0 +1,51 @@
+package com.mitchej123.hodgepodge.mixins.hooks;
+
+import java.util.Set;
+
+import net.minecraft.command.CommandBase;
+
+import com.mitchej123.hodgepodge.config.MemoryConfig;
+
+import cofh.CoFHCore;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.common.network.FMLEmbeddedChannel;
+import cpw.mods.fml.common.network.FMLOutboundHandler;
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.common.network.handshake.NetworkDispatcher;
+import cpw.mods.fml.relauncher.Side;
+
+public final class AfterServerStoppedHook {
+
+    /**
+     * This gets called after all the FMLServerStoppedEvent have fired for all mods
+     */
+    public static void run() {
+        if (MemoryConfig.leaks.fixCoFHWorldLeak && Loader.isModLoaded("CoFHCore")) {
+            clearCoFhServerInstance();
+        }
+        if (MemoryConfig.leaks.fixNetworkChannelsMemoryLeak) {
+            cleanChannelsForSide(Side.CLIENT);
+            cleanChannelsForSide(Side.SERVER);
+        }
+        if (MemoryConfig.leaks.fixServerCommandHandlerLeak) {
+            CommandBase.setAdminCommander(null);
+        }
+    }
+
+    private static void cleanChannelsForSide(Side side) {
+        final Set<String> channels = NetworkRegistry.INSTANCE.channelNamesFor(side);
+        for (String name : channels) {
+            final FMLEmbeddedChannel channel = NetworkRegistry.INSTANCE.getChannel(name, side);
+            channel.attr(FMLOutboundHandler.FML_MESSAGETARGET).remove();
+            channel.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).remove();
+            channel.attr(NetworkDispatcher.FML_DISPATCHER).remove();
+            channel.attr(NetworkRegistry.NET_HANDLER).remove();
+        }
+    }
+
+    @Optional.Method(modid = "CoFHCore")
+    private static void clearCoFhServerInstance() {
+        CoFHCore.server = null;
+    }
+}


### PR DESCRIPTION
this pr is build on top of https://github.com/GTNewHorizons/Hodgepodge/pull/813 which should be merged first

- create MemoryConfig category
- move memory fixes relates mixins to memory package
- inject a hook after all the FMLServerStoppedEvent run to run the memory cleaning fixes