### PR TITLE
Fix villager trading desync

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -455,6 +455,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixFakePlayerChatCrash;
 
+    @Config.Comment("Fix Villagers only updating out-of-stock state after reopening GUI")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixVillagerTradingDesync;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -503,6 +503,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean minLootingIsZero;
 
+    @Config.Comment("Fix Villagers only updating out-of-stock state after reopening GUI")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixVillagerTradingDesync;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -976,6 +976,15 @@ public enum Mixins implements IMixins {
             .addCommonMixins("forge.MixinFakePlayer")
             .setApplyIf(() -> FixesConfig.fixFakePlayerChatCrash)
             .setPhase(Phase.EARLY)),
+    FIX_VILLAGER_TRADING_DESYNC(new MixinBuilder("Fix Villagers only updating out-of-stock state after reopening GUI")
+            .addCommonMixins(
+                    "minecraft.villager.AccessorMerchantRecipe",
+                    "minecraft.villager.MixinMerchantRecipeList_WritePacketData")
+            .addClientMixins(
+                    "minecraft.villager.MixinMerchantRecipeList_ReadPacketData",
+                    "minecraft.villager.MixinNpcMerchant")
+            .setApplyIf(() -> FixesConfig.fixVillagerTradingDesync)
+            .setPhase(Phase.EARLY)),
 
     // Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1095,6 +1095,15 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.crashfixes.MixinEnchantmentHelper")
             .setApplyIf(() -> FixesConfig.minLootingIsZero)
             .setPhase(Phase.EARLY)),
