### PR TITLE
Fix disconnect screen layout for long kick messages

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -36,6 +36,11 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixChatWrappedColors;
 
+    @Config.Comment("Fix disconnect screen button overlapping long kick messages")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixDisconnectScreenLayout;
+
     @Config.Comment("Prevents crash if server sends container with wrong itemStack size")
     @Config.DefaultBoolean(true)
     public static boolean fixContainerPutStacksInSlots;

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -40,6 +40,11 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixCommandFormattingLoss;
 
+    @Config.Comment("Fix disconnect screen button overlapping long kick messages")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixDisconnectScreenLayout;
+
     @Config.Comment("Prevents crash if server sends container with wrong itemStack size")
     @Config.DefaultBoolean(true)
     public static boolean fixContainerPutStacksInSlots;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -608,6 +608,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiNewChat_FixColorWrapping")
             .setApplyIf(() -> FixesConfig.fixChatWrappedColors)
             .setPhase(Phase.EARLY)),
+    FIX_DISCONNECT_SCREEN_LAYOUT(new MixinBuilder("Fix disconnect screen button overlapping long kick messages")
+            .addClientMixins("minecraft.MixinGuiDisconnected_FixLayout")
+            .setApplyIf(() -> FixesConfig.fixDisconnectScreenLayout)
+            .setPhase(Phase.EARLY)),
     COMPACT_CHAT(new MixinBuilder()
             .addClientMixins("minecraft.MixinGuiNewChat_CompactChat")
             .setApplyIf(() -> TweaksConfig.compactChat)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -655,6 +655,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinCommandBase_JoinArgs")
             .setApplyIf(() -> FixesConfig.fixCommandFormattingLoss)
             .setPhase(Phase.EARLY)),
+    FIX_DISCONNECT_SCREEN_LAYOUT(new MixinBuilder("Fix disconnect screen button overlapping long kick messages")
+            .addClientMixins("minecraft.MixinGuiDisconnected_FixLayout")
+            .setApplyIf(() -> FixesConfig.fixDisconnectScreenLayout)
+            .setPhase(Phase.EARLY)),
     COMPACT_CHAT(new MixinBuilder()
             .addClientMixins("minecraft.MixinGuiNewChat_CompactChat")
             .setApplyIf(() -> TweaksConfig.compactChat)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiDisconnected_FixLayout.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiDisconnected_FixLayout.java
@@ -1,0 +1,96 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Iterator;
+import java.util.List;
+
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiDisconnected;
+import net.minecraft.client.gui.GuiScreen;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Vertically centers the disconnect screen as a group so the button doesn't overlap long kick messages.
+ *
+ * <pre>
+ * Layout (top to bottom, group centered on the screen):
+ *   Title                 (FONT_HEIGHT = 9px)
+ *   20px gap              (padding: 10 below title + 10 above text)
+ *   Wrapped reason text   (n * FONT_HEIGHT)
+ *   12px gap              (padding: 10 below text + 2 above button)
+ *   Button                (20px tall)
+ * </pre>
+ */
+@Mixin(GuiDisconnected.class)
+public class MixinGuiDisconnected_FixLayout extends GuiScreen {
+
+    @Shadow
+    private String field_146306_a; // title string
+
+    @Shadow
+    private List field_146305_g; // wrapped text lines
+
+    @Unique
+    private int hodgepodge$titleY;
+
+    @Unique
+    private int hodgepodge$textStartY;
+
+    @Inject(method = "initGui", at = @At("TAIL"))
+    private void hodgepodge$centerLayout(CallbackInfo ci) {
+        int lineHeight = this.fontRendererObj.FONT_HEIGHT;
+        int textLines = field_146305_g != null ? field_146305_g.size() : 0;
+
+        // Inter-element gap = bottom padding of previous + top padding of next.
+        // title→text = 10+10 = 20, text→button = 10+2 = 12.
+        int totalHeight = lineHeight + 20 + (textLines * lineHeight) + 12 + 20;
+
+        int topY = Math.max(5, (this.height - totalHeight) / 2);
+
+        hodgepodge$titleY = topY;
+        hodgepodge$textStartY = topY + lineHeight + 20;
+        int buttonY = hodgepodge$textStartY + (textLines * lineHeight) + 12;
+
+        // Clamp so button stays on screen (button is 20px tall)
+        if (buttonY + 20 > this.height - 5) {
+            buttonY = this.height - 25;
+        }
+
+        for (Object obj : this.buttonList) {
+            GuiButton button = (GuiButton) obj;
+            if (button.id == 0) {
+                button.yPosition = buttonY;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Vanilla hardcodes title at height/2-50 and text at height/2-30. We cancel and redraw at the centered positions,
+     * then let super render the buttons from buttonList.
+     */
+    @Inject(method = "drawScreen", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$drawScreen(int mouseX, int mouseY, float partialTicks, CallbackInfo ci) {
+        ci.cancel();
+
+        this.drawDefaultBackground();
+
+        this.drawCenteredString(this.fontRendererObj, this.field_146306_a, this.width / 2, hodgepodge$titleY, 0xAAAAAA);
+
+        if (this.field_146305_g != null) {
+            int y = hodgepodge$textStartY;
+            for (Iterator<?> iterator = this.field_146305_g.iterator(); iterator
+                    .hasNext(); y += this.fontRendererObj.FONT_HEIGHT) {
+                String s = (String) iterator.next();
+                this.drawCenteredString(this.fontRendererObj, s, this.width / 2, y, 0xFFFFFF);
+            }
+        }
+
+        super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+}


### PR DESCRIPTION
vanilla hardcodes the title at height/2-50 and the back button below the text. with a long kick message (more than ~20 lines), the wrapped text overflows and overlaps the button. 

ports the 1.21 LinearLayout approach: groups title + reason text + button into one block, vertically centers the block on screen, and clamps the button to stay onscreen.

- title (FONT_HEIGHT = 9px)
- 20px gap (10 below title + 10 above text)
- wrapped reason text (n * FONT_HEIGHT)
- 12px gap (10 below text + 2 above button)
- button (20px tall)
<img width="2880" height="1575" alt="image" src="https://github.com/user-attachments/assets/e2a692c9-16e3-4b6b-88e4-6b36c79cd222" />
