### PR TITLE
[Memory-opti:fix leak] fix ic2 block reactor world leak

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -81,6 +81,11 @@ public class MemoryConfig {
         @Config.RequiresMcRestart
         public boolean fixNetHandlerClientWorldLeak;
 
+        @Config.Comment("Fix IC2 block reactor leaking world instance when leaving world")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixIC2BlockReactorLeak;
+
         @Config.Comment("Fix WorldServer leaking entities when no players are present in a dimension")
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1078,6 +1078,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixIc2KeybindsInGuis)
             .addRequiredMod(TargetedMod.IC2)
             .setPhase(Phase.LATE)),
+    IC2_FIX_REACTOR_BLOCK_WORLD_LEAK(new MixinBuilder()
+            .addCommonMixins("ic2.MixinBlockReactorChamber_FixLeak")
+            .setApplyIf(() -> MemoryConfig.leaks.fixIC2BlockReactorLeak)
+            .addRequiredMod(TargetedMod.IC2)
+            .setPhase(Phase.LATE)),
 
     // Disable update checkers
     COFH_CORE_UPDATE_CHECK(new MixinBuilder("Yeet COFH Core Update Check")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinBlockReactorChamber_FixLeak.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinBlockReactorChamber_FixLeak.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import ic2.core.block.reactor.block.BlockReactorChamber;
+import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
+
+@Mixin(BlockReactorChamber.class)
+public class MixinBlockReactorChamber_FixLeak {
+
+    @Shadow
+    TileEntityNuclearReactorElectric reactor;
+
+    @Inject(method = "randomDisplayTick", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.reactor = null;
+    }
+}


### PR DESCRIPTION
it has a field that could be a local variable that keeps a reference to a tile entity...

<img width="490" height="103" alt="image" src="https://github.com/user-attachments/assets/a24cacfb-bbd1-4c30-8952-fbafe96cbc2b" />