+    FIX_VILLAGER_TRADING_DESYNC(new MixinBuilder("Fix Villagers only updating out-of-stock state after reopening GUI")
+            .addCommonMixins(
+                    "minecraft.villager.AccessorMerchantRecipe",
+                    "minecraft.villager.MixinMerchantRecipeList_WritePacketData")
+            .addClientMixins(
+                    "minecraft.villager.MixinMerchantRecipeList_ReadPacketData",
+                    "minecraft.villager.MixinNpcMerchant")
+            .setApplyIf(() -> FixesConfig.fixVillagerTradingDesync)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/AccessorMerchantRecipe.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/AccessorMerchantRecipe.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.villager;
+
+import net.minecraft.village.MerchantRecipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MerchantRecipe.class)
+public interface AccessorMerchantRecipe {
+
+    @Accessor(value = "toolUses")
+    int hodgepodge$getToolUses();
+
+    @Accessor(value = "toolUses")
+    void hodgepodge$setToolUses(int toolUses);
+
+    @Accessor(value = "maxTradeUses")
+    int hodgepodge$getMaxTradeUses();
+
+    @Accessor(value = "maxTradeUses")
+    void hodgepodge$setMaxTradeUses(int maxTradeUses);
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_ReadPacketData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_ReadPacketData.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.villager;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.village.MerchantRecipeList;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+@Mixin(MerchantRecipeList.class)
+public class MixinMerchantRecipeList_ReadPacketData {
+
+    @ModifyReturnValue(method = "func_151390_b", at = @At(value = "TAIL"))
+    private static MerchantRecipeList hodgepodge$readPacketData(MerchantRecipeList original, PacketBuffer buffer) {
+        for (Object recipe : original) {
+            ((AccessorMerchantRecipe) recipe).hodgepodge$setToolUses(buffer.readVarIntFromBuffer());
+            ((AccessorMerchantRecipe) recipe).hodgepodge$setMaxTradeUses(buffer.readVarIntFromBuffer());
+        }
+        return original;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_ReadPacketData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_ReadPacketData.java
@@ -13,6 +13,17 @@ public class MixinMerchantRecipeList_ReadPacketData {
 
     @ModifyReturnValue(method = "func_151390_b", at = @At(value = "TAIL"))
     private static MerchantRecipeList hodgepodge$readPacketData(MerchantRecipeList original, PacketBuffer buffer) {
+        // This is a S3FPacketCustomPayload, so the buffer is almost always larger than needed with the rest being zeros
+        // To make this not set tool uses and max trade uses to zero if hodgepodge is not present on the server side,
+        // cancel if the signal from the server side patch is not detected
+        if (buffer.readableBytes() == 0 || !buffer.readBoolean()) {
+            // we're on a vanilla server, so we don't know max trades, so like vanilla we don't limit trades at all
+            for (Object recipe : original) {
+                ((AccessorMerchantRecipe) recipe).hodgepodge$setMaxTradeUses(Integer.MAX_VALUE);
+            }
+            return original;
+        }
+
         for (Object recipe : original) {
             ((AccessorMerchantRecipe) recipe).hodgepodge$setToolUses(buffer.readVarIntFromBuffer());
             ((AccessorMerchantRecipe) recipe).hodgepodge$setMaxTradeUses(buffer.readVarIntFromBuffer());

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_WritePacketData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_WritePacketData.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.villager;
+
+import java.util.ArrayList;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.village.MerchantRecipe;
+import net.minecraft.village.MerchantRecipeList;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MerchantRecipeList.class)
+public class MixinMerchantRecipeList_WritePacketData extends ArrayList<MerchantRecipe> {
+
+    @Inject(method = "func_151391_a", at = @At(value = "TAIL"))
+    public void hodgepodge$writePacketData(PacketBuffer buffer, CallbackInfo ci) {
+        for (MerchantRecipe recipe : this) {
+            buffer.writeVarIntToBuffer(((AccessorMerchantRecipe) recipe).hodgepodge$getToolUses());
+            buffer.writeVarIntToBuffer(((AccessorMerchantRecipe) recipe).hodgepodge$getMaxTradeUses());
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_WritePacketData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_WritePacketData.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.villager;
+
+import java.util.ArrayList;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.village.MerchantRecipe;
+import net.minecraft.village.MerchantRecipeList;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MerchantRecipeList.class)
+public class MixinMerchantRecipeList_WritePacketData extends ArrayList<MerchantRecipe> {
+
+    @Inject(method = "func_151391_a", at = @At(value = "TAIL"))
+    private void hodgepodge$writePacketData(PacketBuffer buffer, CallbackInfo ci) {
+        for (MerchantRecipe recipe : this) {
+            buffer.writeVarIntToBuffer(((AccessorMerchantRecipe) recipe).hodgepodge$getToolUses());
+            buffer.writeVarIntToBuffer(((AccessorMerchantRecipe) recipe).hodgepodge$getMaxTradeUses());
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_WritePacketData.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinMerchantRecipeList_WritePacketData.java
@@ -16,6 +16,9 @@ public class MixinMerchantRecipeList_WritePacketData extends ArrayList<MerchantR
 
     @Inject(method = "func_151391_a", at = @At(value = "TAIL"))
     private void hodgepodge$writePacketData(PacketBuffer buffer, CallbackInfo ci) {
+        // signal to client that the following data is real data and not just padding
+        buffer.writeBoolean(true);
+
         for (MerchantRecipe recipe : this) {
             buffer.writeVarIntToBuffer(((AccessorMerchantRecipe) recipe).hodgepodge$getToolUses());
             buffer.writeVarIntToBuffer(((AccessorMerchantRecipe) recipe).hodgepodge$getMaxTradeUses());

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinNpcMerchant.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinNpcMerchant.java
@@ -1,0 +1,18 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.villager;
+
+import net.minecraft.entity.NpcMerchant;
+import net.minecraft.village.MerchantRecipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(NpcMerchant.class)
+public class MixinNpcMerchant {
+
+    @Inject(method = "useRecipe", at = @At(value = "HEAD"))
+    public void hodgepodge$useRecipe(MerchantRecipe recipe, CallbackInfo ci) {
+        recipe.incrementToolUses();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinNpcMerchant.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/villager/MixinNpcMerchant.java
@@ -1,0 +1,18 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.villager;
+
+import net.minecraft.entity.NpcMerchant;
+import net.minecraft.village.MerchantRecipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(NpcMerchant.class)
+public class MixinNpcMerchant {
+
+    @Inject(method = "useRecipe", at = @At(value = "HEAD"))
+    private void hodgepodge$useRecipe(MerchantRecipe recipe, CallbackInfo ci) {
+        recipe.incrementToolUses();
+    }
+}


### PR DESCRIPTION
Currently in vanilla when trading with villagers, they only update the out-of-stock state after reopening their GUI. 
This is most obvious when shift-clicking a trade result into ones own inventory for a single emerald recipe for example.
Shift-clicking such a recipe result will correctly trade all the available number of trades, but not stop after, so you get a bunch of ghost items on top of the normal items too.
The reason for this is that the `IMerchant` used client side implements none of the server side logic, not even the updating of trades used. Additionally the number of already used trades and maximum number of trades is also not even sent to the client together with the recipe list.

This PR simply adds the number of trades used and the max number of trades to the recipe list packet, and adds the logic for incrementing the number of trades used for a recipe on the client side too.
This is enough to make everything work as expected.