### PR TITLE
Add transfer packet backport (1.20.5 for 1.7.10)

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
+import com.mitchej123.hodgepodge.commands.TransferCommand;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 import com.mitchej123.hodgepodge.mixins.hooks.ChunkGenScheduler;
@@ -86,6 +87,7 @@ public class Hodgepodge {
     @EventHandler
     public void onServerStarting(FMLServerStartingEvent aEvent) {
         aEvent.registerServerCommand(new DebugCommand());
+        aEvent.registerServerCommand(new TransferCommand());
 
         // needed in case ExtraUtilities' Spike was crashed (and game was switched to a main menu), so it didn't update
         // the variable

--- a/src/main/java/com/mitchej123/hodgepodge/commands/TransferCommand.java
+++ b/src/main/java/com/mitchej123/hodgepodge/commands/TransferCommand.java
@@ -1,0 +1,59 @@
+package com.mitchej123.hodgepodge.commands;
+
+import java.util.List;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+
+import com.mitchej123.hodgepodge.net.MessageTransfer;
+import com.mitchej123.hodgepodge.net.NetworkHandler;
+
+public class TransferCommand extends CommandBase {
+
+    @Override
+    public String getCommandName() {
+        return "transfer";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/transfer <player> <hostname> [port]";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 3;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            throw new WrongUsageException(getCommandUsage(sender));
+        }
+
+        EntityPlayerMP player = getPlayer(sender, args[0]);
+        String hostname = args[1];
+
+        int port = 25565;
+        if (args.length >= 3) {
+            port = parseIntBounded(sender, args[2], 1, 65535);
+        }
+
+        NetworkHandler.instance.sendTo(new MessageTransfer(hostname, port), player);
+        sender.addChatMessage(
+                new ChatComponentText(
+                        "Transferring " + player.getCommandSenderName() + " to " + hostname + ":" + port));
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            return getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -464,4 +464,12 @@ public class TweaksConfig {
     @Config.Comment("Allow creative tab gui title color via localization key")
     @Config.DefaultBoolean(true)
     public static boolean creativeTabLocalizationOverrides;
+
+    @Config.Comment("Enable transfer packet support (allows servers to redirect you to another server:port)")
+    @Config.DefaultBoolean(true)
+    public static boolean enableTransferPacket;
+
+    @Config.Comment("Whitelist of allowed transfer target hosts (empty = allow all). Format: host or host:port")
+    @Config.DefaultStringList({})
+    public static String[] transferWhitelist;
 }

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageTransfer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageTransfer.java
@@ -1,0 +1,93 @@
+package com.mitchej123.hodgepodge.net;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+
+public class MessageTransfer implements IMessage, IMessageHandler<MessageTransfer, IMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger("Hodgepodge/Transfer");
+
+    private String host;
+    private int port;
+
+    public MessageTransfer() {}
+
+    public MessageTransfer(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        int hostLen = buf.readUnsignedShort();
+        byte[] hostBytes = new byte[hostLen];
+        buf.readBytes(hostBytes);
+        host = new String(hostBytes, StandardCharsets.UTF_8);
+        port = buf.readUnsignedShort();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        byte[] hostBytes = host.getBytes(StandardCharsets.UTF_8);
+        buf.writeShort(hostBytes.length);
+        buf.writeBytes(hostBytes);
+        buf.writeShort(port);
+    }
+
+    @Override
+    public IMessage onMessage(MessageTransfer message, MessageContext ctx) {
+        if (!TweaksConfig.enableTransferPacket) {
+            LOGGER.info("Ignoring transfer request to {}:{} (disabled in config)", message.host, message.port);
+            return null;
+        }
+
+        if (message.host == null || message.host.isEmpty() || message.port < 1 || message.port > 65535) {
+            LOGGER.warn("Ignoring invalid transfer request: host={}, port={}", message.host, message.port);
+            return null;
+        }
+
+        if (!isHostAllowed(message.host, message.port)) {
+            LOGGER.warn("Ignoring transfer request to {}:{} (not in whitelist)", message.host, message.port);
+            return null;
+        }
+
+        LOGGER.info("Server requested transfer to {}:{}", message.host, message.port);
+
+        // Delegate to client handler — GUI classes must not be referenced from this class
+        // or the server will crash with NoClassDefFoundError for GuiScreen
+        TransferClientHandler.execute(message.host, message.port);
+
+        return null;
+    }
+
+    private static boolean isHostAllowed(String host, int port) {
+        String[] whitelist = TweaksConfig.transferWhitelist;
+        if (whitelist == null || whitelist.length == 0) {
+            return true;
+        }
+        String hostPort = host + ":" + port;
+        for (String entry : whitelist) {
+            if (entry.equalsIgnoreCase(host) || entry.equalsIgnoreCase(hostPort)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/NetworkHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/NetworkHandler.java
@@ -15,5 +15,6 @@ public class NetworkHandler {
         instance.registerMessage(MessageConfigSync.class, MessageConfigSync.class, 0, Side.CLIENT);
         instance.registerMessage(BatchedDescriptionHandler.class, BatchedDescriptionPacket.class, 1, Side.CLIENT);
         instance.registerMessage(MessageChangeDifficulty.class, MessageChangeDifficulty.class, 2, Side.CLIENT);
+        instance.registerMessage(MessageTransfer.class, MessageTransfer.class, 3, Side.CLIENT);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/net/TransferClientHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/TransferClientHandler.java
@@ -1,0 +1,71 @@
+package com.mitchej123.hodgepodge.net;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiMainMenu;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.multiplayer.GuiConnecting;
+import net.minecraft.client.multiplayer.ServerData;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class TransferClientHandler {
+
+    private static final Logger LOGGER = LogManager.getLogger("Hodgepodge/Transfer");
+
+    public static void execute(String host, int port) {
+        Minecraft mc = Minecraft.getMinecraft();
+        mc.func_152344_a(() -> {
+            if (mc.func_147104_D() == null) {
+                LOGGER.warn("Ignoring transfer request in singleplayer");
+                return;
+            }
+
+            // Don't disconnect or call loadWorld(null) here! Doing so nulls theWorld
+            // while updateController() can still run later this tick (via mixin-injected
+            // code paths), causing NPE when stale packets access the null world.
+            //
+            // Instead, just show GuiTransferring. Its updateScreen() runs AFTER
+            // updateController() in the tick cycle (line 1752 vs 1693 in runTick),
+            // so when it creates GuiConnecting (which calls loadWorld(null)),
+            // updateController has already finished for this tick. Next tick,
+            // theWorld is null and updateController is skipped entirely.
+            String address = port == 25565 ? host : host + ":" + port;
+            ServerData serverData = new ServerData("Transfer", address);
+            mc.displayGuiScreen(new GuiTransferring(serverData));
+        });
+    }
+
+    @SideOnly(Side.CLIENT)
+    static class GuiTransferring extends GuiScreen {
+
+        private final ServerData serverData;
+
+        GuiTransferring(ServerData serverData) {
+            this.serverData = serverData;
+        }
+
+        @Override
+        public void updateScreen() {
+            // This runs after updateController() in the tick, so it's safe to
+            // create GuiConnecting which calls loadWorld(null) internally.
+            this.mc.displayGuiScreen(new GuiConnecting(new GuiMainMenu(), this.mc, this.serverData));
+        }
+
+        @Override
+        public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+            this.drawDefaultBackground();
+            this.drawCenteredString(
+                    this.fontRendererObj,
+                    "Transferring...",
+                    this.width / 2,
+                    this.height / 2 - 50,
+                    0xFFFFFF);
+            super.drawScreen(mouseX, mouseY, partialTicks);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/TransferHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/TransferHelper.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.net;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * Public API for triggering server-to-server transfers. Sends a transfer packet to the client, which will disconnect
+ * from the current server and connect to the specified host:port.
+ */
+public class TransferHelper {
+
+    /**
+     * Transfer a player to another server.
+     *
+     * @param player the player to transfer
+     * @param host   target server hostname or IP
+     * @param port   target server port (1-65535)
+     */
+    public static void transfer(EntityPlayerMP player, String host, int port) {
+        NetworkHandler.instance.sendTo(new MessageTransfer(host, port), player);
+    }
+}


### PR DESCRIPTION
backports 1.20.5 ClientboundTransferPacket to 1.7.10, allowing servers to
seamlessly redirect players to another server:port without bungeecord/velocity/ other kinds of proxies.

- server sends host+port via hodgepodge SimpleNetworkWrapper (discriminator 3)
- client disconnects cleanly and reconnects to the target server
- /transfer <player> <hostname> [port] command (op level 3)
- TransferHelper.transfer() public API for programmatic use
- config: enableTransferPacket toggle, transferWhitelist for allowed hosts
- compatible with BungeeCord/Velocity/Bukkit proxies via raw plugin channel

wire format on the "hodgepodge" channel:

| Field | Value |
|-|-|
| Channel | `hodgepodge` |
| Direction | Server to Client |
| Discriminator | `0x03` |

### Wire Format

| Offset | Size | Type | Description |
|-|-|-|-|
| 0 | 1 | byte | `0x03` (FML SimpleNetworkWrapper discriminator) |
| 1 | 2 | unsigned short | Host string length in bytes (big-endian) |
| 3 | N | byte[] | Hostname or IP address (UTF-8) |
| 3+N | 2 | unsigned short | Port number 1-65535 (big-endian) |

the client disconnect uses a deferred GuiTransferring screen to avoid a packet processing race in modded runTick updateController() can still dispatch stale packets after loadWorld(null) nulls the world, so the actual GuiConnecting is created in updateScreen() which runs after updateController in the tick cycle.

technically they could be done without this however it would be a hacky workaround for velocity, and would be a hit or miss. (higher chance of crash in dense populated gregtech machines area, and this just removes that chance)

An example can be seen here : 

https://github.com/user-attachments/assets/36772a68-cdef-4f97-9ec2-b8fb63e4ae47

