### PR TITLE
Sync world seed to client

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -111,6 +111,10 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean fastBlockPlacingServerSide;
 
+    @Config.Comment("Sync the server world seed to the client world in multiplayer")
+    @Config.DefaultBoolean(true)
+    public static boolean syncWorldSeedToClientWorld;
+
     @Config.Comment("Prevents the inventory from shifting when the player has active potion effects")
     @Config.DefaultBoolean(true)
     public static boolean fixPotionRenderOffset;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -208,6 +208,12 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiChat_LongerMessages")
             .addCommonMixins("minecraft.packets.MixinC01PacketChatMessage_LongerMessages")
             .setPhase(Phase.EARLY)),
+    SYNC_WORLD_SEED_TO_CLIENT_WORLD(new MixinBuilder()
+            .addClientMixins("minecraft.MixinNetHandlerPlayClient_WorldSeed")
+            .addCommonMixins(
+                    "minecraft.packets.MixinS01PacketJoinGame_WorldSeed",
+                    "minecraft.packets.MixinS07PacketRespawn_WorldSeed")
+            .setPhase(Phase.EARLY)),
     SPEEDUP_REMOVE_FORMATTING_CODES(new MixinBuilder("Speed up the vanilla method to remove formatting codes")
             .addClientMixins("minecraft.MixinEnumChatFormatting_FastFormat")
             .setApplyIf(() -> SpeedupsConfig.speedupRemoveFormatting)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_WorldSeed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayClient_WorldSeed.java
@@ -1,0 +1,42 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.network.play.server.S01PacketJoinGame;
+import net.minecraft.network.play.server.S07PacketRespawn;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mitchej123.hodgepodge.mixins.interfaces.WorldSeedPacketExt;
+
+@Mixin(NetHandlerPlayClient.class)
+public class MixinNetHandlerPlayClient_WorldSeed {
+
+    @ModifyArg(
+            method = "handleJoinGame",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/WorldSettings;<init>(JLnet/minecraft/world/WorldSettings$GameType;ZZLnet/minecraft/world/WorldType;)V"),
+            index = 0)
+    private long hodgepodge$replaceJoinSeed(long original, @Local(argsOnly = true) S01PacketJoinGame packetIn) {
+        if (packetIn instanceof WorldSeedPacketExt ext && ext.hodgepodge$hasWorldSeed()) {
+            return ext.hodgepodge$getWorldSeed();
+        }
+        return original;
+    }
+
+    @ModifyArg(
+            method = "handleRespawn",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/WorldSettings;<init>(JLnet/minecraft/world/WorldSettings$GameType;ZZLnet/minecraft/world/WorldType;)V"),
+            index = 0)
+    private long hodgepodge$replaceRespawnSeed(long original, @Local(argsOnly = true) S07PacketRespawn packetIn) {
+        if (packetIn instanceof WorldSeedPacketExt ext && ext.hodgepodge$hasWorldSeed()) {
+            return ext.hodgepodge$getWorldSeed();
+        }
+        return original;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS01PacketJoinGame_WorldSeed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS01PacketJoinGame_WorldSeed.java
@@ -1,0 +1,70 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.packets;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S01PacketJoinGame;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+import com.mitchej123.hodgepodge.mixins.interfaces.WorldSeedPacketExt;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+
+// Lower priority than MixinS01PacketJoinGame_FixDimensionID so this trailing payload is appended/read after it.
+@Mixin(value = S01PacketJoinGame.class, priority = 900)
+public class MixinS01PacketJoinGame_WorldSeed implements WorldSeedPacketExt {
+
+    @Shadow
+    private int field_149202_d;
+
+    @Unique
+    private boolean hodgepodge$hasWorldSeed;
+    @Unique
+    private long hodgepodge$worldSeed;
+
+    @Inject(
+            method = "<init>(ILnet/minecraft/world/WorldSettings$GameType;ZILnet/minecraft/world/EnumDifficulty;ILnet/minecraft/world/WorldType;)V",
+            at = @At("TAIL"))
+    private void hodgepodge$initWorldSeed(int entityId, net.minecraft.world.WorldSettings.GameType gameType,
+            boolean hardcore, int dimensionId, net.minecraft.world.EnumDifficulty difficulty, int maxPlayers,
+            net.minecraft.world.WorldType worldType, CallbackInfo ci) {
+        if (TweaksConfig.syncWorldSeedToClientWorld) {
+            hodgepodge$hasWorldSeed = true;
+            hodgepodge$worldSeed = FMLCommonHandler.instance().getMinecraftServerInstance()
+                    .worldServerForDimension(this.field_149202_d).getSeed();
+        }
+    }
+
+    @Inject(method = "writePacketData", at = @At("TAIL"))
+    private void hodgepodge$writeWorldSeed(PacketBuffer data, CallbackInfo ci) {
+        if (TweaksConfig.syncWorldSeedToClientWorld) {
+            data.writeLong(hodgepodge$worldSeed);
+        }
+    }
+
+    @Inject(method = "readPacketData", at = @At("TAIL"))
+    private void hodgepodge$readWorldSeed(PacketBuffer data, CallbackInfo ci) {
+        if (data.readableBytes() >= 8) {
+            hodgepodge$hasWorldSeed = true;
+            hodgepodge$worldSeed = data.readLong();
+        } else {
+            hodgepodge$hasWorldSeed = false;
+            hodgepodge$worldSeed = 0L;
+        }
+    }
+
+    @Override
+    public boolean hodgepodge$hasWorldSeed() {
+        return hodgepodge$hasWorldSeed;
+    }
+
+    @Override
+    public long hodgepodge$getWorldSeed() {
+        return hodgepodge$worldSeed;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS07PacketRespawn_WorldSeed.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS07PacketRespawn_WorldSeed.java
@@ -1,0 +1,69 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.packets;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S07PacketRespawn;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+import com.mitchej123.hodgepodge.mixins.interfaces.WorldSeedPacketExt;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+
+@Mixin(S07PacketRespawn.class)
+public class MixinS07PacketRespawn_WorldSeed implements WorldSeedPacketExt {
+
+    @Shadow
+    private int field_149088_a;
+
+    @Unique
+    private boolean hodgepodge$hasWorldSeed;
+    @Unique
+    private long hodgepodge$worldSeed;
+
+    @Inject(
+            method = "<init>(ILnet/minecraft/world/EnumDifficulty;Lnet/minecraft/world/WorldType;Lnet/minecraft/world/WorldSettings$GameType;)V",
+            at = @At("TAIL"))
+    private void hodgepodge$initWorldSeed(int dimensionId, net.minecraft.world.EnumDifficulty difficulty,
+            net.minecraft.world.WorldType worldType, net.minecraft.world.WorldSettings.GameType gameType,
+            CallbackInfo ci) {
+        if (TweaksConfig.syncWorldSeedToClientWorld) {
+            hodgepodge$hasWorldSeed = true;
+            hodgepodge$worldSeed = FMLCommonHandler.instance().getMinecraftServerInstance()
+                    .worldServerForDimension(this.field_149088_a).getSeed();
+        }
+    }
+
+    @Inject(method = "writePacketData", at = @At("TAIL"))
+    private void hodgepodge$writeWorldSeed(PacketBuffer data, CallbackInfo ci) {
+        if (TweaksConfig.syncWorldSeedToClientWorld) {
+            data.writeLong(hodgepodge$worldSeed);
+        }
+    }
+
+    @Inject(method = "readPacketData", at = @At("TAIL"))
+    private void hodgepodge$readWorldSeed(PacketBuffer data, CallbackInfo ci) {
+        if (data.readableBytes() >= 8) {
+            hodgepodge$hasWorldSeed = true;
+            hodgepodge$worldSeed = data.readLong();
+        } else {
+            hodgepodge$hasWorldSeed = false;
+            hodgepodge$worldSeed = 0L;
+        }
+    }
+
+    @Override
+    public boolean hodgepodge$hasWorldSeed() {
+        return hodgepodge$hasWorldSeed;
+    }
+
+    @Override
+    public long hodgepodge$getWorldSeed() {
+        return hodgepodge$worldSeed;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/WorldSeedPacketExt.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/WorldSeedPacketExt.java
@@ -1,0 +1,8 @@
+package com.mitchej123.hodgepodge.mixins.interfaces;
+
+public interface WorldSeedPacketExt {
+
+    boolean hodgepodge$hasWorldSeed();
+
+    long hodgepodge$getWorldSeed();
+}


### PR DESCRIPTION
For Distant Horizons.
When Distant Horizons is not installed in the server, we can still use it in client only mode.
However, we need to get biome info not from the chunk, but from the world to be compatible with other mods (like LOTR).

Vanilla client side world has always seed 0, so it will always generate mismatching biome info. This PR aims to fix that by synchronizing the seed.

Note: No idea why during `ChunkEvent.Load` we don't have the biome info from the server yet, but we need to go through world anyways due to messy mod compat...

Needs more testing for now.