### PR TITLE
dedupe magic numbers and gradient-terminator check in color mixins

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinC12PacketUpdateSign_RaiseReadLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinC12PacketUpdateSign_RaiseReadLimit.java
@@ -6,18 +6,20 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
+import com.mitchej123.hodgepodge.util.SignLimits;
+
 /**
  * Vanilla {@code C12PacketUpdateSign.readPacketData} calls {@code readStringFromBuffer(15)} per line, which throws if
- * the incoming line is longer than 15 raw chars. With {@code &} color codes, a legitimate line can exceed 15 raw chars
- * (e.g. {@code &g&#FF0000&#0000FFhello} is 23 raw but 5 visible). Raise the read cap to 90 to match the safety cap in
- * {@link MixinNetHandlerPlayServer_SignLimit}; visible-char validation in {@code processUpdateSign} still enforces the
- * 15-visible limit.
+ * the incoming line is longer than 15 raw chars. With {@code &} color codes, a legitimate line can exceed that (e.g.
+ * {@code &g&#FF0000&#0000FFhello} is 23 raw but 5 visible). Raise the read cap to {@link SignLimits#RAW} to match the
+ * safety cap in {@link MixinNetHandlerPlayServer_SignLimit}; visible-char validation in {@code processUpdateSign} still
+ * enforces the {@link SignLimits#VISIBLE}-visible limit.
  */
 @Mixin(C12PacketUpdateSign.class)
 public class MixinC12PacketUpdateSign_RaiseReadLimit {
 
     @ModifyConstant(method = "readPacketData", constant = @Constant(intValue = 15))
     private int hodgepodge$raisePacketReadLimit(int original) {
-        return 90;
+        return SignLimits.RAW;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
@@ -48,7 +48,8 @@ public abstract class MixinFontRenderer {
             String newFormat = getFormatFromString(formatting.toString());
 
             // Handle gradient continuation: interpolate color at wrap point
-            if (newFormat.length() >= 30 && newFormat.charAt(0) == '\u00a7' && newFormat.charAt(1) == 'g') {
+            if (newFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && newFormat.charAt(0) == '\u00a7'
+                    && newFormat.charAt(1) == 'g') {
                 String remainder = StringUtils.substring(
                         str,
                         lineWidth + (str.charAt(lineWidth) == ' ' || str.charAt(lineWidth) == '\n' ? 1 : 0));
@@ -67,12 +68,14 @@ public abstract class MixinFontRenderer {
 
     @Unique
     private static String hodgepodge$interpolateGradient(String gradientFormat, String rendered, String remaining) {
-        int startRgb = ColorFormatUtils.parseRgbFromSectionX(gradientFormat, 2);
-        int endRgb = ColorFormatUtils.parseRgbFromSectionX(gradientFormat, 16);
+        int startRgb = ColorFormatUtils
+                .parseRgbFromSectionX(gradientFormat, ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(gradientFormat, ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET);
         if (startRgb == -1 || endRgb == -1) return gradientFormat;
 
         int gradientIdx = rendered.indexOf("\u00a7g");
-        int visRendered = gradientIdx >= 0 ? hodgepodge$countVisible(rendered, gradientIdx + 30)
+        int visRendered = gradientIdx >= 0
+                ? hodgepodge$countVisible(rendered, gradientIdx + ColorFormatUtils.GRADIENT_SEQ_LEN)
                 : hodgepodge$countVisible(rendered, 0);
         int visRemaining = hodgepodge$countVisible(remaining, 0);
         int total = visRendered + visRemaining;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiEditSign.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiEditSign.java
@@ -7,13 +7,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+import com.mitchej123.hodgepodge.util.SignLimits;
 
 @Mixin(GuiEditSign.class)
 public class MixinGuiEditSign {
 
     @Redirect(method = "keyTyped", at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 2))
     private int hodgepodge$signVisibleLength(String str) {
-        if (str.length() >= 90) return 15;
+        if (str.length() >= SignLimits.RAW) return SignLimits.VISIBLE;
         return FontRendering.countVisibleChars(str);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
@@ -48,24 +48,26 @@ public class MixinGuiNewChat_FixColorWrapping {
         StringBuilder sb = new StringBuilder(text.length() + 128);
         int last = 0;
 
-        while (gIdx != -1 && gIdx + 29 < text.length()) {
-            // Validate §g followed by two §x§R§R§G§G§B§B sequences (30 chars total)
-            if (text.charAt(gIdx + 2) != '\u00a7' || Character.toLowerCase(text.charAt(gIdx + 3)) != 'x'
-                    || text.charAt(gIdx + 16) != '\u00a7'
-                    || Character.toLowerCase(text.charAt(gIdx + 17)) != 'x') {
+        while (gIdx != -1 && gIdx + ColorFormatUtils.GRADIENT_SEQ_LEN - 1 < text.length()) {
+            // Validate §g followed by two §x§R§R§G§G§B§B sequences
+            final int firstRgbPos = gIdx + ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET;
+            final int secondRgbPos = gIdx + ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET;
+            if (text.charAt(firstRgbPos) != '\u00a7' || Character.toLowerCase(text.charAt(firstRgbPos + 1)) != 'x'
+                    || text.charAt(secondRgbPos) != '\u00a7'
+                    || Character.toLowerCase(text.charAt(secondRgbPos + 1)) != 'x') {
                 gIdx = text.indexOf("\u00a7g", gIdx + 2);
                 continue;
             }
 
-            int startRgb = ColorFormatUtils.parseRgbFromSectionX(text, gIdx + 2);
-            int endRgb = ColorFormatUtils.parseRgbFromSectionX(text, gIdx + 16);
+            int startRgb = ColorFormatUtils.parseRgbFromSectionX(text, firstRgbPos);
+            int endRgb = ColorFormatUtils.parseRgbFromSectionX(text, secondRgbPos);
             if (startRgb == -1 || endRgb == -1) {
                 gIdx = text.indexOf("\u00a7g", gIdx + 2);
                 continue;
             }
 
             // Count visible chars in the gradient span (until §r, color code, or another gradient/rainbow)
-            int textStart = gIdx + 30;
+            int textStart = gIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
             int totalVisible = hodgepodge$countGradientVisible(text, textStart);
             if (totalVisible <= 0) {
                 gIdx = text.indexOf("\u00a7g", gIdx + 2);
@@ -81,12 +83,7 @@ public class MixinGuiNewChat_FixColorWrapping {
                 char ch = text.charAt(i);
                 if (ch == '\u00a7' && i + 1 < text.length()) {
                     char code = Character.toLowerCase(text.charAt(i + 1));
-                    // Gradient terminators: stop expanding
-                    if (code == 'r' || (code >= '0' && code <= '9')
-                            || (code >= 'a' && code <= 'f')
-                            || code == 'x'
-                            || code == 'q'
-                            || code == 'g') {
+                    if (ColorFormatUtils.isGradientTerminator(code)) {
                         last = i;
                         break;
                     }
@@ -125,11 +122,7 @@ public class MixinGuiNewChat_FixColorWrapping {
             char ch = text.charAt(i);
             if (ch == '\u00a7' && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
-                if (code == 'r' || (code >= '0' && code <= '9')
-                        || (code >= 'a' && code <= 'f')
-                        || code == 'x'
-                        || code == 'q'
-                        || code == 'g') {
+                if (ColorFormatUtils.isGradientTerminator(code)) {
                     break;
                 }
                 i++; // skip non-terminating format codes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -116,7 +116,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     private String hodgepodge$fixScrolledColorCodes(String beforeCursor) {
         // Check for gradient embedded in the visible before-cursor text
         int gradInText = beforeCursor.lastIndexOf("\u00a7g");
-        if (gradInText != -1 && gradInText + 30 <= beforeCursor.length()) {
+        if (gradInText != -1 && gradInText + ColorFormatUtils.GRADIENT_SEQ_LEN <= beforeCursor.length()) {
             return hodgepodge$expandGradientToPerChar(beforeCursor, gradInText);
         }
 
@@ -128,7 +128,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (activeFormat.isEmpty()) {
             return beforeCursor;
         }
-        if (activeFormat.length() >= 30 && activeFormat.charAt(0) == '\u00a7' && activeFormat.charAt(1) == 'g') {
+        if (activeFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && activeFormat.charAt(0) == '\u00a7'
+                && activeFormat.charAt(1) == 'g') {
             // Gradient scrolled past: expand continuation as per-char colors
             return hodgepodge$expandScrolledGradientToPerChar(activeFormat, beforeCursor);
         }
@@ -151,7 +152,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (activeFormat.isEmpty()) {
             return afterCursor;
         }
-        if (activeFormat.length() >= 30 && activeFormat.charAt(0) == '\u00a7' && activeFormat.charAt(1) == 'g') {
+        if (activeFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && activeFormat.charAt(0) == '\u00a7'
+                && activeFormat.charAt(1) == 'g') {
             // Expand to per-char §x colors (same path as before-cursor) to avoid
             // float rounding differences between per-char and §g gradient rendering
             return hodgepodge$expandAfterCursorGradientToPerChar(activeFormat, afterCursor);
@@ -165,18 +167,21 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
      */
     @Unique
     private String hodgepodge$expandGradientToPerChar(String beforeCursor, int gradIdx) {
-        if (gradIdx + 30 > beforeCursor.length()) return beforeCursor;
+        if (gradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN > beforeCursor.length()) return beforeCursor;
 
         // Parse from full text to get the real gradient spec
         String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
         int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
-        if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return beforeCursor;
+        if (fullGradIdx == -1 || fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN > this.text.length())
+            return beforeCursor;
 
-        int startRgb = ColorFormatUtils.parseRgbFromSectionX(this.text, fullGradIdx + 2);
-        int endRgb = ColorFormatUtils.parseRgbFromSectionX(this.text, fullGradIdx + 16);
+        int startRgb = ColorFormatUtils
+                .parseRgbFromSectionX(this.text, fullGradIdx + ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET);
+        int endRgb = ColorFormatUtils
+                .parseRgbFromSectionX(this.text, fullGradIdx + ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET);
         if (startRgb == -1 || endRgb == -1) return beforeCursor;
 
-        int specEnd = fullGradIdx + 30;
+        int specEnd = fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
         int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
         if (totalVisible <= 1) return beforeCursor;
 
@@ -194,22 +199,25 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
      */
     @Unique
     private String hodgepodge$expandScrolledGradientToPerChar(String activeFormat, String beforeCursor) {
-        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 2);
-        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 16);
+        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET);
         if (startRgb == -1 || endRgb == -1) return activeFormat + beforeCursor;
 
         String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
         int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
-        if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return activeFormat + beforeCursor;
+        if (fullGradIdx == -1 || fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN > this.text.length())
+            return activeFormat + beforeCursor;
 
-        int specEnd = fullGradIdx + 30;
+        int specEnd = fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
         int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
         if (totalVisible <= 1) return activeFormat + beforeCursor;
 
         int scrolledChars = hodgepodge$countVisibleBounded(this.text, specEnd, this.lineScrollOffset);
 
-        // Preserve effects/styles from activeFormat (after the 30-char gradient spec)
-        String extras = activeFormat.length() > 30 ? activeFormat.substring(30) : "";
+        // Preserve effects/styles from activeFormat (after the gradient spec)
+        String extras = activeFormat.length() > ColorFormatUtils.GRADIENT_SEQ_LEN
+                ? activeFormat.substring(ColorFormatUtils.GRADIENT_SEQ_LEN)
+                : "";
 
         // Build per-char colored text (no embedded gradient spec — it was scrolled past)
         StringBuilder sb = new StringBuilder(beforeCursor.length() * 8);
@@ -219,11 +227,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             char ch = beforeCursor.charAt(i);
             if (ch == '\u00a7' && i + 1 < beforeCursor.length()) {
                 char code = Character.toLowerCase(beforeCursor.charAt(i + 1));
-                if (code == 'r' || (code >= '0' && code <= '9')
-                        || (code >= 'a' && code <= 'f')
-                        || code == 'x'
-                        || code == 'q'
-                        || code == 'g') {
+                if (ColorFormatUtils.isGradientTerminator(code)) {
                     sb.append(beforeCursor, i, beforeCursor.length());
                     return sb.toString();
                 }
@@ -251,18 +255,14 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         // Copy everything before the gradient spec
         sb.append(text, 0, gradIdx);
 
-        // Skip the 30-char gradient spec, emit per-char colors for visible chars after it
+        // Skip the gradient spec, emit per-char colors for visible chars after it
         int gradCharIdx = startCharIdx;
-        for (int i = gradIdx + 30; i < text.length(); i++) {
+        for (int i = gradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN; i < text.length(); i++) {
             char ch = text.charAt(i);
             if (ch == '\u00a7' && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 // Gradient terminator: copy rest as-is
-                if (code == 'r' || (code >= '0' && code <= '9')
-                        || (code >= 'a' && code <= 'f')
-                        || code == 'x'
-                        || code == 'q'
-                        || code == 'g') {
+                if (ColorFormatUtils.isGradientTerminator(code)) {
                     sb.append(text, i, text.length());
                     return sb.toString();
                 }
@@ -287,22 +287,25 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
      */
     @Unique
     private String hodgepodge$expandAfterCursorGradientToPerChar(String activeFormat, String afterCursor) {
-        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 2);
-        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, 16);
+        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET);
+        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET);
         if (startRgb == -1 || endRgb == -1) return activeFormat + afterCursor;
 
         String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
         int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
-        if (fullGradIdx == -1 || fullGradIdx + 30 > this.text.length()) return activeFormat + afterCursor;
+        if (fullGradIdx == -1 || fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN > this.text.length())
+            return activeFormat + afterCursor;
 
-        int specEnd = fullGradIdx + 30;
+        int specEnd = fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
         int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
         if (totalVisible <= 1) return activeFormat + afterCursor;
 
         int visibleBefore = hodgepodge$countVisibleBounded(this.text, specEnd, this.cursorPosition);
 
-        // Preserve effects/styles from activeFormat (after the 30-char gradient spec)
-        String extras = activeFormat.length() > 30 ? activeFormat.substring(30) : "";
+        // Preserve effects/styles from activeFormat (after the gradient spec)
+        String extras = activeFormat.length() > ColorFormatUtils.GRADIENT_SEQ_LEN
+                ? activeFormat.substring(ColorFormatUtils.GRADIENT_SEQ_LEN)
+                : "";
 
         StringBuilder sb = new StringBuilder(afterCursor.length() * 8);
         if (!extras.isEmpty()) sb.append(extras);
@@ -311,11 +314,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             char ch = afterCursor.charAt(i);
             if (ch == '\u00a7' && i + 1 < afterCursor.length()) {
                 char code = Character.toLowerCase(afterCursor.charAt(i + 1));
-                if (code == 'r' || (code >= '0' && code <= '9')
-                        || (code >= 'a' && code <= 'f')
-                        || code == 'x'
-                        || code == 'q'
-                        || code == 'g') {
+                if (ColorFormatUtils.isGradientTerminator(code)) {
                     sb.append(afterCursor, i, afterCursor.length());
                     return sb.toString();
                 }
@@ -340,13 +339,12 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     private static int hodgepodge$snapToFormatBoundary(String text, int offset) {
         if (offset <= 0 || offset >= text.length()) return offset;
 
-        // Look back up to 13 chars to see if we're inside a §x§R§R§G§G§B§B sequence
-        for (int lb = 1; lb <= 13 && offset - lb >= 0; lb++) {
+        // Look back to see if we're inside a §x§R§R§G§G§B§B sequence
+        for (int lb = 1; lb < ColorFormatUtils.SECTION_X_SEQ_LEN && offset - lb >= 0; lb++) {
             int candidate = offset - lb;
             if (candidate + 1 < text.length() && text.charAt(candidate) == '\u00a7'
                     && Character.toLowerCase(text.charAt(candidate + 1)) == 'x') {
-                // Found §x start. The full §x§R§R§G§G§B§B sequence is 14 chars.
-                int seqEnd = candidate + 14;
+                int seqEnd = candidate + ColorFormatUtils.SECTION_X_SEQ_LEN;
                 if (offset < seqEnd && seqEnd <= text.length()) {
                     return seqEnd;
                 }
@@ -411,11 +409,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         for (int i = startIdx; i < text.length(); i++) {
             if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
-                if (code == 'r' || (code >= '0' && code <= '9')
-                        || (code >= 'a' && code <= 'f')
-                        || code == 'x'
-                        || code == 'q'
-                        || code == 'g') {
+                if (ColorFormatUtils.isGradientTerminator(code)) {
                     break;
                 }
                 i++; // skip non-terminating format codes (k-o, w, j)
@@ -434,11 +428,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         for (int i = startIdx; i < limit; i++) {
             if (text.charAt(i) == '\u00a7' && i + 1 < limit) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
-                if (code == 'r' || (code >= '0' && code <= '9')
-                        || (code >= 'a' && code <= 'f')
-                        || code == 'x'
-                        || code == 'q'
-                        || code == 'g') {
+                if (ColorFormatUtils.isGradientTerminator(code)) {
                     break;
                 }
                 i++;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -7,27 +7,35 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import com.mitchej123.hodgepodge.util.ColorFormatUtils;
+
 @Mixin(NetHandlerPlayServer.class)
 public class MixinNetHandlerPlayServer_AnvilColorCodes {
+
+    /** Vanilla's visible-chars cap for anvil item names. */
+    private static final int ANVIL_VISIBLE_LIMIT = 30;
+
+    /** Raw length cap we allow past vanilla's limit so {@code &} color codes can fit. Abuse guard. */
+    private static final int ANVIL_RAW_LIMIT = 256;
 
     // Note: 'g' excluded — &g only valid as part of &g&#RRGGBB&#RRGGBB (handled separately below)
     private static final String HODGEPODGE$VALID_CODES = "0123456789abcdefklmnorqzv";
 
     /**
-     * Vanilla checks {@code s.length() <= 30} for anvil item names and silently drops the name if exceeded. With color
-     * codes like {@code &#FF0000} or {@code &z}, the raw string is longer than the visible text. Allow longer raw
-     * strings for format codes, but enforce:
+     * Vanilla checks {@code s.length() <= ANVIL_VISIBLE_LIMIT} for anvil item names and silently drops the name if
+     * exceeded. With color codes like {@code &#FF0000} or {@code &z}, the raw string is longer than the visible text.
+     * Allow longer raw strings for format codes, but enforce:
      * <ul>
-     * <li>visible chars &lt;= 30 (same as vanilla's intent)</li>
-     * <li>raw length &lt;= 256 (safety cap against abuse)</li>
+     * <li>visible chars &lt;= {@value #ANVIL_VISIBLE_LIMIT} (same as vanilla's intent)</li>
+     * <li>raw length &lt;= {@value #ANVIL_RAW_LIMIT} (safety cap against abuse)</li>
      * </ul>
      */
     @Redirect(
             method = "processVanilla250Packet",
             at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 0))
     private int hodgepodge$validateAnvilNameByVisibleChars(String name) {
-        if (name.length() <= 30) return name.length();
-        if (name.length() > 256) return 256;
+        if (name.length() <= ANVIL_VISIBLE_LIMIT) return name.length();
+        if (name.length() > ANVIL_RAW_LIMIT) return ANVIL_RAW_LIMIT;
         return hodgepodge$countVisibleChars(name);
     }
 
@@ -41,36 +49,36 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
         int len = text.length();
         for (int i = 0; i < len; i++) {
             char ch = text.charAt(i);
-            // &#RRGGBB (8 chars)
-            if (ch == '&' && i + 7 < len && text.charAt(i + 1) == '#') {
+            // &#RRGGBB
+            if (ch == '&' && i + ColorFormatUtils.AMP_HEX_LEN - 1 < len && text.charAt(i + 1) == '#') {
                 boolean valid = true;
-                for (int j = 2; j <= 7; j++) {
+                for (int j = 2; j < ColorFormatUtils.AMP_HEX_LEN; j++) {
                     if (Character.digit(text.charAt(i + j), 16) == -1) {
                         valid = false;
                         break;
                     }
                 }
                 if (valid) {
-                    i += 7;
+                    i += ColorFormatUtils.AMP_HEX_LEN - 1;
                     continue;
                 }
             }
-            // &g&#RRGGBB&#RRGGBB gradient (18 chars)
-            if (ch == '&' && i + 17 < len
+            // &g&#RRGGBB&#RRGGBB gradient
+            if (ch == '&' && i + ColorFormatUtils.AMP_GRADIENT_LEN - 1 < len
                     && Character.toLowerCase(text.charAt(i + 1)) == 'g'
                     && text.charAt(i + 2) == '&'
                     && text.charAt(i + 3) == '#'
-                    && text.charAt(i + 10) == '&'
-                    && text.charAt(i + 11) == '#') {
+                    && text.charAt(i + 2 + ColorFormatUtils.AMP_HEX_LEN) == '&'
+                    && text.charAt(i + 3 + ColorFormatUtils.AMP_HEX_LEN) == '#') {
                 boolean v1 = true, v2 = true;
-                for (int j = 4; j <= 9; j++) {
+                for (int j = 4; j < 2 + ColorFormatUtils.AMP_HEX_LEN; j++) {
                     if (Character.digit(text.charAt(i + j), 16) == -1) {
                         v1 = false;
                         break;
                     }
                 }
                 if (v1) {
-                    for (int j = 12; j <= 17; j++) {
+                    for (int j = 4 + ColorFormatUtils.AMP_HEX_LEN; j < ColorFormatUtils.AMP_GRADIENT_LEN; j++) {
                         if (Character.digit(text.charAt(i + j), 16) == -1) {
                             v2 = false;
                             break;
@@ -78,7 +86,7 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
                     }
                 }
                 if (v1 && v2) {
-                    i += 17;
+                    i += ColorFormatUtils.AMP_GRADIENT_LEN - 1;
                     continue;
                 }
             }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_SignLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_SignLimit.java
@@ -7,21 +7,22 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+import com.mitchej123.hodgepodge.util.SignLimits;
 
 @Mixin(NetHandlerPlayServer.class)
 public class MixinNetHandlerPlayServer_SignLimit {
 
     /**
-     * Vanilla checks {@code length() > 15} and replaces the line with "!?" if exceeded. We allow longer raw strings for
-     * format codes, but enforce: - visible chars <= 15 (same as vanilla's intent) - raw length <= 90 (safety cap
-     * against abuse)
+     * Vanilla checks {@code length() > SignLimits.VISIBLE} and replaces the line with "!?" if exceeded. We allow longer
+     * raw strings for format codes, but enforce: visible chars &lt;= {@link SignLimits#VISIBLE} (vanilla's intent), raw
+     * length &lt;= {@link SignLimits#RAW} (safety cap against abuse).
      */
     @Redirect(
             method = "processUpdateSign",
             at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 0))
     private int hodgepodge$validateSignLineLength(String str) {
-        if (str.length() <= 15) return str.length();
-        if (str.length() > 90) return 90;
+        if (str.length() <= SignLimits.VISIBLE) return str.length();
+        if (str.length() > SignLimits.RAW) return SignLimits.RAW;
         return FontRendering.countVisibleChars(str);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntitySign_RaiseNbtReadLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntitySign_RaiseNbtReadLimit.java
@@ -6,17 +6,20 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
+import com.mitchej123.hodgepodge.util.SignLimits;
+
 /**
  * Vanilla {@code readFromNBT} truncates each sign line to 15 raw chars. With {@code &} color codes, a legitimate line
- * is longer than 15 raw chars (e.g. {@code &g&#FF0000&#0000FFhello} is 23 raw but 5 visible). Raise the cap to 90 to
- * match the server-side safety cap in {@link MixinNetHandlerPlayServer_SignLimit}. Both the {@code length() > 15} check
- * and the {@code substring(0, 15)} call use the same constant, so a single ModifyConstant covers both.
+ * is longer than that (e.g. {@code &g&#FF0000&#0000FFhello} is 23 raw but 5 visible). Raise the cap to
+ * {@link SignLimits#RAW} to match the server-side safety cap in {@link MixinNetHandlerPlayServer_SignLimit}. Both the
+ * {@code length() > 15} check and the {@code substring(0, 15)} call use the same constant, so a single ModifyConstant
+ * covers both.
  */
 @Mixin(TileEntitySign.class)
 public class MixinTileEntitySign_RaiseNbtReadLimit {
 
     @ModifyConstant(method = "readFromNBT", constant = @Constant(intValue = 15))
     private int hodgepodge$raiseNbtReadLimit(int original) {
-        return 90;
+        return SignLimits.RAW;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
@@ -5,12 +5,54 @@ public final class ColorFormatUtils {
 
     private ColorFormatUtils() {}
 
+    /** Length of a {@code §x§R§R§G§G§B§B} RGB sequence. */
+    public static final int SECTION_X_SEQ_LEN = 14;
+
+    /** Offset of the first RGB sequence inside a {@code §g§x...§x...} gradient spec (past the {@code §g}). */
+    public static final int GRADIENT_FIRST_RGB_OFFSET = 2;
+
+    /** Offset of the second RGB sequence inside a {@code §g§x...§x...} gradient spec. */
+    public static final int GRADIENT_SECOND_RGB_OFFSET = GRADIENT_FIRST_RGB_OFFSET + SECTION_X_SEQ_LEN;
+
+    /** Length of a full {@code §g§x§R§R§G§G§B§B§x§R§R§G§G§B§B} gradient spec. */
+    public static final int GRADIENT_SEQ_LEN = GRADIENT_SECOND_RGB_OFFSET + SECTION_X_SEQ_LEN;
+
+    /** Length of a raw {@code &#RRGGBB} ampersand-RGB sequence. */
+    public static final int AMP_HEX_LEN = 8;
+
+    /** Length of a raw {@code &g&#RRGGBB&#RRGGBB} ampersand-gradient sequence. */
+    public static final int AMP_GRADIENT_LEN = 2 + AMP_HEX_LEN + AMP_HEX_LEN;
+
+    /**
+     * Codes that terminate an active gradient: reset ({@code r}), legacy colors ({@code 0}-{@code 9}, {@code a}-{@code
+     * f}), RGB ({@code x}), rainbow ({@code q}), new gradient ({@code g}). Style codes ({@code k}-{@code o}) and other
+     * effect codes ({@code z} wave, {@code v} dinnerbone) do not terminate — they don't change per-char color.
+     */
+    private static final String GRADIENT_TERMINATOR_CODES = "r0123456789abcdefxqg";
+
+    private static final boolean[] IS_GRADIENT_TERMINATOR = new boolean[128];
+
+    static {
+        for (int i = 0; i < GRADIENT_TERMINATOR_CODES.length(); i++) {
+            IS_GRADIENT_TERMINATOR[GRADIENT_TERMINATOR_CODES.charAt(i)] = true;
+        }
+    }
+
+    /**
+     * @param lowerCode the format code character (already lowercased) appearing immediately after a {@code §} or
+     *                  {@code &} marker
+     * @return {@code true} if this code terminates an active gradient
+     */
+    public static boolean isGradientTerminator(char lowerCode) {
+        return lowerCode < 128 && IS_GRADIENT_TERMINATOR[lowerCode];
+    }
+
     /**
      * Parse an RGB int from a {@code §x§R§R§G§G§B§B} sequence starting at {@code offset} (the position of the leading
      * {@code §}). Returns {@code -1} if the sequence is truncated or contains non-hex digits.
      */
     public static int parseRgbFromSectionX(String text, int offset) {
-        if (offset + 13 >= text.length()) return -1;
+        if (offset + SECTION_X_SEQ_LEN - 1 >= text.length()) return -1;
         int val = 0;
         for (int i = 0; i < 6; i++) {
             int d = Character.digit(text.charAt(offset + 3 + i * 2), 16);
@@ -24,11 +66,11 @@ public final class ColorFormatUtils {
     public static String buildSectionX(int rgb) {
         char S = '\u00a7';
         int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
-        return new StringBuilder(14).append(S).append('x').append(S).append(Character.forDigit((r >> 4) & 0xF, 16))
-                .append(S).append(Character.forDigit(r & 0xF, 16)).append(S)
-                .append(Character.forDigit((g >> 4) & 0xF, 16)).append(S).append(Character.forDigit(g & 0xF, 16))
-                .append(S).append(Character.forDigit((b >> 4) & 0xF, 16)).append(S)
-                .append(Character.forDigit(b & 0xF, 16)).toString();
+        return new StringBuilder(SECTION_X_SEQ_LEN).append(S).append('x').append(S)
+                .append(Character.forDigit((r >> 4) & 0xF, 16)).append(S).append(Character.forDigit(r & 0xF, 16))
+                .append(S).append(Character.forDigit((g >> 4) & 0xF, 16)).append(S)
+                .append(Character.forDigit(g & 0xF, 16)).append(S).append(Character.forDigit((b >> 4) & 0xF, 16))
+                .append(S).append(Character.forDigit(b & 0xF, 16)).toString();
     }
 
     /** Linearly interpolate between two RGB ints at parameter {@code t} in [0, 1]. */

--- a/src/main/java/com/mitchej123/hodgepodge/util/SignLimits.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/SignLimits.java
@@ -1,0 +1,18 @@
+package com.mitchej123.hodgepodge.util;
+
+/**
+ * Shared sign-line length caps used by the four mixins that together bypass vanilla's 15-char sign limit for raw text
+ * that contains {@code &} color codes. All four mixins must agree on the raw cap, so it lives here.
+ */
+public final class SignLimits {
+
+    private SignLimits() {}
+
+    /** Vanilla's visible-chars-per-line cap. What the player actually sees on the sign. */
+    public static final int VISIBLE = 15;
+
+    /**
+     * Raw cap we allow past vanilla's limit so {@code &} color codes can fit alongside {@value #VISIBLE} visible chars.
+     */
+    public static final int RAW = 90;
+}


### PR DESCRIPTION
Deduplicates copies of the gradient-terminator check into ColorFormatUtils.isGradientTerminator(char) and replaces magic numbers (14, 30, 15, 90, etc.) with named constants across the color-code mixins zero behavior change.