### PR TITLE
Fix newline characters not rendering as line breaks

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -36,6 +36,14 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixChatWrappedColors;
 
+    @Config.Comment("Fix newline characters in chat messages not rendering as line breaks")
+    @Config.DefaultBoolean(true)
+    public static boolean fixChatNewlines;
+
+    @Config.Comment("Fix newline characters in drawString not rendering as line breaks")
+    @Config.DefaultBoolean(true)
+    public static boolean fixFontRendererNewlines;
+
     @Config.Comment("Prevents crash if server sends container with wrong itemStack size")
     @Config.DefaultBoolean(true)
     public static boolean fixContainerPutStacksInSlots;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -608,6 +608,14 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiNewChat_FixColorWrapping")
             .setApplyIf(() -> FixesConfig.fixChatWrappedColors)
             .setPhase(Phase.EARLY)),
+    FIX_CHAT_NEWLINES(new MixinBuilder("Fix newline characters in chat messages not rendering as line breaks")
+            .addClientMixins("minecraft.MixinGuiNewChat_FixChatNewlines")
+            .setApplyIf(() -> FixesConfig.fixChatNewlines)
+            .setPhase(Phase.EARLY)),
+    FIX_FONT_RENDERER_NEWLINES(new MixinBuilder("Fix newline characters in drawString not rendering as line breaks")
+            .addClientMixins("minecraft.MixinFontRenderer_NewlineSupport")
+            .setApplyIf(() -> FixesConfig.fixFontRendererNewlines)
+            .setPhase(Phase.EARLY)),
     COMPACT_CHAT(new MixinBuilder()
             .addClientMixins("minecraft.MixinGuiNewChat_CompactChat")
             .setApplyIf(() -> TweaksConfig.compactChat)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
@@ -6,9 +6,9 @@ import net.minecraft.client.gui.FontRenderer;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
 @Mixin(value = FontRenderer.class, priority = 1500)
 public abstract class MixinFontRenderer_NewlineSupport {
@@ -19,34 +19,36 @@ public abstract class MixinFontRenderer_NewlineSupport {
     @Shadow
     public abstract List<String> listFormattedStringToWidth(String str, int wrapWidth);
 
-    @Shadow
-    public abstract int getStringWidth(String text);
-
-    @Shadow
-    public abstract int drawString(String text, int x, int y, int color, boolean dropShadow);
-
-    @Inject(method = "drawString(Ljava/lang/String;IIIZ)I", at = @At("HEAD"), cancellable = true)
-    private void hodgepodge$splitNewlines(String text, int x, int y, int color, boolean dropShadow,
-            CallbackInfoReturnable<Integer> cir) {
-        if (text == null || text.indexOf('\n') < 0) return;
+    // @WrapMethod sits outside the @Inject layer — this runs before any cancellable HEAD inject
+    // from other mods on the same method (Angelica's BatchingFontRenderer inject in particular).
+    // Priority-based ordering of competing HEAD injects isn't reliable in mixed environments, so
+    // wrapping the method is the deterministic way to see the \n before anyone rewrites dispatch.
+    @WrapMethod(method = "drawString(Ljava/lang/String;IIIZ)I")
+    private int hodgepodge$splitNewlinesDraw(String text, int x, int y, int color, boolean dropShadow,
+            Operation<Integer> delegate) {
+        if (text == null || text.indexOf('\n') < 0) {
+            return delegate.call(text, x, y, color, dropShadow);
+        }
 
         List<String> lines = this.listFormattedStringToWidth(text, Integer.MAX_VALUE);
         int maxX = x;
         for (int i = 0; i < lines.size(); i++) {
-            maxX = Math.max(maxX, this.drawString(lines.get(i), x, y + i * this.FONT_HEIGHT, color, dropShadow));
+            maxX = Math.max(maxX, delegate.call(lines.get(i), x, y + i * this.FONT_HEIGHT, color, dropShadow));
         }
-        cir.setReturnValue(maxX);
+        return maxX;
     }
 
-    @Inject(method = "getStringWidth", at = @At("HEAD"), cancellable = true)
-    private void hodgepodge$measureNewlines(String text, CallbackInfoReturnable<Integer> cir) {
-        if (text == null || text.indexOf('\n') < 0) return;
+    @WrapMethod(method = "getStringWidth")
+    private int hodgepodge$splitNewlinesWidth(String text, Operation<Integer> delegate) {
+        if (text == null || text.indexOf('\n') < 0) {
+            return delegate.call(text);
+        }
 
         List<String> lines = this.listFormattedStringToWidth(text, Integer.MAX_VALUE);
         int maxWidth = 0;
         for (String line : lines) {
-            maxWidth = Math.max(maxWidth, this.getStringWidth(line));
+            maxWidth = Math.max(maxWidth, delegate.call(line));
         }
-        cir.setReturnValue(maxWidth);
+        return maxWidth;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
@@ -1,0 +1,39 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.List;
+
+import net.minecraft.client.gui.FontRenderer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FontRenderer.class)
+public abstract class MixinFontRenderer_NewlineSupport {
+
+    @Shadow
+    public int FONT_HEIGHT;
+
+    @Shadow
+    public abstract List<String> listFormattedStringToWidth(String str, int wrapWidth);
+
+    @Shadow
+    private int renderString(String text, int x, int y, int color, boolean shadow) {
+        return 0;
+    }
+
+    @Inject(method = "renderString", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$handleNewlines(String text, int x, int y, int color, boolean shadow,
+            CallbackInfoReturnable<Integer> cir) {
+        if (text == null || text.indexOf('\n') < 0) return;
+
+        List<String> lines = this.listFormattedStringToWidth(text, Integer.MAX_VALUE);
+        int lastX = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            lastX = this.renderString(lines.get(i), x, y + i * this.FONT_HEIGHT, color, shadow);
+        }
+        cir.setReturnValue(lastX);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
@@ -25,10 +25,7 @@ public abstract class MixinFontRenderer_NewlineSupport {
     @Shadow
     public abstract int drawString(String text, int x, int y, int color, boolean dropShadow);
 
-    @Inject(
-            method = "drawString(Ljava/lang/String;IIIZ)I",
-            at = @At("HEAD"),
-            cancellable = true)
+    @Inject(method = "drawString(Ljava/lang/String;IIIZ)I", at = @At("HEAD"), cancellable = true)
     private void hodgepodge$splitNewlines(String text, int x, int y, int color, boolean dropShadow,
             CallbackInfoReturnable<Integer> cir) {
         if (text == null || text.indexOf('\n') < 0) return;
@@ -41,10 +38,7 @@ public abstract class MixinFontRenderer_NewlineSupport {
         cir.setReturnValue(maxX);
     }
 
-    @Inject(
-            method = "getStringWidth",
-            at = @At("HEAD"),
-            cancellable = true)
+    @Inject(method = "getStringWidth", at = @At("HEAD"), cancellable = true)
     private void hodgepodge$measureNewlines(String text, CallbackInfoReturnable<Integer> cir) {
         if (text == null || text.indexOf('\n') < 0) return;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_NewlineSupport.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(FontRenderer.class)
+@Mixin(value = FontRenderer.class, priority = 1500)
 public abstract class MixinFontRenderer_NewlineSupport {
 
     @Shadow
@@ -20,20 +20,39 @@ public abstract class MixinFontRenderer_NewlineSupport {
     public abstract List<String> listFormattedStringToWidth(String str, int wrapWidth);
 
     @Shadow
-    private int renderString(String text, int x, int y, int color, boolean shadow) {
-        return 0;
-    }
+    public abstract int getStringWidth(String text);
 
-    @Inject(method = "renderString", at = @At("HEAD"), cancellable = true)
-    private void hodgepodge$handleNewlines(String text, int x, int y, int color, boolean shadow,
+    @Shadow
+    public abstract int drawString(String text, int x, int y, int color, boolean dropShadow);
+
+    @Inject(
+            method = "drawString(Ljava/lang/String;IIIZ)I",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void hodgepodge$splitNewlines(String text, int x, int y, int color, boolean dropShadow,
             CallbackInfoReturnable<Integer> cir) {
         if (text == null || text.indexOf('\n') < 0) return;
 
         List<String> lines = this.listFormattedStringToWidth(text, Integer.MAX_VALUE);
-        int lastX = 0;
+        int maxX = x;
         for (int i = 0; i < lines.size(); i++) {
-            lastX = this.renderString(lines.get(i), x, y + i * this.FONT_HEIGHT, color, shadow);
+            maxX = Math.max(maxX, this.drawString(lines.get(i), x, y + i * this.FONT_HEIGHT, color, dropShadow));
         }
-        cir.setReturnValue(lastX);
+        cir.setReturnValue(maxX);
+    }
+
+    @Inject(
+            method = "getStringWidth",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void hodgepodge$measureNewlines(String text, CallbackInfoReturnable<Integer> cir) {
+        if (text == null || text.indexOf('\n') < 0) return;
+
+        List<String> lines = this.listFormattedStringToWidth(text, Integer.MAX_VALUE);
+        int maxWidth = 0;
+        for (String line : lines) {
+            maxWidth = Math.max(maxWidth, this.getStringWidth(line));
+        }
+        cir.setReturnValue(maxWidth);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
@@ -1,0 +1,46 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiNewChat;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiNewChat.class)
+public class MixinGuiNewChat_FixChatNewlines {
+
+    @Inject(method = "printChatMessageWithOptionalDeletion", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$splitNewlines(IChatComponent component, int id, CallbackInfo ci) {
+        String formatted = component.getFormattedText();
+        if (formatted.indexOf('\n') < 0) return;
+
+        List<IChatComponent> lines = hodgepodge$splitOnNewlines(formatted);
+        for (int i = 0; i < lines.size(); i++) {
+            ((GuiNewChat) (Object) this).printChatMessageWithOptionalDeletion(lines.get(i), i == 0 ? id : 0);
+        }
+        ci.cancel();
+    }
+
+    @Unique
+    private static List<IChatComponent> hodgepodge$splitOnNewlines(String formatted) {
+        String[] parts = formatted.split("\n", -1);
+        List<IChatComponent> lines = new ArrayList<>();
+        String carryFormat = "";
+
+        for (String part : parts) {
+            String fullLine = carryFormat + part;
+            lines.add(new ChatComponentText(fullLine));
+            carryFormat = FontRenderer.getFormatFromString(fullLine);
+        }
+
+        return lines;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
@@ -39,10 +39,7 @@ public abstract class MixinGuiNewChat_FixChatNewlines {
         throw new AssertionError();
     }
 
-    @Inject(
-            method = "func_146237_a(Lnet/minecraft/util/IChatComponent;IIZ)V",
-            at = @At("HEAD"),
-            cancellable = true)
+    @Inject(method = "func_146237_a(Lnet/minecraft/util/IChatComponent;IIZ)V", at = @At("HEAD"), cancellable = true)
     private void hodgepodge$splitNewlines(IChatComponent original, int id, int updateCounter, boolean displayed,
             CallbackInfo ci) {
         if (original.getUnformattedText().indexOf('\n') < 0) return;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
@@ -15,10 +15,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
 @Mixin(GuiNewChat.class)
@@ -34,38 +34,41 @@ public abstract class MixinGuiNewChat_FixChatNewlines {
     @Shadow
     public abstract void deleteChatLine(int id);
 
-    @Shadow
-    private void func_146237_a(IChatComponent component, int id, int updateCounter, boolean displayed) {
-        throw new AssertionError();
-    }
-
-    @Inject(method = "func_146237_a(Lnet/minecraft/util/IChatComponent;IIZ)V", at = @At("HEAD"), cancellable = true)
+    @WrapMethod(method = "func_146237_a(Lnet/minecraft/util/IChatComponent;IIZ)V")
     private void hodgepodge$splitNewlines(IChatComponent original, int id, int updateCounter, boolean displayed,
-            CallbackInfo ci) {
-        if (original.getUnformattedText().indexOf('\n') < 0) return;
+            Operation<Void> delegate) {
+        if (original.getUnformattedText().indexOf('\n') < 0) {
+            delegate.call(original, id, updateCounter, displayed);
+            return;
+        }
 
+        // Delete-by-id must run exactly once even though we delegate per sub-line; the
+        // @Redirect below suppresses the per-sub-call delete that would otherwise wipe
+        // earlier sub-lines we just added to field_146253_i.
         if (id != 0 && !displayed) {
             this.deleteChatLine(id);
         }
 
-        List<IChatComponent> lines = hodgepodge$splitOnNewlines(original);
         this.hodgepodge$suppressInnerDelete = true;
         try {
-            for (IChatComponent line : lines) {
-                this.func_146237_a(line, id, updateCounter, true);
+            for (IChatComponent line : hodgepodge$splitOnNewlines(original)) {
+                // delegate.call re-enters the patched func_146237_a body per sub-line so
+                // sibling mixins (CompactChat, LongerChat, FixColorWrapping) all fire as
+                // if the sub-line had been printed directly.
+                delegate.call(line, id, updateCounter, true);
             }
         } finally {
             this.hodgepodge$suppressInnerDelete = false;
         }
 
+        // Keep the un-split component in chatLines so refreshChat() re-enters this wrap
+        // and re-splits cleanly after e.g. a chat width change.
         if (!displayed) {
             this.chatLines.add(0, new ChatLine(updateCounter, original, id));
             while (this.chatLines.size() > TweaksConfig.chatLength) {
                 this.chatLines.remove(this.chatLines.size() - 1);
             }
         }
-
-        ci.cancel();
     }
 
     @Redirect(
@@ -76,32 +79,51 @@ public abstract class MixinGuiNewChat_FixChatNewlines {
         self.deleteChatLine(id);
     }
 
+    /**
+     * Splits a chat component tree on newline boundaries, preserving per-sibling style.
+     *
+     * <p>
+     * Walks the component's iterator (which yields deep-copied nodes with resolved styles), splits each node's raw text
+     * on {@code \n}, and flushes the current line buffer whenever a {@code \n} is crossed. Trailing format codes of the
+     * just-flushed line are carried over to the first non-empty segment of the next line so sticky codes ({@code §a},
+     * {@code §l}, ...) continue — the same continuation vanilla's own word-wrap applies across wrapped sub-lines.
+     *
+     * <p>
+     * Per-sibling {@code ChatStyle} (including click/hover events) is preserved by shallow-copying onto each rebuilt
+     * piece — the same construction vanilla {@code func_146237_a} uses when building its wrapped sub-pieces.
+     */
     @Unique
     private static List<IChatComponent> hodgepodge$splitOnNewlines(IChatComponent original) {
         List<IChatComponent> lines = new ArrayList<>();
         ChatComponentText currentLine = new ChatComponentText("");
-        StringBuilder lineRawText = new StringBuilder();
-        String carryFormat = "";
+        StringBuilder currentLineRaw = new StringBuilder();
+        // Format codes carried from the last flushed line onto the next line's first
+        // non-empty segment.
+        String formatCarry = "";
 
         for (Iterator<IChatComponent> it = original.iterator(); it.hasNext();) {
             IChatComponent node = it.next();
-            String text = node.getUnformattedTextForChat();
-            if (text.isEmpty()) continue;
+            String nodeText = node.getUnformattedTextForChat();
+            if (nodeText.isEmpty()) continue;
 
-            String[] parts = text.split("\n", -1);
-            for (int i = 0; i < parts.length; i++) {
-                if (i > 0) {
-                    carryFormat = FontRenderer.getFormatFromString(lineRawText.toString());
+            // limit=-1 preserves trailing empty segments so "abc\n" -> ["abc", ""].
+            String[] segments = nodeText.split("\n", -1);
+            for (int i = 0; i < segments.length; i++) {
+                boolean startsNewLine = i > 0;
+                if (startsNewLine) {
+                    formatCarry = FontRenderer.getFormatFromString(currentLineRaw.toString());
                     lines.add(currentLine);
                     currentLine = new ChatComponentText("");
-                    lineRawText.setLength(0);
+                    currentLineRaw.setLength(0);
                 }
-                if (!parts[i].isEmpty()) {
-                    String effText = carryFormat.isEmpty() ? parts[i] : carryFormat + parts[i];
-                    currentLine.appendSibling(hodgepodge$copyStyled(effText, node));
-                    lineRawText.append(effText);
-                    carryFormat = "";
-                }
+
+                String segment = segments[i];
+                if (segment.isEmpty()) continue;
+
+                String segmentWithCarry = formatCarry.isEmpty() ? segment : formatCarry + segment;
+                currentLine.appendSibling(hodgepodge$copyStyled(segmentWithCarry, node));
+                currentLineRaw.append(segmentWithCarry);
+                formatCarry = "";
             }
         }
         lines.add(currentLine);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixChatNewlines.java
@@ -1,46 +1,120 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
+import net.minecraft.client.gui.ChatLine;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiNewChat;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IChatComponent;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+
 @Mixin(GuiNewChat.class)
-public class MixinGuiNewChat_FixChatNewlines {
+public abstract class MixinGuiNewChat_FixChatNewlines {
 
-    @Inject(method = "printChatMessageWithOptionalDeletion", at = @At("HEAD"), cancellable = true)
-    private void hodgepodge$splitNewlines(IChatComponent component, int id, CallbackInfo ci) {
-        String formatted = component.getFormattedText();
-        if (formatted.indexOf('\n') < 0) return;
+    @Unique
+    private boolean hodgepodge$suppressInnerDelete = false;
 
-        List<IChatComponent> lines = hodgepodge$splitOnNewlines(formatted);
-        for (int i = 0; i < lines.size(); i++) {
-            ((GuiNewChat) (Object) this).printChatMessageWithOptionalDeletion(lines.get(i), i == 0 ? id : 0);
+    @Shadow
+    @Final
+    private List<ChatLine> chatLines;
+
+    @Shadow
+    public abstract void deleteChatLine(int id);
+
+    @Shadow
+    private void func_146237_a(IChatComponent component, int id, int updateCounter, boolean displayed) {
+        throw new AssertionError();
+    }
+
+    @Inject(
+            method = "func_146237_a(Lnet/minecraft/util/IChatComponent;IIZ)V",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void hodgepodge$splitNewlines(IChatComponent original, int id, int updateCounter, boolean displayed,
+            CallbackInfo ci) {
+        if (original.getUnformattedText().indexOf('\n') < 0) return;
+
+        if (id != 0 && !displayed) {
+            this.deleteChatLine(id);
         }
+
+        List<IChatComponent> lines = hodgepodge$splitOnNewlines(original);
+        this.hodgepodge$suppressInnerDelete = true;
+        try {
+            for (IChatComponent line : lines) {
+                this.func_146237_a(line, id, updateCounter, true);
+            }
+        } finally {
+            this.hodgepodge$suppressInnerDelete = false;
+        }
+
+        if (!displayed) {
+            this.chatLines.add(0, new ChatLine(updateCounter, original, id));
+            while (this.chatLines.size() > TweaksConfig.chatLength) {
+                this.chatLines.remove(this.chatLines.size() - 1);
+            }
+        }
+
         ci.cancel();
     }
 
+    @Redirect(
+            method = "func_146237_a(Lnet/minecraft/util/IChatComponent;IIZ)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiNewChat;deleteChatLine(I)V"))
+    private void hodgepodge$maybeSkipInnerDelete(GuiNewChat self, int id) {
+        if (this.hodgepodge$suppressInnerDelete) return;
+        self.deleteChatLine(id);
+    }
+
     @Unique
-    private static List<IChatComponent> hodgepodge$splitOnNewlines(String formatted) {
-        String[] parts = formatted.split("\n", -1);
+    private static List<IChatComponent> hodgepodge$splitOnNewlines(IChatComponent original) {
         List<IChatComponent> lines = new ArrayList<>();
+        ChatComponentText currentLine = new ChatComponentText("");
+        StringBuilder lineRawText = new StringBuilder();
         String carryFormat = "";
 
-        for (String part : parts) {
-            String fullLine = carryFormat + part;
-            lines.add(new ChatComponentText(fullLine));
-            carryFormat = FontRenderer.getFormatFromString(fullLine);
-        }
+        for (Iterator<IChatComponent> it = original.iterator(); it.hasNext();) {
+            IChatComponent node = it.next();
+            String text = node.getUnformattedTextForChat();
+            if (text.isEmpty()) continue;
 
+            String[] parts = text.split("\n", -1);
+            for (int i = 0; i < parts.length; i++) {
+                if (i > 0) {
+                    carryFormat = FontRenderer.getFormatFromString(lineRawText.toString());
+                    lines.add(currentLine);
+                    currentLine = new ChatComponentText("");
+                    lineRawText.setLength(0);
+                }
+                if (!parts[i].isEmpty()) {
+                    String effText = carryFormat.isEmpty() ? parts[i] : carryFormat + parts[i];
+                    currentLine.appendSibling(hodgepodge$copyStyled(effText, node));
+                    lineRawText.append(effText);
+                    carryFormat = "";
+                }
+            }
+        }
+        lines.add(currentLine);
         return lines;
+    }
+
+    @Unique
+    private static ChatComponentText hodgepodge$copyStyled(String text, IChatComponent source) {
+        ChatComponentText piece = new ChatComponentText(text);
+        piece.setChatStyle(source.getChatStyle().createShallowCopy());
+        return piece;
     }
 }


### PR DESCRIPTION
`\n` in chat text renders invisible text concatenates on one line instead of breaking. the font renderer just iterates characters and treats `\n` as an empty glyph. mojang never fixed the renderer, in 1.8+ they just made callers split text before rendering.

1.7.10 already has the splitting infra (`sizeStringToWidth` case 10, `listFormattedStringToWidth`), disconnect screen and hover tooltips use it. but the chat system and `drawString`/`drawStringWithShadow` don't  this wires them through the existing splitter.

- chat: splits incoming components on `\n` into separate chat lines with format carryover
- drawString: splits via `listFormattedStringToWidth(text, MAX_VALUE)` then renders each line normally

worldedit, serverutilities, personalspace all have manual `split("\n")` workarounds for this. with the fix future code doesn't need that.
<img width="1060" height="390" alt="image copy 3" src="https://github.com/user-attachments/assets/04ad2177-ad1a-4301-a96a-e83fb38c0909" />
<img width="1036" height="121" alt="image" src="https://github.com/user-attachments/assets/4b73ce61-070b-4e4a-874b-7e17045b3845" />
