### PR TITLE
Add title and subtitle overlay rendering with /title command

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -86,6 +86,9 @@ public class Hodgepodge {
     @EventHandler
     public void onServerStarting(FMLServerStartingEvent aEvent) {
         aEvent.registerServerCommand(new DebugCommand());
+        if (TweaksConfig.enableTitleSubtitle) {
+            aEvent.registerServerCommand(new com.mitchej123.hodgepodge.commands.TitleCommand());
+        }
 
         // needed in case ExtraUtilities' Spike was crashed (and game was switched to a main menu), so it didn't update
         // the variable

--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -63,6 +63,10 @@ public class HodgepodgeClient {
         MinecraftForge.EVENT_BUS.register(new AllocationRateHUD(true));
         ClientCommandHandler.instance.registerCommand(new AllocationsCommand());
 
+        if (TweaksConfig.enableTitleSubtitle) {
+            com.gtnewhorizon.gtnhlib.client.title.TitleAPI.registerRenderer();
+        }
+
         FMLCommonHandler.instance().bus().register(new ClientKeyListener());
 
         if (FixesConfig.fixModlistEntries) {

--- a/src/main/java/com/mitchej123/hodgepodge/commands/TitleCommand.java
+++ b/src/main/java/com/mitchej123/hodgepodge/commands/TitleCommand.java
@@ -1,0 +1,100 @@
+package com.mitchej123.hodgepodge.commands;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+
+import com.mitchej123.hodgepodge.net.TitlePacketHandler;
+
+public final class TitleCommand extends CommandBase {
+
+    @Override
+    public String getCommandName() {
+        return "title";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/title <player> <clear|reset|title|subtitle|times> [args...]";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 2;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            throw new WrongUsageException(getCommandUsage(sender));
+        }
+
+        EntityPlayerMP player = getPlayer(sender, args[0]);
+        String action = args[1].toLowerCase();
+
+        switch (action) {
+            case "clear":
+                TitlePacketHandler.sendClear(player);
+                func_152373_a(sender, this, "commands.title.cleared.single", player.getCommandSenderName());
+                break;
+            case "reset":
+                TitlePacketHandler.sendReset(player);
+                func_152373_a(sender, this, "commands.title.reset.single", player.getCommandSenderName());
+                break;
+            case "title":
+                if (args.length < 3) throw new WrongUsageException("/title <player> title <text...>");
+                TitlePacketHandler.sendTitle(player, textFromArgs(args, 2));
+                func_152373_a(sender, this, "commands.title.show.title.single", player.getCommandSenderName());
+                break;
+            case "subtitle":
+                if (args.length < 3) throw new WrongUsageException("/title <player> subtitle <text...>");
+                TitlePacketHandler.sendSubtitle(player, textFromArgs(args, 2));
+                func_152373_a(sender, this, "commands.title.show.subtitle.single", player.getCommandSenderName());
+                break;
+            case "times":
+                if (args.length < 5) throw new WrongUsageException("/title <player> times <fadeIn> <stay> <fadeOut>");
+                TitlePacketHandler.sendTimes(
+                        player,
+                        parseInt(sender, args[2]),
+                        parseInt(sender, args[3]),
+                        parseInt(sender, args[4]));
+                func_152373_a(sender, this, "commands.title.times.single", player.getCommandSenderName());
+                break;
+            default:
+                throw new WrongUsageException(getCommandUsage(sender));
+        }
+    }
+
+    @Override
+    public List addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == 1) {
+            return getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        if (args.length == 2) {
+            return getListOfStringsMatchingLastWord(args, "clear", "reset", "title", "subtitle", "times");
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index) {
+        return index == 0;
+    }
+
+    private static IChatComponent textFromArgs(String[] args, int start) {
+        String text = String.join(" ", Arrays.copyOfRange(args, start, args.length));
+        // Try parsing as JSON component first, fall back to plain text
+        try {
+            return IChatComponent.Serializer.func_150699_a(text);
+        } catch (Exception e) {
+            return new ChatComponentText(text);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -8,6 +8,11 @@ public class TweaksConfig {
 
     // Minecraft
 
+    @Config.Comment("Enable title and subtitle overlay rendering (backported from 1.8+)")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean enableTitleSubtitle;
+
     @Config.Comment("Adds a button in the sounds menu to reload the sound system without needing to press F3 + S")
     @Config.DefaultBoolean(true)
     public static boolean reloadSoundsButton;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -608,6 +608,12 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiNewChat_FixColorWrapping")
             .setApplyIf(() -> FixesConfig.fixChatWrappedColors)
             .setPhase(Phase.EARLY)),
+    TITLE_SUBTITLE(new MixinBuilder("Title and subtitle overlay rendering")
+            .addClientMixins(
+                    "minecraft.MixinGuiIngame_TitleTick",
+                    "minecraft.MixinGuiIngameForge_TitleRender")
+            .setApplyIf(() -> TweaksConfig.enableTitleSubtitle)
+            .setPhase(Phase.EARLY)),
     COMPACT_CHAT(new MixinBuilder()
             .addClientMixins("minecraft.MixinGuiNewChat_CompactChat")
             .setApplyIf(() -> TweaksConfig.compactChat)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiIngameForge_TitleRender.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiIngameForge_TitleRender.java
@@ -1,0 +1,94 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.MathHelper;
+import net.minecraftforge.client.GuiIngameForge;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.client.title.TitleAPI;
+
+@Mixin(GuiIngameForge.class)
+public class MixinGuiIngameForge_TitleRender {
+
+    @Shadow
+    private ScaledResolution res;
+
+    @Shadow
+    private FontRenderer fontrenderer;
+
+    @Inject(
+            method = "renderGameOverlay",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraftforge/client/GuiIngameForge;renderRecordOverlay(IIF)V",
+                    shift = At.Shift.AFTER,
+                    remap = false))
+    private void hodgepodge$renderTitle(float partialTicks, boolean hasScreen, int mouseX, int mouseY,
+            CallbackInfo ci) {
+        IChatComponent title = TitleAPI.getTitle();
+        int titleTime = TitleAPI.getTitleTime();
+        if (title == null || titleTime <= 0) return;
+
+        Minecraft mc = Minecraft.getMinecraft();
+        mc.mcProfiler.startSection("titleAndSubtitle");
+
+        int width = res.getScaledWidth();
+        int height = res.getScaledHeight();
+
+        float f = (float) titleTime - partialTicks;
+        int fadeIn = TitleAPI.getFadeInTime();
+        int stay = TitleAPI.getStayTime();
+        int fadeOut = TitleAPI.getFadeOutTime();
+        int alpha = 255;
+
+        if (titleTime > fadeOut + stay) {
+            float totalTime = (float) (fadeIn + stay + fadeOut);
+            alpha = (int) ((totalTime - f) * 255.0F / (float) fadeIn);
+        } else if (titleTime <= fadeOut) {
+            alpha = (int) (f * 255.0F / (float) fadeOut);
+        }
+
+        alpha = MathHelper.clamp_int(alpha, 0, 255);
+        if (alpha <= 8) {
+            mc.mcProfiler.endSection();
+            return;
+        }
+
+        int color = 0xFFFFFF | (alpha << 24);
+
+        GL11.glPushMatrix();
+        GL11.glTranslatef((float) (width / 2), (float) (height / 2), 0.0F);
+        GL11.glEnable(GL11.GL_BLEND);
+
+        GL11.glPushMatrix();
+        GL11.glScalef(4.0F, 4.0F, 4.0F);
+        String titleText = title.getFormattedText();
+        int titleWidth = fontrenderer.getStringWidth(titleText);
+        fontrenderer.drawStringWithShadow(titleText, -titleWidth / 2, -10, color);
+        GL11.glPopMatrix();
+
+        IChatComponent subtitle = TitleAPI.getSubtitle();
+        if (subtitle != null) {
+            GL11.glPushMatrix();
+            GL11.glScalef(2.0F, 2.0F, 2.0F);
+            String subText = subtitle.getFormattedText();
+            int subWidth = fontrenderer.getStringWidth(subText);
+            fontrenderer.drawStringWithShadow(subText, -subWidth / 2, 5, color);
+            GL11.glPopMatrix();
+        }
+
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glPopMatrix();
+
+        mc.mcProfiler.endSection();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiIngame_TitleTick.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiIngame_TitleTick.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.gui.GuiIngame;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.gtnewhorizon.gtnhlib.client.title.TitleAPI;
+
+@Mixin(GuiIngame.class)
+public class MixinGuiIngame_TitleTick {
+
+    @Inject(method = "updateTick", at = @At("TAIL"))
+    private void hodgepodge$tickTitle(CallbackInfo ci) {
+        TitleAPI.tick();
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageTitle.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageTitle.java
@@ -1,0 +1,94 @@
+package com.mitchej123.hodgepodge.net;
+
+import java.nio.charset.StandardCharsets;
+
+import net.minecraft.util.IChatComponent;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import io.netty.buffer.ByteBuf;
+
+public class MessageTitle implements IMessage {
+
+    /** 0=TITLE, 1=SUBTITLE, 2=TIMES, 3=CLEAR, 4=RESET */
+    public int action;
+
+    /** For TITLE/SUBTITLE: the IChatComponent JSON */
+    public String componentJson;
+
+    /** For TIMES: fadeIn, stay, fadeOut ticks */
+    public int fadeIn, stay, fadeOut;
+
+    public MessageTitle() {}
+
+    public static MessageTitle title(IChatComponent component) {
+        MessageTitle msg = new MessageTitle();
+        msg.action = 0;
+        msg.componentJson = IChatComponent.Serializer.func_150696_a(component);
+        return msg;
+    }
+
+    public static MessageTitle subtitle(IChatComponent component) {
+        MessageTitle msg = new MessageTitle();
+        msg.action = 1;
+        msg.componentJson = IChatComponent.Serializer.func_150696_a(component);
+        return msg;
+    }
+
+    public static MessageTitle times(int fadeIn, int stay, int fadeOut) {
+        MessageTitle msg = new MessageTitle();
+        msg.action = 2;
+        msg.fadeIn = fadeIn;
+        msg.stay = stay;
+        msg.fadeOut = fadeOut;
+        return msg;
+    }
+
+    public static MessageTitle clear() {
+        MessageTitle msg = new MessageTitle();
+        msg.action = 3;
+        return msg;
+    }
+
+    public static MessageTitle reset() {
+        MessageTitle msg = new MessageTitle();
+        msg.action = 4;
+        return msg;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        action = buf.readByte();
+        switch (action) {
+            case 0:
+            case 1:
+                int len = buf.readShort();
+                byte[] bytes = new byte[len];
+                buf.readBytes(bytes);
+                componentJson = new String(bytes, StandardCharsets.UTF_8);
+                break;
+            case 2:
+                fadeIn = buf.readInt();
+                stay = buf.readInt();
+                fadeOut = buf.readInt();
+                break;
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeByte(action);
+        switch (action) {
+            case 0:
+            case 1:
+                byte[] bytes = componentJson.getBytes(StandardCharsets.UTF_8);
+                buf.writeShort(bytes.length);
+                buf.writeBytes(bytes);
+                break;
+            case 2:
+                buf.writeInt(fadeIn);
+                buf.writeInt(stay);
+                buf.writeInt(fadeOut);
+                break;
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessageTitleHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessageTitleHandler.java
@@ -1,0 +1,45 @@
+package com.mitchej123.hodgepodge.net;
+
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+
+import com.gtnewhorizon.gtnhlib.client.title.TitleAPI;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+
+public class MessageTitleHandler implements IMessageHandler<MessageTitle, IMessage> {
+
+    @Override
+    public IMessage onMessage(MessageTitle msg, MessageContext ctx) {
+        switch (msg.action) {
+            case 0: // TITLE
+                TitleAPI.setTitle(deserialize(msg.componentJson));
+                break;
+            case 1: // SUBTITLE
+                TitleAPI.setSubtitle(deserialize(msg.componentJson));
+                break;
+            case 2: // TIMES
+                TitleAPI.setTimes(msg.fadeIn, msg.stay, msg.fadeOut);
+                break;
+            case 3: // CLEAR
+                TitleAPI.clear();
+                break;
+            case 4: // RESET
+                TitleAPI.clear();
+                TitleAPI.reset();
+                break;
+        }
+        return null;
+    }
+
+    private static IChatComponent deserialize(String json) {
+        if (json == null || json.isEmpty()) return new ChatComponentText("");
+        try {
+            return IChatComponent.Serializer.func_150699_a(json);
+        } catch (Exception e) {
+            return new ChatComponentText(json);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/NetworkHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/NetworkHandler.java
@@ -15,5 +15,6 @@ public class NetworkHandler {
         instance.registerMessage(MessageConfigSync.class, MessageConfigSync.class, 0, Side.CLIENT);
         instance.registerMessage(BatchedDescriptionHandler.class, BatchedDescriptionPacket.class, 1, Side.CLIENT);
         instance.registerMessage(MessageChangeDifficulty.class, MessageChangeDifficulty.class, 2, Side.CLIENT);
+        instance.registerMessage(MessageTitleHandler.class, MessageTitle.class, 3, Side.CLIENT);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/net/TitlePacketHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/TitlePacketHandler.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.net;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.IChatComponent;
+
+public class TitlePacketHandler {
+
+    public static void sendTitle(EntityPlayerMP player, IChatComponent component) {
+        NetworkHandler.instance.sendTo(MessageTitle.title(component), player);
+    }
+
+    public static void sendSubtitle(EntityPlayerMP player, IChatComponent component) {
+        NetworkHandler.instance.sendTo(MessageTitle.subtitle(component), player);
+    }
+
+    public static void sendTimes(EntityPlayerMP player, int fadeIn, int stay, int fadeOut) {
+        NetworkHandler.instance.sendTo(MessageTitle.times(fadeIn, stay, fadeOut), player);
+    }
+
+    public static void sendClear(EntityPlayerMP player) {
+        NetworkHandler.instance.sendTo(MessageTitle.clear(), player);
+    }
+
+    public static void sendReset(EntityPlayerMP player) {
+        NetworkHandler.instance.sendTo(MessageTitle.reset(), player);
+    }
+}

--- a/src/main/resources/assets/hodgepodge/lang/en_US.lang
+++ b/src/main/resources/assets/hodgepodge/lang/en_US.lang
@@ -24,6 +24,12 @@ item.fish.name=Fish
 commands.time.get=The current world time is %s (time of day: %s)
 commands.time.usageWithGet=/time <set|add> <value> OR /time get
 
+commands.title.cleared.single=Cleared title for %s
+commands.title.reset.single=Reset title options for %s
+commands.title.show.title.single=Showed title to %s
+commands.title.show.subtitle.single=Showed subtitle to %s
+commands.title.times.single=Changed title display times for %s
+
 hodgepodge.soundsmenu.refreshsounds=Refresh Sounds
 hodgepodge.bed_respawn.msg=Respawn point set
 hodgepodge.menu.mod_options=Mod Options...


### PR DESCRIPTION
backports the 1.8+ title/subtitle overlay system. uses gtnhlib's TitleAPI for state. this PR provides:

- mixin renderer hooks GuiIngameForge.renderGameOverlay after renderRecordOverlay
  (4x scale title at -10y, 2x scale subtitle at +5y, fade in/stay/fade out)
- mixin tick on GuiIngame.updateTick decrements the timer
- /title <player> clear|reset|title|subtitle|times <args> (op level 2)
- TitlePacketHandler convenience methods for sending from server side
- packet protocol matching 1.8 S45PacketTitle (action ids 0=title, 1=subtitle, 2=times, 3=clear, 4=reset)
- config: enableTitleSubtitle (default true, requires restart)

action 4 (reset) does both clear() + reset() to match 1.21 semantics. JSON IChatComponent input falls back to plain text on parse failure.

requires: https://github.com/GTNewHorizons/GTNHLib/pull/330


<img width="2880" height="1575" alt="image" src="https://github.com/user-attachments/assets/cb638bda-3111-4ba5-b2f1-bd2f407f9eab" />
<img width="2880" height="1575" alt="image" src="https://github.com/user-attachments/assets/34f6ddf7-67cf-42f3-87d2-1e077d02c6d5" />
