### PR TITLE
Add color code support for text rendering

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.9.47:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.9.52:dev")
 
     compileOnly("com.gtnewhorizons.retrofuturabootstrap:RetroFuturaBootstrap:1.0.16") { transitive = false }
     compileOnly("com.mitchej123:supernova:0.0.2:api") { transitive = false }

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -8,6 +8,10 @@ public class TweaksConfig {
 
     // Minecraft
 
+    @Config.Comment("Sign input counts visible characters only, ignoring color format codes like &RRGGBB")
+    @Config.DefaultBoolean(true)
+    public static boolean signInputIgnoresFormatCodes;
+
     @Config.Comment("Adds a button in the sounds menu to reload the sound system without needing to press F3 + S")
     @Config.DefaultBoolean(true)
     public static boolean reloadSoundsButton;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -23,6 +23,15 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGameSettings_SprintKey")
             .setApplyIf(() -> TweaksConfig.changeSprintCategory)
             .setPhase(Phase.EARLY)),
+    SIGN_INPUT_IGNORES_FORMAT_CODES(new MixinBuilder("Sign input counts visible chars only")
+            .addClientMixins("minecraft.MixinGuiEditSign")
+            .addCommonMixins("minecraft.MixinNetHandlerPlayServer_SignLimit")
+            .setApplyIf(() -> TweaksConfig.signInputIgnoresFormatCodes)
+            .setPhase(Phase.EARLY)),
+    ANVIL_INPUT_IGNORES_FORMAT_CODES(new MixinBuilder("Anvil rename counts visible chars only, format codes don't eat the 30-char limit")
+            .addCommonMixins("minecraft.MixinNetHandlerPlayServer_AnvilColorCodes")
+            .setApplyIf(() -> TweaksConfig.signInputIgnoresFormatCodes)
+            .setPhase(Phase.EARLY)),
     FIX_TOO_MANY_ALLOCATIONS_CHUNK_POSITION_INT_PAIR(new MixinBuilder("Stops MC from allocating too many ChunkPositionIntPair objects")
             .addCommonMixins(
                     "minecraft.MixinChunkCoordIntPair_FixAllocations",
@@ -605,7 +614,9 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> TweaksConfig.creativeTabLocalizationOverrides)
             .setPhase(Phase.EARLY)),
     FIX_CHAT_COLOR_WRAPPING(new MixinBuilder("Fix wrapped chat lines missing colors")
-            .addClientMixins("minecraft.MixinGuiNewChat_FixColorWrapping")
+            .addClientMixins(
+                    "minecraft.MixinGuiNewChat_FixColorWrapping",
+                    "minecraft.MixinGuiTextField_FixColorScroll")
             .setApplyIf(() -> FixesConfig.fixChatWrappedColors)
             .setPhase(Phase.EARLY)),
     COMPACT_CHAT(new MixinBuilder()

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -25,7 +25,10 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     SIGN_INPUT_IGNORES_FORMAT_CODES(new MixinBuilder("Sign input counts visible chars only")
             .addClientMixins("minecraft.MixinGuiEditSign")
-            .addCommonMixins("minecraft.MixinNetHandlerPlayServer_SignLimit")
+            .addCommonMixins(
+                    "minecraft.MixinNetHandlerPlayServer_SignLimit",
+                    "minecraft.MixinC12PacketUpdateSign_RaiseReadLimit",
+                    "minecraft.MixinTileEntitySign_RaiseNbtReadLimit")
             .setApplyIf(() -> TweaksConfig.signInputIgnoresFormatCodes)
             .setPhase(Phase.EARLY)),
     ANVIL_INPUT_IGNORES_FORMAT_CODES(new MixinBuilder("Anvil rename counts visible chars only, format codes don't eat the 30-char limit")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinC12PacketUpdateSign_RaiseReadLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinC12PacketUpdateSign_RaiseReadLimit.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.play.client.C12PacketUpdateSign;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+/**
+ * Vanilla {@code C12PacketUpdateSign.readPacketData} calls {@code readStringFromBuffer(15)} per line, which throws if
+ * the incoming line is longer than 15 raw chars. With {@code &} color codes, a legitimate line can exceed 15 raw chars
+ * (e.g. {@code &g&#FF0000&#0000FFhello} is 23 raw but 5 visible). Raise the read cap to 90 to match the safety cap in
+ * {@link MixinNetHandlerPlayServer_SignLimit}; visible-char validation in {@code processUpdateSign} still enforces the
+ * 15-visible limit.
+ */
+@Mixin(C12PacketUpdateSign.class)
+public class MixinC12PacketUpdateSign_RaiseReadLimit {
+
+    @ModifyConstant(method = "readPacketData", constant = @Constant(intValue = 15))
+    private int hodgepodge$raisePacketReadLimit(int original) {
+        return 90;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(FontRenderer.class)
 public abstract class MixinFontRenderer {
@@ -43,6 +44,15 @@ public abstract class MixinFontRenderer {
             output.append('\n');
             formatting.append(line);
             String newFormat = getFormatFromString(formatting.toString());
+
+            // Handle gradient continuation: interpolate color at wrap point
+            if (newFormat.length() >= 30 && newFormat.charAt(0) == '\u00a7' && newFormat.charAt(1) == 'g') {
+                String remainder = StringUtils.substring(
+                        str,
+                        lineWidth + (str.charAt(lineWidth) == ' ' || str.charAt(lineWidth) == '\n' ? 1 : 0));
+                newFormat = hodgepodge$interpolateGradient(newFormat, formatting.toString(), remainder);
+            }
+
             formatting.setLength(0);
             formatting.append(newFormat);
             output.append(formatting);
@@ -51,5 +61,70 @@ public abstract class MixinFontRenderer {
             str = StringUtils.substring(str, lineWidth + (nextIsBlank ? 1 : 0));
         }
         return output.toString();
+    }
+
+    @Unique
+    private static String hodgepodge$interpolateGradient(String gradientFormat, String rendered, String remaining) {
+        int startRgb = hodgepodge$parseRgb(gradientFormat, 2);
+        int endRgb = hodgepodge$parseRgb(gradientFormat, 16);
+        if (startRgb == -1 || endRgb == -1) return gradientFormat;
+
+        int gradientIdx = rendered.indexOf("\u00a7g");
+        int visRendered = gradientIdx >= 0 ? hodgepodge$countVisible(rendered, gradientIdx + 30)
+                : hodgepodge$countVisible(rendered, 0);
+        int visRemaining = hodgepodge$countVisible(remaining, 0);
+        int total = visRendered + visRemaining;
+
+        if (total <= 1) {
+            return hodgepodge$buildSectionX(endRgb);
+        }
+
+        float t = Math.min((float) visRendered / (total - 1), 1f);
+        int interpRgb = hodgepodge$lerpRgb(startRgb, endRgb, t);
+        return "\u00a7g" + hodgepodge$buildSectionX(interpRgb) + hodgepodge$buildSectionX(endRgb);
+    }
+
+    @Unique
+    private static int hodgepodge$lerpRgb(int from, int to, float t) {
+        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
+        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
+        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
+        return (r << 16) | (g << 8) | b;
+    }
+
+    @Unique
+    private static int hodgepodge$parseRgb(String text, int offset) {
+        if (offset + 13 >= text.length()) return -1;
+        int val = 0;
+        for (int i = 0; i < 6; i++) {
+            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
+            if (d == -1) return -1;
+            val = (val << 4) | d;
+        }
+        return val;
+    }
+
+    @Unique
+    private static String hodgepodge$buildSectionX(int rgb) {
+        char S = '\u00a7';
+        int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
+        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
+                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
+                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
+                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
+                .append(Character.forDigit(b & 0xF, 16)).toString();
+    }
+
+    @Unique
+    private static int hodgepodge$countVisible(String text, int startIdx) {
+        int count = 0;
+        for (int i = startIdx; i < text.length(); i++) {
+            if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
+                i++;
+            } else {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
@@ -8,6 +8,8 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
+import com.mitchej123.hodgepodge.util.ColorFormatUtils;
+
 @Mixin(FontRenderer.class)
 public abstract class MixinFontRenderer {
 
@@ -65,8 +67,8 @@ public abstract class MixinFontRenderer {
 
     @Unique
     private static String hodgepodge$interpolateGradient(String gradientFormat, String rendered, String remaining) {
-        int startRgb = hodgepodge$parseRgb(gradientFormat, 2);
-        int endRgb = hodgepodge$parseRgb(gradientFormat, 16);
+        int startRgb = ColorFormatUtils.parseRgbFromSectionX(gradientFormat, 2);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(gradientFormat, 16);
         if (startRgb == -1 || endRgb == -1) return gradientFormat;
 
         int gradientIdx = rendered.indexOf("\u00a7g");
@@ -76,43 +78,12 @@ public abstract class MixinFontRenderer {
         int total = visRendered + visRemaining;
 
         if (total <= 1) {
-            return hodgepodge$buildSectionX(endRgb);
+            return ColorFormatUtils.buildSectionX(endRgb);
         }
 
         float t = Math.min((float) visRendered / (total - 1), 1f);
-        int interpRgb = hodgepodge$lerpRgb(startRgb, endRgb, t);
-        return "\u00a7g" + hodgepodge$buildSectionX(interpRgb) + hodgepodge$buildSectionX(endRgb);
-    }
-
-    @Unique
-    private static int hodgepodge$lerpRgb(int from, int to, float t) {
-        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
-        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
-        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
-        return (r << 16) | (g << 8) | b;
-    }
-
-    @Unique
-    private static int hodgepodge$parseRgb(String text, int offset) {
-        if (offset + 13 >= text.length()) return -1;
-        int val = 0;
-        for (int i = 0; i < 6; i++) {
-            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
-            if (d == -1) return -1;
-            val = (val << 4) | d;
-        }
-        return val;
-    }
-
-    @Unique
-    private static String hodgepodge$buildSectionX(int rgb) {
-        char S = '\u00a7';
-        int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
-        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
-                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
-                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
-                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
-                .append(Character.forDigit(b & 0xF, 16)).toString();
+        int interpRgb = ColorFormatUtils.lerpRgb(startRgb, endRgb, t);
+        return "\u00a7g" + ColorFormatUtils.buildSectionX(interpRgb) + ColorFormatUtils.buildSectionX(endRgb);
     }
 
     @Unique

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiEditSign.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiEditSign.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.gui.inventory.GuiEditSign;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+
+@Mixin(GuiEditSign.class)
+public class MixinGuiEditSign {
+
+    @Redirect(method = "keyTyped", at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 2))
+    private int hodgepodge$signVisibleLength(String str) {
+        if (str.length() >= 90) return 15;
+        return FontRendering.countVisibleChars(str);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
@@ -4,13 +4,48 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiNewChat;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
 import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(GuiNewChat.class)
 public class MixinGuiNewChat_FixColorWrapping {
+
+    @Unique
+    private static boolean hodgepodge$preprocessChecked = false;
+    @Unique
+    private static boolean hodgepodge$preprocessAvailable = false;
+
+    @Unique
+    private static String hodgepodge$safePreprocess(String s) {
+        if (!hodgepodge$preprocessChecked) {
+            hodgepodge$preprocessChecked = true;
+            try {
+                FontRendering.class.getMethod("preprocessText", String.class);
+                hodgepodge$preprocessAvailable = true;
+            } catch (NoSuchMethodException e) {
+                hodgepodge$preprocessAvailable = false;
+            }
+        }
+        return hodgepodge$preprocessAvailable ? FontRendering.preprocessText(s) : s;
+    }
+
+    /**
+     * Preprocess the per-component string (convert &#RRGGBB → §x§R§R§G§G§B§B) before any width calculations, trimming,
+     * or format extraction happen.
+     */
+    @ModifyVariable(
+            method = "func_146237_a",
+            at = @At(
+                    value = "INVOKE_ASSIGN",
+                    target = "Lnet/minecraft/client/gui/GuiNewChat;func_146235_b(Ljava/lang/String;)Ljava/lang/String;"),
+            name = "s")
+    private String hodgepodge$preprocessBeforeWrap(String s) {
+        return hodgepodge$safePreprocess(s);
+    }
 
     @ModifyVariable(
             method = "func_146237_a",
@@ -21,7 +56,100 @@ public class MixinGuiNewChat_FixColorWrapping {
                     shift = At.Shift.BEFORE),
             name = "s2")
     private String hodgepodge$fixColorWrapping(String s2, @Local(name = "s1") String s1) {
-        return FontRenderer.getFormatFromString(s1) + s2;
+        String format = FontRenderer.getFormatFromString(s1);
+
+        // Handle gradient: instead of restarting the full gradient on each wrapped line,
+        // compute the interpolated color at the wrap point and emit a new gradient
+        // from that color to the end color. This makes the gradient continue seamlessly.
+        if (format.length() >= 30 && format.charAt(0) == '\u00a7' && format.charAt(1) == 'g') {
+            return hodgepodge$continueGradient(format, s1, s2);
+        }
+
+        return format + s2;
     }
 
+    /**
+     * Build a continuation gradient from the interpolated color at the wrap point to the original end color.
+     */
+    @Unique
+    private static String hodgepodge$continueGradient(String gradientFormat, String s1, String s2) {
+        // Parse start/end RGB from §g§x§R§R§G§G§B§B§x§R§R§G§G§B§B (30 chars)
+        int startRgb = hodgepodge$parseRgbFromSectionX(gradientFormat, 2);
+        int endRgb = hodgepodge$parseRgbFromSectionX(gradientFormat, 16);
+        if (startRgb == -1 || endRgb == -1) {
+            return gradientFormat + s2;
+        }
+
+        // Count visible chars rendered on the current line (after gradient prefix in s1)
+        int gradientStart = s1.indexOf("\u00a7g");
+        int visibleOnLine = gradientStart >= 0 ? hodgepodge$countVisible(s1, gradientStart + 30)
+                : hodgepodge$countVisible(s1, 0);
+
+        // Count visible chars remaining
+        int visibleRemaining = hodgepodge$countVisible(s2, 0);
+        int totalVisible = visibleOnLine + visibleRemaining;
+
+        if (totalVisible <= 1) {
+            // Not enough chars for meaningful gradient, use end color
+            return hodgepodge$buildSectionX(endRgb) + s2;
+        }
+
+        // Interpolate color at the wrap point
+        float t = (float) visibleOnLine / (totalVisible - 1);
+        t = Math.min(t, 1f);
+        int interpRgb = hodgepodge$lerpRgb(startRgb, endRgb, t);
+
+        // Emit a new gradient from interpolated color to end color
+        return "\u00a7g" + hodgepodge$buildSectionX(interpRgb) + hodgepodge$buildSectionX(endRgb) + s2;
+    }
+
+    @Unique
+    private static int hodgepodge$lerpRgb(int from, int to, float t) {
+        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
+        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
+        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
+        return (r << 16) | (g << 8) | b;
+    }
+
+    /** Parse RGB int from §x§R§R§G§G§B§B starting at offset in text. Returns -1 on failure. */
+    @Unique
+    private static int hodgepodge$parseRgbFromSectionX(String text, int offset) {
+        if (offset + 13 >= text.length()) return -1;
+        // §x at offset, then §R§R§G§G§B§B = 6 hex digit pairs at offset+2,+4,+6,+8,+10,+12
+        int val = 0;
+        for (int i = 0; i < 6; i++) {
+            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
+            if (d == -1) return -1;
+            val = (val << 4) | d;
+        }
+        return val;
+    }
+
+    /** Build §x§R§R§G§G§B§B from an RGB int. */
+    @Unique
+    private static String hodgepodge$buildSectionX(int rgb) {
+        int r = (rgb >> 16) & 0xFF;
+        int g = (rgb >> 8) & 0xFF;
+        int b = rgb & 0xFF;
+        char S = '\u00a7';
+        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
+                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
+                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
+                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
+                .append(Character.forDigit(b & 0xF, 16)).toString();
+    }
+
+    /** Count visible characters in text starting from startIdx, skipping §X format pairs. */
+    @Unique
+    private static int hodgepodge$countVisible(String text, int startIdx) {
+        int count = 0;
+        for (int i = startIdx; i < text.length(); i++) {
+            if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
+                i++;
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import com.llamalad7.mixinextras.sugar.Local;
+import com.mitchej123.hodgepodge.util.ColorFormatUtils;
 import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 
 @Mixin(GuiNewChat.class)
@@ -50,13 +51,14 @@ public class MixinGuiNewChat_FixColorWrapping {
         while (gIdx != -1 && gIdx + 29 < text.length()) {
             // Validate §g followed by two §x§R§R§G§G§B§B sequences (30 chars total)
             if (text.charAt(gIdx + 2) != '\u00a7' || Character.toLowerCase(text.charAt(gIdx + 3)) != 'x'
-                || text.charAt(gIdx + 16) != '\u00a7' || Character.toLowerCase(text.charAt(gIdx + 17)) != 'x') {
+                    || text.charAt(gIdx + 16) != '\u00a7'
+                    || Character.toLowerCase(text.charAt(gIdx + 17)) != 'x') {
                 gIdx = text.indexOf("\u00a7g", gIdx + 2);
                 continue;
             }
 
-            int startRgb = hodgepodge$parseRgbFromSectionX(text, gIdx + 2);
-            int endRgb = hodgepodge$parseRgbFromSectionX(text, gIdx + 16);
+            int startRgb = ColorFormatUtils.parseRgbFromSectionX(text, gIdx + 2);
+            int endRgb = ColorFormatUtils.parseRgbFromSectionX(text, gIdx + 16);
             if (startRgb == -1 || endRgb == -1) {
                 gIdx = text.indexOf("\u00a7g", gIdx + 2);
                 continue;
@@ -80,8 +82,11 @@ public class MixinGuiNewChat_FixColorWrapping {
                 if (ch == '\u00a7' && i + 1 < text.length()) {
                     char code = Character.toLowerCase(text.charAt(i + 1));
                     // Gradient terminators: stop expanding
-                    if (code == 'r' || (code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')
-                        || code == 'x' || code == 'q' || code == 'g') {
+                    if (code == 'r' || (code >= '0' && code <= '9')
+                            || (code >= 'a' && code <= 'f')
+                            || code == 'x'
+                            || code == 'q'
+                            || code == 'g') {
                         last = i;
                         break;
                     }
@@ -92,8 +97,8 @@ public class MixinGuiNewChat_FixColorWrapping {
                     // Visible char: emit interpolated §x color + the char
                     float t = totalVisible > 1 ? (float) visIdx / (totalVisible - 1) : 0f;
                     t = Math.min(t, 1f);
-                    int rgb = hodgepodge$lerpRgb(startRgb, endRgb, t);
-                    sb.append(hodgepodge$buildSectionX(rgb));
+                    int rgb = ColorFormatUtils.lerpRgb(startRgb, endRgb, t);
+                    sb.append(ColorFormatUtils.buildSectionX(rgb));
                     sb.append(ch);
                     visIdx++;
                     if (visIdx >= totalVisible) {
@@ -120,8 +125,11 @@ public class MixinGuiNewChat_FixColorWrapping {
             char ch = text.charAt(i);
             if (ch == '\u00a7' && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
-                if (code == 'r' || (code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')
-                    || code == 'x' || code == 'q' || code == 'g') {
+                if (code == 'r' || (code >= '0' && code <= '9')
+                        || (code >= 'a' && code <= 'f')
+                        || code == 'x'
+                        || code == 'q'
+                        || code == 'g') {
                     break;
                 }
                 i++; // skip non-terminating format codes
@@ -143,42 +151,6 @@ public class MixinGuiNewChat_FixColorWrapping {
     private String hodgepodge$fixColorWrapping(String s2, @Local(name = "s1") String s1) {
         String format = FontRenderer.getFormatFromString(s1);
         return format + s2;
-    }
-
-    @Unique
-    private static int hodgepodge$lerpRgb(int from, int to, float t) {
-        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
-        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
-        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
-        return (r << 16) | (g << 8) | b;
-    }
-
-    /** Parse RGB int from §x§R§R§G§G§B§B starting at offset in text. Returns -1 on failure. */
-    @Unique
-    private static int hodgepodge$parseRgbFromSectionX(String text, int offset) {
-        if (offset + 13 >= text.length()) return -1;
-        // §x at offset, then §R§R§G§G§B§B = 6 hex digit pairs at offset+2,+4,+6,+8,+10,+12
-        int val = 0;
-        for (int i = 0; i < 6; i++) {
-            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
-            if (d == -1) return -1;
-            val = (val << 4) | d;
-        }
-        return val;
-    }
-
-    /** Build §x§R§R§G§G§B§B from an RGB int. */
-    @Unique
-    private static String hodgepodge$buildSectionX(int rgb) {
-        int r = (rgb >> 16) & 0xFF;
-        int g = (rgb >> 8) & 0xFF;
-        int b = rgb & 0xFF;
-        char S = '\u00a7';
-        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
-                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
-                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
-                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
-                .append(Character.forDigit(b & 0xF, 16)).toString();
     }
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
@@ -8,29 +8,15 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 
 @Mixin(GuiNewChat.class)
 public class MixinGuiNewChat_FixColorWrapping {
 
     @Unique
-    private static boolean hodgepodge$preprocessChecked = false;
-    @Unique
-    private static boolean hodgepodge$preprocessAvailable = false;
-
-    @Unique
     private static String hodgepodge$safePreprocess(String s) {
-        if (!hodgepodge$preprocessChecked) {
-            hodgepodge$preprocessChecked = true;
-            try {
-                FontRendering.class.getMethod("preprocessText", String.class);
-                hodgepodge$preprocessAvailable = true;
-            } catch (NoSuchMethodException e) {
-                hodgepodge$preprocessAvailable = false;
-            }
-        }
-        return hodgepodge$preprocessAvailable ? FontRendering.preprocessText(s) : s;
+        return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(s) : s;
     }
 
     /**
@@ -44,7 +30,106 @@ public class MixinGuiNewChat_FixColorWrapping {
                     target = "Lnet/minecraft/client/gui/GuiNewChat;func_146235_b(Ljava/lang/String;)Ljava/lang/String;"),
             name = "s")
     private String hodgepodge$preprocessBeforeWrap(String s) {
-        return hodgepodge$safePreprocess(s);
+        s = hodgepodge$safePreprocess(s);
+        return hodgepodge$expandGradients(s);
+    }
+
+    /**
+     * Expand §g gradients into per-character §x colors so that line wrapping preserves the correct color at every
+     * character. Without this, the renderer's per-line countVisibleChars reaches t=1.0 at the end of each wrapped line,
+     * causing a color jump at wrap boundaries.
+     */
+    @Unique
+    private static String hodgepodge$expandGradients(String text) {
+        int gIdx = text.indexOf("\u00a7g");
+        if (gIdx == -1) return text;
+
+        StringBuilder sb = new StringBuilder(text.length() + 128);
+        int last = 0;
+
+        while (gIdx != -1 && gIdx + 29 < text.length()) {
+            // Validate §g followed by two §x§R§R§G§G§B§B sequences (30 chars total)
+            if (text.charAt(gIdx + 2) != '\u00a7' || Character.toLowerCase(text.charAt(gIdx + 3)) != 'x'
+                || text.charAt(gIdx + 16) != '\u00a7' || Character.toLowerCase(text.charAt(gIdx + 17)) != 'x') {
+                gIdx = text.indexOf("\u00a7g", gIdx + 2);
+                continue;
+            }
+
+            int startRgb = hodgepodge$parseRgbFromSectionX(text, gIdx + 2);
+            int endRgb = hodgepodge$parseRgbFromSectionX(text, gIdx + 16);
+            if (startRgb == -1 || endRgb == -1) {
+                gIdx = text.indexOf("\u00a7g", gIdx + 2);
+                continue;
+            }
+
+            // Count visible chars in the gradient span (until §r, color code, or another gradient/rainbow)
+            int textStart = gIdx + 30;
+            int totalVisible = hodgepodge$countGradientVisible(text, textStart);
+            if (totalVisible <= 0) {
+                gIdx = text.indexOf("\u00a7g", gIdx + 2);
+                continue;
+            }
+
+            // Append everything before the §g prefix
+            sb.append(text, last, gIdx);
+
+            // Expand each visible char with its interpolated §x color
+            int visIdx = 0;
+            for (int i = textStart; i < text.length(); i++) {
+                char ch = text.charAt(i);
+                if (ch == '\u00a7' && i + 1 < text.length()) {
+                    char code = Character.toLowerCase(text.charAt(i + 1));
+                    // Gradient terminators: stop expanding
+                    if (code == 'r' || (code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')
+                        || code == 'x' || code == 'q' || code == 'g') {
+                        last = i;
+                        break;
+                    }
+                    // Non-terminating format code (style toggles): pass through
+                    sb.append(ch).append(text.charAt(i + 1));
+                    i++;
+                } else {
+                    // Visible char: emit interpolated §x color + the char
+                    float t = totalVisible > 1 ? (float) visIdx / (totalVisible - 1) : 0f;
+                    t = Math.min(t, 1f);
+                    int rgb = hodgepodge$lerpRgb(startRgb, endRgb, t);
+                    sb.append(hodgepodge$buildSectionX(rgb));
+                    sb.append(ch);
+                    visIdx++;
+                    if (visIdx >= totalVisible) {
+                        last = i + 1;
+                        break;
+                    }
+                }
+                last = i + 1;
+            }
+
+            gIdx = text.indexOf("\u00a7g", last);
+        }
+
+        if (last == 0) return text;
+        sb.append(text, last, text.length());
+        return sb.toString();
+    }
+
+    /** Count visible chars from startIdx until a gradient-terminating code (§r, §0-f, §x, §q, §g). */
+    @Unique
+    private static int hodgepodge$countGradientVisible(String text, int startIdx) {
+        int count = 0;
+        for (int i = startIdx; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch == '\u00a7' && i + 1 < text.length()) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (code == 'r' || (code >= '0' && code <= '9') || (code >= 'a' && code <= 'f')
+                    || code == 'x' || code == 'q' || code == 'g') {
+                    break;
+                }
+                i++; // skip non-terminating format codes
+            } else {
+                count++;
+            }
+        }
+        return count;
     }
 
     @ModifyVariable(
@@ -57,50 +142,7 @@ public class MixinGuiNewChat_FixColorWrapping {
             name = "s2")
     private String hodgepodge$fixColorWrapping(String s2, @Local(name = "s1") String s1) {
         String format = FontRenderer.getFormatFromString(s1);
-
-        // Handle gradient: instead of restarting the full gradient on each wrapped line,
-        // compute the interpolated color at the wrap point and emit a new gradient
-        // from that color to the end color. This makes the gradient continue seamlessly.
-        if (format.length() >= 30 && format.charAt(0) == '\u00a7' && format.charAt(1) == 'g') {
-            return hodgepodge$continueGradient(format, s1, s2);
-        }
-
         return format + s2;
-    }
-
-    /**
-     * Build a continuation gradient from the interpolated color at the wrap point to the original end color.
-     */
-    @Unique
-    private static String hodgepodge$continueGradient(String gradientFormat, String s1, String s2) {
-        // Parse start/end RGB from §g§x§R§R§G§G§B§B§x§R§R§G§G§B§B (30 chars)
-        int startRgb = hodgepodge$parseRgbFromSectionX(gradientFormat, 2);
-        int endRgb = hodgepodge$parseRgbFromSectionX(gradientFormat, 16);
-        if (startRgb == -1 || endRgb == -1) {
-            return gradientFormat + s2;
-        }
-
-        // Count visible chars rendered on the current line (after gradient prefix in s1)
-        int gradientStart = s1.indexOf("\u00a7g");
-        int visibleOnLine = gradientStart >= 0 ? hodgepodge$countVisible(s1, gradientStart + 30)
-                : hodgepodge$countVisible(s1, 0);
-
-        // Count visible chars remaining
-        int visibleRemaining = hodgepodge$countVisible(s2, 0);
-        int totalVisible = visibleOnLine + visibleRemaining;
-
-        if (totalVisible <= 1) {
-            // Not enough chars for meaningful gradient, use end color
-            return hodgepodge$buildSectionX(endRgb) + s2;
-        }
-
-        // Interpolate color at the wrap point
-        float t = (float) visibleOnLine / (totalVisible - 1);
-        t = Math.min(t, 1f);
-        int interpRgb = hodgepodge$lerpRgb(startRgb, endRgb, t);
-
-        // Emit a new gradient from interpolated color to end color
-        return "\u00a7g" + hodgepodge$buildSectionX(interpRgb) + hodgepodge$buildSectionX(endRgb) + s2;
     }
 
     @Unique
@@ -139,17 +181,4 @@ public class MixinGuiNewChat_FixColorWrapping {
                 .append(Character.forDigit(b & 0xF, 16)).toString();
     }
 
-    /** Count visible characters in text starting from startIdx, skipping §X format pairs. */
-    @Unique
-    private static int hodgepodge$countVisible(String text, int startIdx) {
-        int count = 0;
-        for (int i = startIdx; i < text.length(); i++) {
-            if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
-                i++;
-            } else {
-                count++;
-            }
-        }
-        return count;
-    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.mitchej123.hodgepodge.util.ColorFormatUtils;
 import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 
 /**
@@ -171,8 +172,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
         if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return beforeCursor;
 
-        int startRgb = hodgepodge$parseRgb(this.text, fullGradIdx + 2);
-        int endRgb = hodgepodge$parseRgb(this.text, fullGradIdx + 16);
+        int startRgb = ColorFormatUtils.parseRgbFromSectionX(this.text, fullGradIdx + 2);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(this.text, fullGradIdx + 16);
         if (startRgb == -1 || endRgb == -1) return beforeCursor;
 
         int specEnd = fullGradIdx + 30;
@@ -193,8 +194,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
      */
     @Unique
     private String hodgepodge$expandScrolledGradientToPerChar(String activeFormat, String beforeCursor) {
-        int startRgb = hodgepodge$parseRgb(activeFormat, 2);
-        int endRgb = hodgepodge$parseRgb(activeFormat, 16);
+        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 2);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 16);
         if (startRgb == -1 || endRgb == -1) return activeFormat + beforeCursor;
 
         String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
@@ -231,7 +232,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             } else {
                 float t = (float) gradCharIdx / (totalVisible - 1);
                 t = Math.min(t, 1f);
-                sb.append(hodgepodge$buildSectionX(hodgepodge$lerpRgb(startRgb, endRgb, t)));
+                sb.append(ColorFormatUtils.buildSectionX(ColorFormatUtils.lerpRgb(startRgb, endRgb, t)));
                 sb.append(ch);
                 gradCharIdx++;
             }
@@ -272,7 +273,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 // Visible char: emit its exact gradient color
                 float t = (float) gradCharIdx / (totalVisible - 1);
                 t = Math.min(t, 1f);
-                sb.append(hodgepodge$buildSectionX(hodgepodge$lerpRgb(startRgb, endRgb, t)));
+                sb.append(ColorFormatUtils.buildSectionX(ColorFormatUtils.lerpRgb(startRgb, endRgb, t)));
                 sb.append(ch);
                 gradCharIdx++;
             }
@@ -286,8 +287,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
      */
     @Unique
     private String hodgepodge$expandAfterCursorGradientToPerChar(String activeFormat, String afterCursor) {
-        int startRgb = hodgepodge$parseRgb(activeFormat, 2);
-        int endRgb = hodgepodge$parseRgb(activeFormat, 16);
+        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 2);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 16);
         if (startRgb == -1 || endRgb == -1) return activeFormat + afterCursor;
 
         String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
@@ -323,7 +324,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             } else {
                 float t = (float) gradCharIdx / (totalVisible - 1);
                 t = Math.min(t, 1f);
-                sb.append(hodgepodge$buildSectionX(hodgepodge$lerpRgb(startRgb, endRgb, t)));
+                sb.append(ColorFormatUtils.buildSectionX(ColorFormatUtils.lerpRgb(startRgb, endRgb, t)));
                 sb.append(ch);
                 gradCharIdx++;
             }
@@ -448,35 +449,4 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         return count;
     }
 
-    /** Parse RGB int from §x§R§R§G§G§B§B starting at offset. Returns -1 on failure. */
-    @Unique
-    private static int hodgepodge$parseRgb(String text, int offset) {
-        if (offset + 13 >= text.length()) return -1;
-        int val = 0;
-        for (int i = 0; i < 6; i++) {
-            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
-            if (d == -1) return -1;
-            val = (val << 4) | d;
-        }
-        return val;
-    }
-
-    @Unique
-    private static int hodgepodge$lerpRgb(int from, int to, float t) {
-        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
-        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
-        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
-        return (r << 16) | (g << 8) | b;
-    }
-
-    @Unique
-    private static String hodgepodge$buildSectionX(int rgb) {
-        char S = '\u00a7';
-        int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
-        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
-                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
-                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
-                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
-                .append(Character.forDigit(b & 0xF, 16)).toString();
-    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -1,0 +1,496 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiTextField;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+
+/**
+ * Fixes color codes being lost when the chat input field scrolls or splits text at the cursor.
+ *
+ * Two-part fix: 1. HEAD/RETURN: swap text with preprocessed version so trimStringToWidth correctly treats
+ * §x§R§R§G§G§B§B as zero-width format pairs. After recomputing lineScrollOffset, snap it to format code boundaries so
+ * substring never starts mid-§x sequence. 2. ModifyArg on drawStringWithShadow: prepend the active format from the
+ * scrolled-past / cursor-preceding portion, so colors survive substring clipping.
+ */
+@Mixin(GuiTextField.class)
+public abstract class MixinGuiTextField_FixColorScroll extends Gui {
+
+    @Shadow
+    private String text;
+    @Shadow
+    private int lineScrollOffset;
+    @Shadow
+    private int cursorPosition;
+    @Shadow
+    private int selectionEnd;
+    @Shadow
+    private FontRenderer field_146211_a;
+
+    @Shadow
+    public abstract void setSelectionPos(int p_146199_1_);
+
+    @Unique
+    private String hodgepodge$originalText;
+    @Unique
+    private int hodgepodge$originalScrollOffset;
+    @Unique
+    private int hodgepodge$originalCursorPosition;
+    @Unique
+    private int hodgepodge$originalSelectionEnd;
+    @Unique
+    private boolean hodgepodge$swapped;
+
+    @Unique
+    private static boolean hodgepodge$preprocessChecked = false;
+    @Unique
+    private static boolean hodgepodge$preprocessAvailable = false;
+
+    @Unique
+    private static String hodgepodge$safePreprocess(String s) {
+        if (!hodgepodge$preprocessChecked) {
+            hodgepodge$preprocessChecked = true;
+            try {
+                FontRendering.class.getMethod("preprocessText", String.class);
+                hodgepodge$preprocessAvailable = true;
+            } catch (NoSuchMethodException e) {
+                hodgepodge$preprocessAvailable = false;
+            }
+        }
+        return hodgepodge$preprocessAvailable ? FontRendering.preprocessText(s) : s;
+    }
+
+    @Inject(method = "drawTextBox", at = @At("HEAD"))
+    private void hodgepodge$preprocessOnDrawHead(CallbackInfo ci) {
+        hodgepodge$swapped = false;
+        String preprocessed = hodgepodge$safePreprocess(this.text);
+        if (preprocessed.length() == this.text.length()) {
+            return;
+        }
+
+        hodgepodge$originalText = this.text;
+        hodgepodge$originalScrollOffset = this.lineScrollOffset;
+        hodgepodge$originalCursorPosition = this.cursorPosition;
+        hodgepodge$originalSelectionEnd = this.selectionEnd;
+        hodgepodge$swapped = true;
+
+        int[] posMap = hodgepodge$buildPositionMap(this.text, preprocessed);
+
+        int mappedSelection = hodgepodge$mapPosition(posMap, hodgepodge$originalSelectionEnd);
+        this.text = preprocessed;
+        this.cursorPosition = hodgepodge$mapPosition(posMap, hodgepodge$originalCursorPosition);
+
+        // Compute scroll offset in two passes:
+        // 1) Let setSelectionPos compute an initial offset
+        // 2) Snap past any format code boundary
+        // 3) Re-run setSelectionPos so it readjusts to keep cursor visible
+        this.lineScrollOffset = 0;
+        this.setSelectionPos(mappedSelection);
+        int preSnap = this.lineScrollOffset;
+        this.lineScrollOffset = hodgepodge$snapToFormatBoundary(preprocessed, this.lineScrollOffset);
+        int snapped = this.lineScrollOffset - preSnap; // how many extra chars we skipped
+        this.setSelectionPos(mappedSelection);
+        // The snap skipped zero-width format chars, but setSelectionPos doesn't know that.
+        // Add the skipped count so the cursor stays fully in view.
+        if (snapped > 0) {
+            this.lineScrollOffset += snapped;
+        }
+    }
+
+    @Inject(method = "drawTextBox", at = @At("RETURN"))
+    private void hodgepodge$restoreAfterDraw(CallbackInfo ci) {
+        if (!hodgepodge$swapped) return;
+        this.text = hodgepodge$originalText;
+        this.lineScrollOffset = hodgepodge$originalScrollOffset;
+        this.cursorPosition = hodgepodge$originalCursorPosition;
+        this.selectionEnd = hodgepodge$originalSelectionEnd;
+    }
+
+    /**
+     * First drawStringWithShadow (text before cursor / all visible text): prepend active format from text before scroll
+     * offset, and expand any gradient into per-char §x colors so it matches the full gradient's distribution.
+     */
+    @ModifyArg(
+            method = "drawTextBox",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
+                    ordinal = 0),
+            index = 0)
+    private String hodgepodge$fixScrolledColorCodes(String beforeCursor) {
+        // Check for gradient embedded in the visible before-cursor text
+        int gradInText = beforeCursor.lastIndexOf("\u00a7g");
+        if (gradInText != -1 && gradInText + 30 <= beforeCursor.length()) {
+            return hodgepodge$expandGradientToPerChar(beforeCursor, gradInText);
+        }
+
+        if (this.lineScrollOffset <= 0) {
+            return beforeCursor;
+        }
+        String prefix = this.text.substring(0, Math.min(this.lineScrollOffset, this.text.length()));
+        String activeFormat = FontRenderer.getFormatFromString(prefix);
+        if (activeFormat.isEmpty()) {
+            return beforeCursor;
+        }
+        if (activeFormat.length() >= 30 && activeFormat.charAt(0) == '\u00a7' && activeFormat.charAt(1) == 'g') {
+            // Gradient scrolled past: expand continuation as per-char colors
+            return hodgepodge$expandScrolledGradientToPerChar(activeFormat, beforeCursor);
+        }
+        return activeFormat + beforeCursor;
+    }
+
+    /**
+     * Second drawStringWithShadow (text after cursor): prepend active format from text before cursor position.
+     */
+    @ModifyArg(
+            method = "drawTextBox",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
+                    ordinal = 1),
+            index = 0)
+    private String hodgepodge$fixCursorSplitColorCodes(String afterCursor) {
+        String prefix = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
+        String activeFormat = FontRenderer.getFormatFromString(prefix);
+        if (activeFormat.isEmpty()) {
+            return afterCursor;
+        }
+        if (activeFormat.length() >= 30 && activeFormat.charAt(0) == '\u00a7' && activeFormat.charAt(1) == 'g') {
+            // Expand to per-char §x colors (same path as before-cursor) to avoid
+            // float rounding differences between per-char and §g gradient rendering
+            return hodgepodge$expandAfterCursorGradientToPerChar(activeFormat, afterCursor);
+        }
+        return activeFormat + afterCursor;
+    }
+
+    /**
+     * Expand a gradient embedded in beforeCursor into per-char §x color codes. Uses the full text's gradient parameters
+     * so each char gets the exact color it would have in the unsplit gradient.
+     */
+    @Unique
+    private String hodgepodge$expandGradientToPerChar(String beforeCursor, int gradIdx) {
+        if (gradIdx + 30 > beforeCursor.length()) return beforeCursor;
+
+        // Parse from full text to get the real gradient spec
+        String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
+        int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
+        if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return beforeCursor;
+
+        int startRgb = hodgepodge$parseRgb(this.text, fullGradIdx + 2);
+        int endRgb = hodgepodge$parseRgb(this.text, fullGradIdx + 16);
+        if (startRgb == -1 || endRgb == -1) return beforeCursor;
+
+        int specEnd = fullGradIdx + 30;
+        int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
+        if (totalVisible <= 1) return beforeCursor;
+
+        // Count gradient chars scrolled past (if any)
+        int scrolledChars = 0;
+        if (this.lineScrollOffset > specEnd) {
+            scrolledChars = hodgepodge$countVisibleBounded(this.text, specEnd, this.lineScrollOffset);
+        }
+
+        return hodgepodge$buildPerCharGradient(beforeCursor, gradIdx, startRgb, endRgb, totalVisible, scrolledChars);
+    }
+
+    /**
+     * Expand a scrolled-past gradient into per-char §x color codes for the visible text.
+     */
+    @Unique
+    private String hodgepodge$expandScrolledGradientToPerChar(String activeFormat, String beforeCursor) {
+        int startRgb = hodgepodge$parseRgb(activeFormat, 2);
+        int endRgb = hodgepodge$parseRgb(activeFormat, 16);
+        if (startRgb == -1 || endRgb == -1) return activeFormat + beforeCursor;
+
+        String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
+        int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
+        if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return activeFormat + beforeCursor;
+
+        int specEnd = fullGradIdx + 30;
+        int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
+        if (totalVisible <= 1) return activeFormat + beforeCursor;
+
+        int scrolledChars = hodgepodge$countVisibleBounded(this.text, specEnd, this.lineScrollOffset);
+
+        // Preserve effects/styles from activeFormat (after the 30-char gradient spec)
+        String extras = activeFormat.length() > 30 ? activeFormat.substring(30) : "";
+
+        // Build per-char colored text (no embedded gradient spec — it was scrolled past)
+        StringBuilder sb = new StringBuilder(beforeCursor.length() * 8);
+        if (!extras.isEmpty()) sb.append(extras);
+        int gradCharIdx = scrolledChars;
+        for (int i = 0; i < beforeCursor.length(); i++) {
+            char ch = beforeCursor.charAt(i);
+            if (ch == '\u00a7' && i + 1 < beforeCursor.length()) {
+                char code = Character.toLowerCase(beforeCursor.charAt(i + 1));
+                if (code == 'r' || (code >= '0' && code <= '9')
+                        || (code >= 'a' && code <= 'f')
+                        || code == 'x'
+                        || code == 'y'
+                        || code == 'g') {
+                    sb.append(beforeCursor, i, beforeCursor.length());
+                    return sb.toString();
+                }
+                sb.append(ch).append(beforeCursor.charAt(i + 1));
+                i++;
+            } else {
+                float t = (float) gradCharIdx / (totalVisible - 1);
+                t = Math.min(t, 1f);
+                sb.append(hodgepodge$buildSectionX(hodgepodge$lerpRgb(startRgb, endRgb, t)));
+                sb.append(ch);
+                gradCharIdx++;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Build a string with per-char §x colors replacing an embedded gradient spec. Text before the gradient and
+     * non-gradient format codes are preserved.
+     */
+    @Unique
+    private static String hodgepodge$buildPerCharGradient(String text, int gradIdx, int startRgb, int endRgb,
+            int totalVisible, int startCharIdx) {
+        StringBuilder sb = new StringBuilder(text.length() * 8);
+        // Copy everything before the gradient spec
+        sb.append(text, 0, gradIdx);
+
+        // Skip the 30-char gradient spec, emit per-char colors for visible chars after it
+        int gradCharIdx = startCharIdx;
+        for (int i = gradIdx + 30; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch == '\u00a7' && i + 1 < text.length()) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                // Gradient terminator: copy rest as-is
+                if (code == 'r' || (code >= '0' && code <= '9')
+                        || (code >= 'a' && code <= 'f')
+                        || code == 'x'
+                        || code == 'y'
+                        || code == 'g') {
+                    sb.append(text, i, text.length());
+                    return sb.toString();
+                }
+                // Non-terminating format code (§l, §o, §w, §j etc.): copy through
+                sb.append(ch).append(text.charAt(i + 1));
+                i++;
+            } else {
+                // Visible char: emit its exact gradient color
+                float t = (float) gradCharIdx / (totalVisible - 1);
+                t = Math.min(t, 1f);
+                sb.append(hodgepodge$buildSectionX(hodgepodge$lerpRgb(startRgb, endRgb, t)));
+                sb.append(ch);
+                gradCharIdx++;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Expand the after-cursor gradient into per-char §x colors using the full gradient's parameters, matching the
+     * before-cursor computation path exactly.
+     */
+    @Unique
+    private String hodgepodge$expandAfterCursorGradientToPerChar(String activeFormat, String afterCursor) {
+        int startRgb = hodgepodge$parseRgb(activeFormat, 2);
+        int endRgb = hodgepodge$parseRgb(activeFormat, 16);
+        if (startRgb == -1 || endRgb == -1) return activeFormat + afterCursor;
+
+        String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
+        int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
+        if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return activeFormat + afterCursor;
+
+        int specEnd = fullGradIdx + 30;
+        int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
+        if (totalVisible <= 1) return activeFormat + afterCursor;
+
+        int visibleBefore = hodgepodge$countVisibleBounded(this.text, specEnd, this.cursorPosition);
+
+        // Preserve effects/styles from activeFormat (after the 30-char gradient spec)
+        String extras = activeFormat.length() > 30 ? activeFormat.substring(30) : "";
+
+        StringBuilder sb = new StringBuilder(afterCursor.length() * 8);
+        if (!extras.isEmpty()) sb.append(extras);
+        int gradCharIdx = visibleBefore;
+        for (int i = 0; i < afterCursor.length(); i++) {
+            char ch = afterCursor.charAt(i);
+            if (ch == '\u00a7' && i + 1 < afterCursor.length()) {
+                char code = Character.toLowerCase(afterCursor.charAt(i + 1));
+                if (code == 'r' || (code >= '0' && code <= '9')
+                        || (code >= 'a' && code <= 'f')
+                        || code == 'x'
+                        || code == 'y'
+                        || code == 'g') {
+                    sb.append(afterCursor, i, afterCursor.length());
+                    return sb.toString();
+                }
+                sb.append(ch).append(afterCursor.charAt(i + 1));
+                i++;
+            } else {
+                float t = (float) gradCharIdx / (totalVisible - 1);
+                t = Math.min(t, 1f);
+                sb.append(hodgepodge$buildSectionX(hodgepodge$lerpRgb(startRgb, endRgb, t)));
+                sb.append(ch);
+                gradCharIdx++;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * If offset lands inside a §x§R§R§G§G§B§B (14-char) or §c (2-char) sequence, advance it past the end so substring
+     * never starts mid-format-code.
+     */
+    @Unique
+    private static int hodgepodge$snapToFormatBoundary(String text, int offset) {
+        if (offset <= 0 || offset >= text.length()) return offset;
+
+        // Look back up to 13 chars to see if we're inside a §x§R§R§G§G§B§B sequence
+        for (int lb = 1; lb <= 13 && offset - lb >= 0; lb++) {
+            int candidate = offset - lb;
+            if (candidate + 1 < text.length() && text.charAt(candidate) == '\u00a7'
+                    && Character.toLowerCase(text.charAt(candidate + 1)) == 'x') {
+                // Found §x start. The full §x§R§R§G§G§B§B sequence is 14 chars.
+                int seqEnd = candidate + 14;
+                if (offset < seqEnd && seqEnd <= text.length()) {
+                    return seqEnd;
+                }
+                break; // Past this §x, no need to look further
+            }
+        }
+
+        // Check if we're between § and its pair char (simple 2-char format like §c)
+        if (text.charAt(offset - 1) == '\u00a7') {
+            return Math.min(offset + 1, text.length());
+        }
+
+        return offset;
+    }
+
+    @Unique
+    private static int[] hodgepodge$buildPositionMap(String raw, String preprocessed) {
+        int[] map = new int[raw.length() + 1];
+        int ri = 0;
+        int pi = 0;
+
+        while (ri < raw.length() && pi < preprocessed.length()) {
+            map[ri] = pi;
+
+            if (raw.charAt(ri) == '&' && preprocessed.charAt(pi) == '\u00a7') {
+                if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi + 1) == 'x') {
+                    int rawEnd = Math.min(ri + 7, raw.length());
+                    for (int sub = 1; sub < rawEnd - ri; sub++) {
+                        map[ri + sub] = pi + sub * 2;
+                    }
+                    ri += 7;
+                    pi += 14;
+                } else {
+                    if (ri + 1 < raw.length()) {
+                        map[ri + 1] = pi + 1;
+                    }
+                    ri += 2;
+                    pi += 2;
+                }
+                continue;
+            }
+
+            ri++;
+            pi++;
+        }
+
+        map[raw.length()] = preprocessed.length();
+        return map;
+    }
+
+    @Unique
+    private static int hodgepodge$mapPosition(int[] posMap, int rawPos) {
+        if (rawPos <= 0) return 0;
+        if (rawPos >= posMap.length) return posMap[posMap.length - 1];
+        return posMap[rawPos];
+    }
+
+    /** Count visible chars from startIdx, stopping at gradient-terminating codes (§r, §0-f, §x, §y, §g). */
+    @Unique
+    private static int hodgepodge$countVisibleInGradient(String text, int startIdx) {
+        int count = 0;
+        for (int i = startIdx; i < text.length(); i++) {
+            if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (code == 'r' || (code >= '0' && code <= '9')
+                        || (code >= 'a' && code <= 'f')
+                        || code == 'x'
+                        || code == 'y'
+                        || code == 'g') {
+                    break;
+                }
+                i++; // skip non-terminating format codes (k-o, w, j)
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Count visible chars from startIdx to endIdx, stopping at gradient-terminating codes. */
+    @Unique
+    private static int hodgepodge$countVisibleBounded(String text, int startIdx, int endIdx) {
+        int count = 0;
+        int limit = Math.min(endIdx, text.length());
+        for (int i = startIdx; i < limit; i++) {
+            if (text.charAt(i) == '\u00a7' && i + 1 < limit) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (code == 'r' || (code >= '0' && code <= '9')
+                        || (code >= 'a' && code <= 'f')
+                        || code == 'x'
+                        || code == 'y'
+                        || code == 'g') {
+                    break;
+                }
+                i++;
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Parse RGB int from §x§R§R§G§G§B§B starting at offset. Returns -1 on failure. */
+    @Unique
+    private static int hodgepodge$parseRgb(String text, int offset) {
+        if (offset + 13 >= text.length()) return -1;
+        int val = 0;
+        for (int i = 0; i < 6; i++) {
+            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
+            if (d == -1) return -1;
+            val = (val << 4) | d;
+        }
+        return val;
+    }
+
+    @Unique
+    private static int hodgepodge$lerpRgb(int from, int to, float t) {
+        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
+        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
+        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
+        return (r << 16) | (g << 8) | b;
+    }
+
+    @Unique
+    private static String hodgepodge$buildSectionX(int rgb) {
+        char S = '\u00a7';
+        int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
+        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
+                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
+                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
+                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
+                .append(Character.forDigit(b & 0xF, 16)).toString();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 
 /**
  * Fixes color codes being lost when the chat input field scrolls or splits text at the cursor.
@@ -51,22 +51,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     private boolean hodgepodge$swapped;
 
     @Unique
-    private static boolean hodgepodge$preprocessChecked = false;
-    @Unique
-    private static boolean hodgepodge$preprocessAvailable = false;
-
-    @Unique
     private static String hodgepodge$safePreprocess(String s) {
-        if (!hodgepodge$preprocessChecked) {
-            hodgepodge$preprocessChecked = true;
-            try {
-                FontRendering.class.getMethod("preprocessText", String.class);
-                hodgepodge$preprocessAvailable = true;
-            } catch (NoSuchMethodException e) {
-                hodgepodge$preprocessAvailable = false;
-            }
-        }
-        return hodgepodge$preprocessAvailable ? FontRendering.preprocessText(s) : s;
+        return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(s) : s;
     }
 
     @Inject(method = "drawTextBox", at = @At("HEAD"))
@@ -235,7 +221,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 if (code == 'r' || (code >= '0' && code <= '9')
                         || (code >= 'a' && code <= 'f')
                         || code == 'x'
-                        || code == 'y'
+                        || code == 'q'
                         || code == 'g') {
                     sb.append(beforeCursor, i, beforeCursor.length());
                     return sb.toString();
@@ -274,12 +260,12 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 if (code == 'r' || (code >= '0' && code <= '9')
                         || (code >= 'a' && code <= 'f')
                         || code == 'x'
-                        || code == 'y'
+                        || code == 'q'
                         || code == 'g') {
                     sb.append(text, i, text.length());
                     return sb.toString();
                 }
-                // Non-terminating format code (§l, §o, §w, §j etc.): copy through
+                // Non-terminating format code (§l, §o, §z, §v etc.): copy through
                 sb.append(ch).append(text.charAt(i + 1));
                 i++;
             } else {
@@ -327,7 +313,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 if (code == 'r' || (code >= '0' && code <= '9')
                         || (code >= 'a' && code <= 'f')
                         || code == 'x'
-                        || code == 'y'
+                        || code == 'q'
                         || code == 'g') {
                     sb.append(afterCursor, i, afterCursor.length());
                     return sb.toString();
@@ -417,7 +403,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         return posMap[rawPos];
     }
 
-    /** Count visible chars from startIdx, stopping at gradient-terminating codes (§r, §0-f, §x, §y, §g). */
+    /** Count visible chars from startIdx, stopping at gradient-terminating codes (§r, §0-f, §x, §q, §g). */
     @Unique
     private static int hodgepodge$countVisibleInGradient(String text, int startIdx) {
         int count = 0;
@@ -427,7 +413,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 if (code == 'r' || (code >= '0' && code <= '9')
                         || (code >= 'a' && code <= 'f')
                         || code == 'x'
-                        || code == 'y'
+                        || code == 'q'
                         || code == 'g') {
                     break;
                 }
@@ -450,7 +436,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 if (code == 'r' || (code >= '0' && code <= '9')
                         || (code >= 'a' && code <= 'f')
                         || code == 'x'
-                        || code == 'y'
+                        || code == 'q'
                         || code == 'g') {
                     break;
                 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -56,16 +56,26 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
                 }
             }
             // &g&#RRGGBB&#RRGGBB gradient (18 chars)
-            if (ch == '&' && i + 1 < len && Character.toLowerCase(text.charAt(i + 1)) == 'g'
-                && i + 17 < len && text.charAt(i + 2) == '&' && text.charAt(i + 3) == '#'
-                && text.charAt(i + 10) == '&' && text.charAt(i + 11) == '#') {
+            if (ch == '&' && i + 1 < len
+                    && Character.toLowerCase(text.charAt(i + 1)) == 'g'
+                    && i + 17 < len
+                    && text.charAt(i + 2) == '&'
+                    && text.charAt(i + 3) == '#'
+                    && text.charAt(i + 10) == '&'
+                    && text.charAt(i + 11) == '#') {
                 boolean v1 = true, v2 = true;
                 for (int j = 4; j <= 9; j++) {
-                    if (Character.digit(text.charAt(i + j), 16) == -1) { v1 = false; break; }
+                    if (Character.digit(text.charAt(i + j), 16) == -1) {
+                        v1 = false;
+                        break;
+                    }
                 }
                 if (v1) {
                     for (int j = 12; j <= 17; j++) {
-                        if (Character.digit(text.charAt(i + j), 16) == -1) { v2 = false; break; }
+                        if (Character.digit(text.charAt(i + j), 16) == -1) {
+                            v2 = false;
+                            break;
+                        }
                     }
                 }
                 if (v1 && v2) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -42,7 +42,7 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
         for (int i = 0; i < len; i++) {
             char ch = text.charAt(i);
             // &#RRGGBB (8 chars)
-            if (ch == '&' && i + 1 < len && text.charAt(i + 1) == '#' && i + 7 < len) {
+            if (ch == '&' && i + 7 < len && text.charAt(i + 1) == '#') {
                 boolean valid = true;
                 for (int j = 2; j <= 7; j++) {
                     if (Character.digit(text.charAt(i + j), 16) == -1) {
@@ -56,9 +56,8 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
                 }
             }
             // &g&#RRGGBB&#RRGGBB gradient (18 chars)
-            if (ch == '&' && i + 1 < len
+            if (ch == '&' && i + 17 < len
                     && Character.toLowerCase(text.charAt(i + 1)) == 'g'
-                    && i + 17 < len
                     && text.charAt(i + 2) == '&'
                     && text.charAt(i + 3) == '#'
                     && text.charAt(i + 10) == '&'

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -10,11 +10,12 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(NetHandlerPlayServer.class)
 public class MixinNetHandlerPlayServer_AnvilColorCodes {
 
-    private static final String HODGEPODGE$VALID_CODES = "0123456789abcdefklmnorywjg";
+    // Note: 'g' excluded — &g only valid as part of &g&#RRGGBB&#RRGGBB (handled separately below)
+    private static final String HODGEPODGE$VALID_CODES = "0123456789abcdefklmnorqzv";
 
     /**
      * Vanilla checks {@code s.length() <= 30} for anvil item names and silently drops the name if exceeded. With color
-     * codes like {@code &#FF0000} or {@code &w}, the raw string is longer than the visible text. Allow longer raw
+     * codes like {@code &#FF0000} or {@code &z}, the raw string is longer than the visible text. Allow longer raw
      * strings for format codes, but enforce:
      * <ul>
      * <li>visible chars &lt;= 30 (same as vanilla's intent)</li>
@@ -51,6 +52,24 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
                 }
                 if (valid) {
                     i += 7;
+                    continue;
+                }
+            }
+            // &g&#RRGGBB&#RRGGBB gradient (18 chars)
+            if (ch == '&' && i + 1 < len && Character.toLowerCase(text.charAt(i + 1)) == 'g'
+                && i + 17 < len && text.charAt(i + 2) == '&' && text.charAt(i + 3) == '#'
+                && text.charAt(i + 10) == '&' && text.charAt(i + 11) == '#') {
+                boolean v1 = true, v2 = true;
+                for (int j = 4; j <= 9; j++) {
+                    if (Character.digit(text.charAt(i + j), 16) == -1) { v1 = false; break; }
+                }
+                if (v1) {
+                    for (int j = 12; j <= 17; j++) {
+                        if (Character.digit(text.charAt(i + j), 16) == -1) { v2 = false; break; }
+                    }
+                }
+                if (v1 && v2) {
+                    i += 17;
                     continue;
                 }
             }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -1,0 +1,74 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.NetHandlerPlayServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(NetHandlerPlayServer.class)
+public class MixinNetHandlerPlayServer_AnvilColorCodes {
+
+    private static final String HODGEPODGE$VALID_CODES = "0123456789abcdefklmnorywjg";
+
+    /**
+     * Vanilla checks {@code s.length() <= 30} for anvil item names and silently drops the name if exceeded. With color
+     * codes like {@code &#FF0000} or {@code &w}, the raw string is longer than the visible text. Allow longer raw
+     * strings for format codes, but enforce:
+     * <ul>
+     * <li>visible chars &lt;= 30 (same as vanilla's intent)</li>
+     * <li>raw length &lt;= 256 (safety cap against abuse)</li>
+     * </ul>
+     */
+    @Redirect(
+            method = "processVanilla250Packet",
+            at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 0))
+    private int hodgepodge$validateAnvilNameByVisibleChars(String name) {
+        if (name.length() <= 30) return name.length();
+        if (name.length() > 256) return 256;
+        return hodgepodge$countVisibleChars(name);
+    }
+
+    /**
+     * Count visible characters in raw text, skipping valid {@code &} format codes and {@code §} format pairs. Does not
+     * depend on a registered preprocessor.
+     */
+    @Unique
+    private static int hodgepodge$countVisibleChars(String text) {
+        int count = 0;
+        int len = text.length();
+        for (int i = 0; i < len; i++) {
+            char ch = text.charAt(i);
+            // &#RRGGBB (8 chars)
+            if (ch == '&' && i + 1 < len && text.charAt(i + 1) == '#' && i + 7 < len) {
+                boolean valid = true;
+                for (int j = 2; j <= 7; j++) {
+                    if (Character.digit(text.charAt(i + j), 16) == -1) {
+                        valid = false;
+                        break;
+                    }
+                }
+                if (valid) {
+                    i += 7;
+                    continue;
+                }
+            }
+            // &X single format code (2 chars)
+            if (ch == '&' && i + 1 < len) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (HODGEPODGE$VALID_CODES.indexOf(code) != -1) {
+                    i++;
+                    continue;
+                }
+            }
+            // §X format pair (2 chars)
+            if (ch == '\u00a7' && i + 1 < len) {
+                i++;
+                continue;
+            }
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_SignLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_SignLimit.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.NetHandlerPlayServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+
+@Mixin(NetHandlerPlayServer.class)
+public class MixinNetHandlerPlayServer_SignLimit {
+
+    /**
+     * Vanilla checks {@code length() > 15} and replaces the line with "!?" if exceeded. We allow longer raw strings for
+     * format codes, but enforce: - visible chars <= 15 (same as vanilla's intent) - raw length <= 90 (safety cap
+     * against abuse)
+     */
+    @Redirect(
+            method = "processUpdateSign",
+            at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 0))
+    private int hodgepodge$validateSignLineLength(String str) {
+        if (str.length() <= 15) return str.length();
+        if (str.length() > 90) return 90;
+        return FontRendering.countVisibleChars(str);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntitySign_RaiseNbtReadLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntitySign_RaiseNbtReadLimit.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.tileentity.TileEntitySign;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+/**
+ * Vanilla {@code readFromNBT} truncates each sign line to 15 raw chars. With {@code &} color codes, a legitimate line
+ * is longer than 15 raw chars (e.g. {@code &g&#FF0000&#0000FFhello} is 23 raw but 5 visible). Raise the cap to 90 to
+ * match the server-side safety cap in {@link MixinNetHandlerPlayServer_SignLimit}. Both the {@code length() > 15} check
+ * and the {@code substring(0, 15)} call use the same constant, so a single ModifyConstant covers both.
+ */
+@Mixin(TileEntitySign.class)
+public class MixinTileEntitySign_RaiseNbtReadLimit {
+
+    @ModifyConstant(method = "readFromNBT", constant = @Constant(intValue = 15))
+    private int hodgepodge$raiseNbtReadLimit(int original) {
+        return 90;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.util;
+
+/** Shared helpers for parsing, building, and interpolating {@code §x§R§R§G§G§B§B} RGB color sequences. */
+public final class ColorFormatUtils {
+
+    private ColorFormatUtils() {}
+
+    /**
+     * Parse an RGB int from a {@code §x§R§R§G§G§B§B} sequence starting at {@code offset} (the position of the leading
+     * {@code §}). Returns {@code -1} if the sequence is truncated or contains non-hex digits.
+     */
+    public static int parseRgbFromSectionX(String text, int offset) {
+        if (offset + 13 >= text.length()) return -1;
+        int val = 0;
+        for (int i = 0; i < 6; i++) {
+            int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
+            if (d == -1) return -1;
+            val = (val << 4) | d;
+        }
+        return val;
+    }
+
+    /** Build a {@code §x§R§R§G§G§B§B} sequence from an RGB int. */
+    public static String buildSectionX(int rgb) {
+        char S = '\u00a7';
+        int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
+        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
+                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
+                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
+                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
+                .append(Character.forDigit(b & 0xF, 16)).toString();
+    }
+
+    /** Linearly interpolate between two RGB ints at parameter {@code t} in [0, 1]. */
+    public static int lerpRgb(int from, int to, float t) {
+        int r = (int) (((from >> 16) & 0xFF) * (1 - t) + ((to >> 16) & 0xFF) * t);
+        int g = (int) (((from >> 8) & 0xFF) * (1 - t) + ((to >> 8) & 0xFF) * t);
+        int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
+        return (r << 16) | (g << 8) | b;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/FontRenderingCompat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FontRenderingCompat.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.util;
+
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+
+/** Checks for GTNHLib font rendering methods that may not exist in older versions. */
+public class FontRenderingCompat {
+
+    public static final boolean HAS_PREPROCESS_TEXT;
+
+    static {
+        boolean found = false;
+        try {
+            FontRendering.class.getMethod("preprocessText", String.class);
+            found = true;
+        } catch (NoSuchMethodException ignored) {}
+        HAS_PREPROCESS_TEXT = found;
+    }
+
+    /** Only call when {@link #HAS_PREPROCESS_TEXT} is true. */
+    public static String preprocessText(String s) {
+        return FontRendering.preprocessText(s);
+    }
+}


### PR DESCRIPTION
add color code support for text rendering edge cases

- chat wrapping: preserves &#RRGGBB and gradient colors across wrapped lines
- text field scroll: fixes color loss when scrolling/splitting at cursor in input fields
- anvil naming: skips format codes when counting visible chars so colored names
  don't hit the 30 char limit
- sign input: allows color codes in sign editing
- old gtnhlib safety: preprocessText calls wrapped in try/catch for backwards compat

requires: https://github.com/GTNewHorizons/GTNHLib/pull/328 , https://github.com/GTNewHorizons/Angelica/pull/1669