### PR TITLE
[Memory-opti:fix leak] Fix RenderFallingBlock leaking world instance

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -72,6 +72,11 @@ public class MemoryConfig {
         @Config.RequiresMcRestart
         public boolean fixEnchantmentHelperLeak;
 
+        @Config.Comment("Fix Render Falling Block leaking world instance when leaving world")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixRenderFallingBlockLeak;
+
         @Config.Comment("Fix PlayerController leaking world instance when leaving world")
         @Config.DefaultBoolean(true)
         public boolean fixPlayerControllerWorldLeak;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -400,6 +400,10 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> MemoryConfig.leaks.fixEnchantmentHelperLeak)
             .addExcludedMod(TargetedMod.ARCHAICFIX)
             .setPhase(Phase.EARLY)),
+    FIX_RENDER_FALLING_BLOCK_WORLD_LEAK(new MixinBuilder()
+            .addClientMixins("memory.MixinRenderFallingBlock")
+            .setApplyIf(() -> MemoryConfig.leaks.fixRenderFallingBlockLeak)
+            .setPhase(Phase.EARLY)),
     FIX_ARROW_WRONG_LIGHTING(new MixinBuilder()
             .addClientMixins("minecraft.MixinRendererLivingEntity")
             .setApplyIf(() -> FixesConfig.fixGlStateBugs)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinRenderFallingBlock.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinRenderFallingBlock.java
@@ -1,0 +1,24 @@
+package com.mitchej123.hodgepodge.mixins.early.memory;
+
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.entity.RenderFallingBlock;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderFallingBlock.class)
+public class MixinRenderFallingBlock {
+
+    @Shadow
+    @Final
+    private RenderBlocks field_147920_a;
+
+    @Inject(method = "doRender(Lnet/minecraft/entity/item/EntityFallingBlock;DDDFF)V", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.field_147920_a.blockAccess = null;
+    }
+}


### PR DESCRIPTION
<img width="582" height="166" alt="image" src="https://github.com/user-attachments/assets/14e8ca20-dbd2-43a4-96b5-9b0a4d50ce75" />
