### PR TITLE
Make a deep copy when sending objects from the data watcher to the client in SinglePlayer

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -455,6 +455,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixFakePlayerChatCrash;
 
+    @Config.Comment("Make a deep copy when sending objects from the data watcher to the client in SinglePlayer")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean deepCopyDataWatcherInSP;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -15,6 +15,10 @@ public enum Mixins implements IMixins {
 
     // spotless:off
     // Vanilla Fixes
+    FIX_DATAWATCHER_SHARING_OBJECTS_IN_SP(new MixinBuilder()
+            .addClientMixins("minecraft.MixinDataWatcher_DeepCopyInSP")
+            .setApplyIf(() -> FixesConfig.deepCopyDataWatcherInSP)
+            .setPhase(Phase.EARLY)),
     ONLY_LOAD_LANGUAGES_ONCE_PER_FILE(new MixinBuilder()
             .addCommonMixins("minecraft.MixinLanguageRegistry")
             .setApplyIf(() -> FixesConfig.onlyLoadLanguagesOnce)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinDataWatcher_DeepCopyInSP.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinDataWatcher_DeepCopyInSP.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 import net.minecraft.entity.DataWatcher;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
@@ -11,23 +12,23 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public class MixinDataWatcher_DeepCopyInSP {
 
     @ModifyArg(
-            method = {"getAllWatched", "getChanged"},
-            at = @At(
-                    value = "INVOKE",
-                    target = "Ljava/util/ArrayList;add(Ljava/lang/Object;)Z",
-                    remap = false))
+            method = { "getAllWatched", "getChanged" },
+            at = @At(value = "INVOKE", target = "Ljava/util/ArrayList;add(Ljava/lang/Object;)Z", remap = false))
     private Object deepCopy(Object o) {
         final DataWatcher.WatchableObject obj = (DataWatcher.WatchableObject) o;
         switch (obj.getObjectType()) {
             case 0, 1, 3, 2, 4: // Byte, Short, Integer, Float
-                return new DataWatcher.WatchableObject(obj.getObjectType(),obj.getDataValueId(), obj.getObject());
+                return new DataWatcher.WatchableObject(obj.getObjectType(), obj.getDataValueId(), obj.getObject());
             case 5: // ItemStack - can be null
                 final ItemStack itemstack = (ItemStack) obj.getObject();
                 final ItemStack copy = itemstack == null ? null : itemstack.copy();
-                return new DataWatcher.WatchableObject(obj.getObjectType(),obj.getDataValueId(), copy);
+                return new DataWatcher.WatchableObject(obj.getObjectType(), obj.getDataValueId(), copy);
             case 6: // ChunkCoordinates
                 final ChunkCoordinates coords = (ChunkCoordinates) obj.getObject();
-                return new DataWatcher.WatchableObject(obj.getObjectType(),obj.getDataValueId(), new ChunkCoordinates(coords));
+                return new DataWatcher.WatchableObject(
+                        obj.getObjectType(),
+                        obj.getDataValueId(),
+                        new ChunkCoordinates(coords));
         }
         return o;
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinDataWatcher_DeepCopyInSP.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinDataWatcher_DeepCopyInSP.java
@@ -1,0 +1,34 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.DataWatcher;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChunkCoordinates;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(DataWatcher.class)
+public class MixinDataWatcher_DeepCopyInSP {
+
+    @ModifyArg(
+            method = {"getAllWatched", "getChanged"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/util/ArrayList;add(Ljava/lang/Object;)Z",
+                    remap = false))
+    private Object deepCopy(Object o) {
+        final DataWatcher.WatchableObject obj = (DataWatcher.WatchableObject) o;
+        switch (obj.getObjectType()) {
+            case 0, 1, 3, 2, 4: // Byte, Short, Integer, Float
+                return new DataWatcher.WatchableObject(obj.getObjectType(),obj.getDataValueId(), obj.getObject());
+            case 5: // ItemStack - can be null
+                final ItemStack itemstack = (ItemStack) obj.getObject();
+                final ItemStack copy = itemstack == null ? null : itemstack.copy();
+                return new DataWatcher.WatchableObject(obj.getObjectType(),obj.getDataValueId(), copy);
+            case 6: // ChunkCoordinates
+                final ChunkCoordinates coords = (ChunkCoordinates) obj.getObject();
+                return new DataWatcher.WatchableObject(obj.getObjectType(),obj.getDataValueId(), new ChunkCoordinates(coords));
+        }
+        return o;
+    }
+}


### PR DESCRIPTION
When playing single player the packets are not serialized/deserialized and when synchronizing objects from the DataWatcher, it just shares the objects in between the server -> client. I changed the code to make a deep copy of the objects.
Before for example when having an ItemStack in a ItemFrame, it would share the ItemStack instance in between the server and the client which means the reference to the server EntityItemFrame would be reachable from the client instance EntityItemFrame.

<img width="512" height="164" alt="image" src="https://github.com/user-attachments/assets/6859b66b-d277-4238-ae6a-fd89bc92aada" />
