### PR TITLE
Hodgepodge textfield cursor

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -16,8 +16,8 @@ import com.mitchej123.hodgepodge.commands.AllocationsCommand;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
-import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 import com.mitchej123.hodgepodge.mixins.hooks.ClientLeaksCleaningHook;
+import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 import com.mitchej123.hodgepodge.util.ManagedEnum;
 
 import biomesoplenty.common.eventhandler.client.gui.WorldTypeMessageEventHandler;

--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -15,6 +15,7 @@ import com.mitchej123.hodgepodge.commands.AllocationsCommand;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
+import com.mitchej123.hodgepodge.util.FontRenderingCompat;
 import com.mitchej123.hodgepodge.util.ManagedEnum;
 
 import biomesoplenty.common.eventhandler.client.gui.WorldTypeMessageEventHandler;
@@ -31,6 +32,7 @@ public class HodgepodgeClient {
     public static final ManagedEnum<RenderDebugMode> renderDebugMode = new ManagedEnum<>(RenderDebugMode.REDUCED);
 
     public static void postInit() {
+        FontRenderingCompat.registerFallbackIfNoAngelica();
 
         if (DebugConfig.renderDebug) {
             renderDebugMode.set(DebugConfig.renderDebugMode);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -566,6 +566,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinFontRenderer")
             .setApplyIf(() -> FixesConfig.fixFontRendererLinewrapRecursion)
             .setPhase(Phase.EARLY)),
+    FONT_RENDERER_FALLBACK_PREPROCESS(new MixinBuilder("Preprocess text through GTNHLib fallback when Angelica is absent")
+            .addClientMixins("minecraft.MixinFontRenderer_FallbackPreprocess")
+            .setApplyIf(() -> true)
+            .setPhase(Phase.EARLY)),
     BED_MESSAGE_ABOVE_HOTBAR(new MixinBuilder()
             .addCommonMixins("minecraft.MixinBlockBed")
             .setApplyIf(() -> TweaksConfig.bedMessageAboveHotbar)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer.java
@@ -48,7 +48,8 @@ public abstract class MixinFontRenderer {
             String newFormat = getFormatFromString(formatting.toString());
 
             // Handle gradient continuation: interpolate color at wrap point
-            if (newFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && newFormat.charAt(0) == '\u00a7'
+            if (newFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN
+                    && newFormat.charAt(0) == ColorFormatUtils.SECTION
                     && newFormat.charAt(1) == 'g') {
                 String remainder = StringUtils.substring(
                         str,
@@ -93,7 +94,7 @@ public abstract class MixinFontRenderer {
     private static int hodgepodge$countVisible(String text, int startIdx) {
         int count = 0;
         for (int i = startIdx; i < text.length(); i++) {
-            if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
+            if (text.charAt(i) == ColorFormatUtils.SECTION && i + 1 < text.length()) {
                 i++;
             } else {
                 count++;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_FallbackPreprocess.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFontRenderer_FallbackPreprocess.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.gui.FontRenderer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import com.mitchej123.hodgepodge.util.FontRenderingCompat;
+
+/**
+ * When Angelica is not installed, preprocesses text through GTNHLib's registered TextPreprocessor (the
+ * LegacyColorFallback) before the vanilla FontRenderer handles it. This converts extended color codes (&amp;#RRGGBB,
+ * &amp;c, etc.) to their nearest vanilla equivalents.
+ *
+ * When Angelica IS installed, its HEAD @Inject on drawString cancels before this code path is reached, so this mixin
+ * effectively never fires.
+ */
+@Mixin(FontRenderer.class)
+public class MixinFontRenderer_FallbackPreprocess {
+
+    @ModifyVariable(method = "drawString(Ljava/lang/String;IIIZ)I", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private String hodgepodge$preprocessDrawString(String text) {
+        return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(text) : text;
+    }
+
+    @ModifyVariable(method = "getStringWidth", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private String hodgepodge$preprocessGetStringWidth(String text) {
+        return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(text) : text;
+    }
+
+    @ModifyVariable(method = "listFormattedStringToWidth", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private String hodgepodge$preprocessListFormatted(String text) {
+        return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(text) : text;
+    }
+
+    @ModifyVariable(method = "wrapFormattedStringToWidth", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private String hodgepodge$preprocessWrapFormatted(String text) {
+        return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(text) : text;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiNewChat_FixColorWrapping.java
@@ -52,8 +52,9 @@ public class MixinGuiNewChat_FixColorWrapping {
             // Validate §g followed by two §x§R§R§G§G§B§B sequences
             final int firstRgbPos = gIdx + ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET;
             final int secondRgbPos = gIdx + ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET;
-            if (text.charAt(firstRgbPos) != '\u00a7' || Character.toLowerCase(text.charAt(firstRgbPos + 1)) != 'x'
-                    || text.charAt(secondRgbPos) != '\u00a7'
+            if (text.charAt(firstRgbPos) != ColorFormatUtils.SECTION
+                    || Character.toLowerCase(text.charAt(firstRgbPos + 1)) != 'x'
+                    || text.charAt(secondRgbPos) != ColorFormatUtils.SECTION
                     || Character.toLowerCase(text.charAt(secondRgbPos + 1)) != 'x') {
                 gIdx = text.indexOf("\u00a7g", gIdx + 2);
                 continue;
@@ -81,7 +82,7 @@ public class MixinGuiNewChat_FixColorWrapping {
             int visIdx = 0;
             for (int i = textStart; i < text.length(); i++) {
                 char ch = text.charAt(i);
-                if (ch == '\u00a7' && i + 1 < text.length()) {
+                if (ch == ColorFormatUtils.SECTION && i + 1 < text.length()) {
                     char code = Character.toLowerCase(text.charAt(i + 1));
                     if (ColorFormatUtils.isGradientTerminator(code)) {
                         last = i;
@@ -120,7 +121,7 @@ public class MixinGuiNewChat_FixColorWrapping {
         int count = 0;
         for (int i = startIdx; i < text.length(); i++) {
             char ch = text.charAt(i);
-            if (ch == '\u00a7' && i + 1 < text.length()) {
+            if (ch == ColorFormatUtils.SECTION && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 if (ColorFormatUtils.isGradientTerminator(code)) {
                     break;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -2,6 +2,7 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.mitchej123.hodgepodge.util.ColorFormatUtils;
 import com.mitchej123.hodgepodge.util.FontRenderingCompat;
@@ -36,9 +38,22 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     private int selectionEnd;
     @Shadow
     private FontRenderer field_146211_a;
+    @Shadow
+    private boolean isFocused;
+    @Shadow
+    private boolean isEnabled;
 
     @Shadow
     public abstract void setSelectionPos(int p_146199_1_);
+
+    @Shadow
+    public abstract void setCursorPosition(int pos);
+
+    @Shadow
+    public abstract int getNthWordFromCursor(int n);
+
+    @Shadow
+    public abstract int getSelectionEnd();
 
     @Unique
     private String hodgepodge$originalText;
@@ -371,12 +386,12 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
 
             if (raw.charAt(ri) == '&' && preprocessed.charAt(pi) == '\u00a7') {
                 if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi + 1) == 'x') {
-                    int rawEnd = Math.min(ri + 7, raw.length());
+                    int rawEnd = Math.min(ri + ColorFormatUtils.AMP_HEX_LEN, raw.length());
                     for (int sub = 1; sub < rawEnd - ri; sub++) {
                         map[ri + sub] = pi + sub * 2;
                     }
-                    ri += 7;
-                    pi += 14;
+                    ri += ColorFormatUtils.AMP_HEX_LEN;
+                    pi += ColorFormatUtils.SECTION_X_SEQ_LEN;
                 } else {
                     if (ri + 1 < raw.length()) {
                         map[ri + 1] = pi + 1;
@@ -437,6 +452,147 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             }
         }
         return count;
+    }
+
+    // --- Format-code-aware cursor navigation ---
+
+    @Inject(method = "textboxKeyTyped", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$formatAwareCursorNav(char typedChar, int keyCode, CallbackInfoReturnable<Boolean> cir) {
+        if (!this.isFocused || !FontRenderingCompat.HAS_PREPROCESS_TEXT) return;
+        if (this.text == null || this.text.indexOf('&') == -1) return;
+
+        if (keyCode == 203) { // LEFT
+            int target;
+            if (GuiScreen.isShiftKeyDown()) {
+                if (GuiScreen.isCtrlKeyDown()) {
+                    target = this.getNthWordFromCursor(-1);
+                } else {
+                    target = this.getSelectionEnd() - 1;
+                }
+                target = hodgepodge$snapPastAmpCodes(this.text, target, false);
+                this.setSelectionPos(target);
+            } else if (GuiScreen.isCtrlKeyDown()) {
+                target = this.getNthWordFromCursor(-1);
+                target = hodgepodge$snapPastAmpCodes(this.text, target, false);
+                this.setCursorPosition(target);
+            } else {
+                target = hodgepodge$snapPastAmpCodes(this.text, this.selectionEnd - 1, false);
+                this.setCursorPosition(target);
+            }
+            cir.setReturnValue(true);
+        } else if (keyCode == 205) { // RIGHT
+            int target;
+            if (GuiScreen.isShiftKeyDown()) {
+                if (GuiScreen.isCtrlKeyDown()) {
+                    target = this.getNthWordFromCursor(1);
+                } else {
+                    target = this.getSelectionEnd() + 1;
+                }
+                target = hodgepodge$snapPastAmpCodes(this.text, target, true);
+                this.setSelectionPos(target);
+            } else if (GuiScreen.isCtrlKeyDown()) {
+                target = this.getNthWordFromCursor(1);
+                target = hodgepodge$snapPastAmpCodes(this.text, target, true);
+                this.setCursorPosition(target);
+            } else {
+                target = hodgepodge$snapPastAmpCodes(this.text, this.selectionEnd + 1, true);
+                this.setCursorPosition(target);
+            }
+            cir.setReturnValue(true);
+        } else if (this.isEnabled && this.selectionEnd == this.cursorPosition && !GuiScreen.isCtrlKeyDown()) {
+            if (keyCode == 14) { // BACKSPACE — delete format code as atomic unit
+                int deletePos = this.cursorPosition - 1;
+                if (deletePos >= 0) {
+                    int[] range = hodgepodge$findAmpCodeRange(this.text, deletePos);
+                    if (range != null) {
+                        this.text = this.text.substring(0, range[0]) + this.text.substring(range[1]);
+                        this.setCursorPosition(range[0]);
+                        cir.setReturnValue(true);
+                    }
+                }
+            } else if (keyCode == 211) { // DELETE — delete format code as atomic unit
+                if (this.cursorPosition < this.text.length()) {
+                    int[] range = hodgepodge$findAmpCodeRange(this.text, this.cursorPosition);
+                    if (range != null) {
+                        this.text = this.text.substring(0, range[0]) + this.text.substring(range[1]);
+                        this.setCursorPosition(range[0]);
+                        cir.setReturnValue(true);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * If {@code pos} is inside an {@code &}-based format code, snap it to the boundary: forward → end, backward →
+     * start. For forward movement, landing exactly on the {@code &} also snaps past the code.
+     */
+    @Unique
+    private static int hodgepodge$snapPastAmpCodes(String text, int pos, boolean forward) {
+        if (text == null || text.isEmpty()) return pos;
+        pos = Math.max(0, Math.min(pos, text.length()));
+
+        int i = 0;
+        while (i < text.length()) {
+            if (text.charAt(i) != '&' || i + 1 >= text.length()) {
+                i++;
+                continue;
+            }
+            char next = Character.toLowerCase(text.charAt(i + 1));
+            int codeEnd = -1;
+
+            if (next == 'g' && ColorFormatUtils.isAmpGradientAt(text, i)) {
+                codeEnd = i + ColorFormatUtils.AMP_GRADIENT_LEN;
+            } else if (next == '#' && ColorFormatUtils.isAmpHexAt(text, i)) {
+                codeEnd = i + ColorFormatUtils.AMP_HEX_LEN;
+            } else if (ColorFormatUtils.VALID_AMP_SINGLE_CODES.indexOf(next) != -1) {
+                codeEnd = i + 2;
+            }
+
+            if (codeEnd != -1) {
+                boolean inside = forward ? (pos >= i && pos < codeEnd) : (pos > i && pos < codeEnd);
+                if (inside) {
+                    return forward ? codeEnd : i;
+                }
+                i = codeEnd;
+            } else {
+                i++;
+            }
+        }
+        return pos;
+    }
+
+    /** Returns {@code [start, end)} if {@code pos} is inside an {@code &}-based format code, or {@code null}. */
+    @Unique
+    private static int[] hodgepodge$findAmpCodeRange(String text, int pos) {
+        if (text == null || pos < 0 || pos >= text.length()) return null;
+        int i = 0;
+        while (i < text.length()) {
+            if (text.charAt(i) != '&' || i + 1 >= text.length()) {
+                i++;
+                continue;
+            }
+            char next = Character.toLowerCase(text.charAt(i + 1));
+            int codeEnd = -1;
+
+            if (next == 'g' && ColorFormatUtils.isAmpGradientAt(text, i)) {
+                codeEnd = i + ColorFormatUtils.AMP_GRADIENT_LEN;
+            } else if (next == '#' && ColorFormatUtils.isAmpHexAt(text, i)) {
+                codeEnd = i + ColorFormatUtils.AMP_HEX_LEN;
+            } else if (ColorFormatUtils.VALID_AMP_SINGLE_CODES.indexOf(next) != -1) {
+                codeEnd = i + 2;
+            }
+
+            if (codeEnd != -1) {
+                if (pos >= i && pos < codeEnd) {
+                    return new int[] { i, codeEnd };
+                }
+                i = codeEnd;
+            } else {
+                i++;
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -55,6 +55,9 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     @Shadow
     public abstract int getSelectionEnd();
 
+    @Shadow
+    public abstract int getWidth();
+
     @Unique
     private String hodgepodge$originalText;
     @Unique
@@ -118,43 +121,41 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     }
 
     @Unique
-    private static int hodgepodge$hsvToRgb(float hue) {
-        int h = (int) (hue / 60f) % 6;
-        float f = hue / 60f - h;
-        float r, g, b;
-        switch (h) {
-            case 0:
-                r = 1;
-                g = f;
-                b = 0;
-                break;
-            case 1:
-                r = 1 - f;
-                g = 1;
-                b = 0;
-                break;
-            case 2:
-                r = 0;
-                g = 1;
-                b = f;
-                break;
-            case 3:
-                r = 0;
-                g = 1 - f;
-                b = 1;
-                break;
-            case 4:
-                r = f;
-                g = 0;
-                b = 1;
-                break;
-            default:
-                r = 1;
-                g = 0;
-                b = 1 - f;
-                break;
+    private static boolean hodgepodge$formatHasBold(String format) {
+        for (int i = 0; i < format.length() - 1; i++) {
+            if (format.charAt(i) == '§' && Character.toLowerCase(format.charAt(i + 1)) == 'l') {
+                return true;
+            }
         }
-        return ((int) (r * 255) << 16) | ((int) (g * 255) << 8) | (int) (b * 255);
+        return false;
+    }
+
+    @Unique
+    private void hodgepodge$compensateBoldScroll(String text) {
+        if (this.lineScrollOffset <= 0 || this.lineScrollOffset >= text.length()) return;
+
+        int targetPos = Math.min(this.cursorPosition, text.length());
+        String prefix = text.substring(0, this.lineScrollOffset);
+        String activeFormat = FontRenderer.getFormatFromString(prefix);
+        if (!hodgepodge$formatHasBold(activeFormat)) return;
+
+        int fieldWidth = this.getWidth();
+
+        for (int i = 0; i < 20 && this.lineScrollOffset < targetPos; i++) {
+            String withFormat = activeFormat + text.substring(this.lineScrollOffset);
+            String trimmed = this.field_146211_a.trimStringToWidth(withFormat, fieldWidth);
+            int visibleEnd = this.lineScrollOffset + trimmed.length() - activeFormat.length();
+
+            if (targetPos <= visibleEnd) break;
+
+            this.lineScrollOffset++;
+            this.lineScrollOffset = hodgepodge$snapToFormatBoundary(text, this.lineScrollOffset);
+            if (this.lineScrollOffset >= text.length()) break;
+
+            prefix = text.substring(0, this.lineScrollOffset);
+            activeFormat = FontRenderer.getFormatFromString(prefix);
+            if (!hodgepodge$formatHasBold(activeFormat)) break;
+        }
     }
 
     @Unique
@@ -208,7 +209,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 i++;
             } else {
                 float hue = (charIdx * 15f) % 360f;
-                sb.append(ColorFormatUtils.buildSectionX(hodgepodge$hsvToRgb(hue)));
+                sb.append(ColorFormatUtils.buildSectionX(ColorFormatUtils.hsvToRgb(hue)));
                 sb.append(ch);
                 charIdx++;
             }
@@ -236,21 +237,14 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         this.text = preprocessed;
         this.cursorPosition = hodgepodge$mapPosition(posMap, hodgepodge$originalCursorPosition);
 
-        // Compute scroll offset in two passes:
-        // 1) Let setSelectionPos compute an initial offset
-        // 2) Snap past any format code boundary
-        // 3) Re-run setSelectionPos so it readjusts to keep cursor visible
         this.lineScrollOffset = 0;
-        this.setSelectionPos(mappedSelection);
-        int preSnap = this.lineScrollOffset;
-        this.lineScrollOffset = hodgepodge$snapToFormatBoundary(preprocessed, this.lineScrollOffset);
-        int snapped = this.lineScrollOffset - preSnap; // how many extra chars we skipped
-        this.setSelectionPos(mappedSelection);
-        // The snap skipped zero-width format chars, but setSelectionPos doesn't know that.
-        // Add the skipped count so the cursor stays fully in view.
-        if (snapped > 0) {
-            this.lineScrollOffset += snapped;
+        for (int iter = 0; iter < 10; iter++) {
+            int prev = this.lineScrollOffset;
+            this.setSelectionPos(mappedSelection);
+            this.lineScrollOffset = hodgepodge$snapToFormatBoundary(preprocessed, this.lineScrollOffset);
+            if (this.lineScrollOffset == prev) break;
         }
+        hodgepodge$compensateBoldScroll(preprocessed);
     }
 
     @Inject(method = "drawTextBox", at = @At("RETURN"))
@@ -274,33 +268,36 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                     ordinal = 0),
             index = 0)
     private String hodgepodge$fixScrolledColorCodes(String beforeCursor) {
-        // Check for gradient embedded in the visible before-cursor text
+        // Vanilla shadow-pass style leak fix: drawString calls renderStringAtPos twice (shadow + main)
+        // but only resets styles once. Style codes set during shadow leak into main pass.
+        // Prepending reset at the start fixes this (no-op in shadow, resets leaked styles in main).
         int gradInText = beforeCursor.lastIndexOf("\u00a7g");
         if (gradInText != -1 && gradInText + ColorFormatUtils.GRADIENT_SEQ_LEN <= beforeCursor.length()) {
-            return hodgepodge$expandGradientToPerChar(beforeCursor, gradInText);
+            return "\u00a7r" + hodgepodge$expandGradientToPerChar(beforeCursor, gradInText);
         }
 
         if (this.lineScrollOffset <= 0) {
-            return beforeCursor;
+            return "\u00a7r" + beforeCursor;
         }
         String prefix = this.text.substring(0, Math.min(this.lineScrollOffset, this.text.length()));
         String activeFormat = FontRenderer.getFormatFromString(prefix);
         String activeEffects = hodgepodge$getActiveEffects(prefix);
         String colorAndStyles = hodgepodge$stripEffectCodes(activeFormat);
         if (colorAndStyles.isEmpty() && activeEffects.isEmpty()) {
-            return beforeCursor;
+            return "\u00a7r" + beforeCursor;
         }
         if (activeEffects.length() >= 2 && activeEffects.charAt(1) == 'q') {
             int scrolledChars = hodgepodge$getRainbowCharOffset(this.lineScrollOffset);
             String otherEffects = activeEffects.length() > 2 ? activeEffects.substring(2) : "";
-            return hodgepodge$expandRainbowToPerChar(beforeCursor, scrolledChars, otherEffects + colorAndStyles);
+            return "\u00a7r"
+                    + hodgepodge$expandRainbowToPerChar(beforeCursor, scrolledChars, otherEffects + colorAndStyles);
         }
         if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && colorAndStyles.charAt(0) == '\u00a7'
                 && colorAndStyles.charAt(1) == 'g') {
-            String expanded = hodgepodge$expandScrolledGradientToPerChar(colorAndStyles, beforeCursor);
-            return activeEffects.isEmpty() ? expanded : activeEffects + expanded;
+            String expanded = hodgepodge$expandGradientSegment(colorAndStyles, beforeCursor, this.lineScrollOffset);
+            return "\u00a7r" + (activeEffects.isEmpty() ? expanded : activeEffects + expanded);
         }
-        return activeEffects + colorAndStyles + beforeCursor;
+        return "\u00a7r" + activeEffects + colorAndStyles + beforeCursor;
     }
 
     /**
@@ -319,21 +316,22 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         String activeEffects = hodgepodge$getActiveEffects(prefix);
         String colorAndStyles = hodgepodge$stripEffectCodes(activeFormat);
         if (colorAndStyles.isEmpty() && activeEffects.isEmpty()) {
-            return afterCursor;
+            return "\u00a7r" + afterCursor;
         }
         if (activeEffects.length() >= 2 && activeEffects.charAt(1) == 'q') {
             int rainbowOffset = hodgepodge$getRainbowCharOffset(this.cursorPosition);
             String otherEffects = activeEffects.length() > 2 ? activeEffects.substring(2) : "";
-            return hodgepodge$expandRainbowToPerChar(afterCursor, rainbowOffset, otherEffects + colorAndStyles);
+            return "\u00a7r"
+                    + hodgepodge$expandRainbowToPerChar(afterCursor, rainbowOffset, otherEffects + colorAndStyles);
         }
         if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && colorAndStyles.charAt(0) == '\u00a7'
                 && colorAndStyles.charAt(1) == 'g') {
             // Expand to per-char §x colors (same path as before-cursor) to avoid
             // float rounding differences between per-char and §g gradient rendering
-            String expanded = hodgepodge$expandAfterCursorGradientToPerChar(colorAndStyles, afterCursor);
-            return activeEffects.isEmpty() ? expanded : activeEffects + expanded;
+            String expanded = hodgepodge$expandGradientSegment(colorAndStyles, afterCursor, this.cursorPosition);
+            return "\u00a7r" + (activeEffects.isEmpty() ? expanded : activeEffects + expanded);
         }
-        return activeEffects + colorAndStyles + afterCursor;
+        return "\u00a7r" + activeEffects + colorAndStyles + afterCursor;
     }
 
     /**
@@ -357,56 +355,51 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (startRgb == -1 || endRgb == -1) return beforeCursor;
 
         int specEnd = fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
-        int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
+        int totalVisible = ColorFormatUtils.countVisibleInGradient(this.text, specEnd);
         if (totalVisible <= 1) return beforeCursor;
 
         // Count gradient chars scrolled past (if any)
         int scrolledChars = 0;
         if (this.lineScrollOffset > specEnd) {
-            scrolledChars = hodgepodge$countVisibleBounded(this.text, specEnd, this.lineScrollOffset);
+            scrolledChars = ColorFormatUtils.countVisibleBounded(this.text, specEnd, this.lineScrollOffset);
         }
 
         return hodgepodge$buildPerCharGradient(beforeCursor, gradIdx, startRgb, endRgb, totalVisible, scrolledChars);
     }
 
-    /**
-     * Expand a scrolled-past gradient into per-char §x color codes for the visible text.
-     */
     @Unique
-    private String hodgepodge$expandScrolledGradientToPerChar(String activeFormat, String beforeCursor) {
+    private String hodgepodge$expandGradientSegment(String activeFormat, String visibleText, int countFromOffset) {
         int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET);
         int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET);
-        if (startRgb == -1 || endRgb == -1) return activeFormat + beforeCursor;
+        if (startRgb == -1 || endRgb == -1) return activeFormat + visibleText;
 
         String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
         int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
         if (fullGradIdx == -1 || fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN > this.text.length())
-            return activeFormat + beforeCursor;
+            return activeFormat + visibleText;
 
         int specEnd = fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
-        int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
-        if (totalVisible <= 1) return activeFormat + beforeCursor;
+        int totalVisible = ColorFormatUtils.countVisibleInGradient(this.text, specEnd);
+        if (totalVisible <= 1) return activeFormat + visibleText;
 
-        int scrolledChars = hodgepodge$countVisibleBounded(this.text, specEnd, this.lineScrollOffset);
+        int startCharIdx = ColorFormatUtils.countVisibleBounded(this.text, specEnd, countFromOffset);
 
-        // Preserve effects/styles from activeFormat (after the gradient spec)
         String extras = activeFormat.length() > ColorFormatUtils.GRADIENT_SEQ_LEN
                 ? activeFormat.substring(ColorFormatUtils.GRADIENT_SEQ_LEN)
                 : "";
 
-        // Build per-char colored text (no embedded gradient spec — it was scrolled past)
-        StringBuilder sb = new StringBuilder(beforeCursor.length() * 8);
+        StringBuilder sb = new StringBuilder(visibleText.length() * 8);
         if (!extras.isEmpty()) sb.append(extras);
-        int gradCharIdx = scrolledChars;
-        for (int i = 0; i < beforeCursor.length(); i++) {
-            char ch = beforeCursor.charAt(i);
-            if (ch == '\u00a7' && i + 1 < beforeCursor.length()) {
-                char code = Character.toLowerCase(beforeCursor.charAt(i + 1));
+        int gradCharIdx = startCharIdx;
+        for (int i = 0; i < visibleText.length(); i++) {
+            char ch = visibleText.charAt(i);
+            if (ch == '\u00a7' && i + 1 < visibleText.length()) {
+                char code = Character.toLowerCase(visibleText.charAt(i + 1));
                 if (ColorFormatUtils.isGradientTerminator(code)) {
-                    sb.append(beforeCursor, i, beforeCursor.length());
+                    sb.append(visibleText, i, visibleText.length());
                     return sb.toString();
                 }
-                sb.append(ch).append(beforeCursor.charAt(i + 1));
+                sb.append(ch).append(visibleText.charAt(i + 1));
                 i++;
             } else {
                 float t = (float) gradCharIdx / (totalVisible - 1);
@@ -446,56 +439,6 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
                 i++;
             } else {
                 // Visible char: emit its exact gradient color
-                float t = (float) gradCharIdx / (totalVisible - 1);
-                t = Math.min(t, 1f);
-                sb.append(ColorFormatUtils.buildSectionX(ColorFormatUtils.lerpRgb(startRgb, endRgb, t)));
-                sb.append(ch);
-                gradCharIdx++;
-            }
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Expand the after-cursor gradient into per-char §x colors using the full gradient's parameters, matching the
-     * before-cursor computation path exactly.
-     */
-    @Unique
-    private String hodgepodge$expandAfterCursorGradientToPerChar(String activeFormat, String afterCursor) {
-        int startRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_FIRST_RGB_OFFSET);
-        int endRgb = ColorFormatUtils.parseRgbFromSectionX(activeFormat, ColorFormatUtils.GRADIENT_SECOND_RGB_OFFSET);
-        if (startRgb == -1 || endRgb == -1) return activeFormat + afterCursor;
-
-        String upToCursor = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
-        int fullGradIdx = upToCursor.lastIndexOf("\u00a7g");
-        if (fullGradIdx == -1 || fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN > this.text.length())
-            return activeFormat + afterCursor;
-
-        int specEnd = fullGradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN;
-        int totalVisible = hodgepodge$countVisibleInGradient(this.text, specEnd);
-        if (totalVisible <= 1) return activeFormat + afterCursor;
-
-        int visibleBefore = hodgepodge$countVisibleBounded(this.text, specEnd, this.cursorPosition);
-
-        // Preserve effects/styles from activeFormat (after the gradient spec)
-        String extras = activeFormat.length() > ColorFormatUtils.GRADIENT_SEQ_LEN
-                ? activeFormat.substring(ColorFormatUtils.GRADIENT_SEQ_LEN)
-                : "";
-
-        StringBuilder sb = new StringBuilder(afterCursor.length() * 8);
-        if (!extras.isEmpty()) sb.append(extras);
-        int gradCharIdx = visibleBefore;
-        for (int i = 0; i < afterCursor.length(); i++) {
-            char ch = afterCursor.charAt(i);
-            if (ch == '\u00a7' && i + 1 < afterCursor.length()) {
-                char code = Character.toLowerCase(afterCursor.charAt(i + 1));
-                if (ColorFormatUtils.isGradientTerminator(code)) {
-                    sb.append(afterCursor, i, afterCursor.length());
-                    return sb.toString();
-                }
-                sb.append(ch).append(afterCursor.charAt(i + 1));
-                i++;
-            } else {
                 float t = (float) gradCharIdx / (totalVisible - 1);
                 t = Math.min(t, 1f);
                 sb.append(ColorFormatUtils.buildSectionX(ColorFormatUtils.lerpRgb(startRgb, endRgb, t)));
@@ -602,43 +545,6 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (rawPos <= 0) return 0;
         if (rawPos >= posMap.length) return posMap[posMap.length - 1];
         return posMap[rawPos];
-    }
-
-    /** Count visible chars from startIdx, stopping at gradient-terminating codes (§r, §0-f, §x, §q, §g). */
-    @Unique
-    private static int hodgepodge$countVisibleInGradient(String text, int startIdx) {
-        int count = 0;
-        for (int i = startIdx; i < text.length(); i++) {
-            if (text.charAt(i) == '\u00a7' && i + 1 < text.length()) {
-                char code = Character.toLowerCase(text.charAt(i + 1));
-                if (ColorFormatUtils.isGradientTerminator(code)) {
-                    break;
-                }
-                i++; // skip non-terminating format codes (k-o, w, j)
-            } else {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    /** Count visible chars from startIdx to endIdx, stopping at gradient-terminating codes. */
-    @Unique
-    private static int hodgepodge$countVisibleBounded(String text, int startIdx, int endIdx) {
-        int count = 0;
-        int limit = Math.min(endIdx, text.length());
-        for (int i = startIdx; i < limit; i++) {
-            if (text.charAt(i) == '\u00a7' && i + 1 < limit) {
-                char code = Character.toLowerCase(text.charAt(i + 1));
-                if (ColorFormatUtils.isGradientTerminator(code)) {
-                    break;
-                }
-                i++;
-            } else {
-                count++;
-            }
-        }
-        return count;
     }
 
     // --- Format-code-aware cursor navigation ---

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -71,11 +71,156 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         return FontRenderingCompat.HAS_PREPROCESS_TEXT ? FontRenderingCompat.preprocessText(s) : s;
     }
 
+    @Unique
+    private static String hodgepodge$getActiveEffects(String text) {
+        boolean wave = false, dinnerbone = false, rainbow = false;
+        for (int i = 0; i < text.length() - 1; i++) {
+            if (text.charAt(i) == '§') {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (code == 'r') {
+                    wave = false;
+                    dinnerbone = false;
+                    rainbow = false;
+                } else if (code == 'z') {
+                    wave = true;
+                } else if (code == 'v') {
+                    dinnerbone = true;
+                } else if (code == 'q') {
+                    rainbow = true;
+                } else if (ColorFormatUtils.isGradientTerminator(code)) {
+                    rainbow = false;
+                }
+                i++;
+            }
+        }
+        if (!wave && !dinnerbone && !rainbow) return "";
+        StringBuilder sb = new StringBuilder(6);
+        if (rainbow) sb.append('§').append('q');
+        if (wave) sb.append('§').append('z');
+        if (dinnerbone) sb.append('§').append('v');
+        return sb.toString();
+    }
+
+    @Unique
+    private static String hodgepodge$stripEffectCodes(String format) {
+        if (format.indexOf('q') == -1 && format.indexOf('z') == -1 && format.indexOf('v') == -1) return format;
+        StringBuilder sb = new StringBuilder(format.length());
+        for (int i = 0; i < format.length() - 1; i++) {
+            if (format.charAt(i) == '§') {
+                char code = Character.toLowerCase(format.charAt(i + 1));
+                if (code != 'q' && code != 'z' && code != 'v') {
+                    sb.append(format, i, i + 2);
+                }
+                i++;
+            }
+        }
+        return sb.toString();
+    }
+
+    @Unique
+    private static int hodgepodge$hsvToRgb(float hue) {
+        int h = (int) (hue / 60f) % 6;
+        float f = hue / 60f - h;
+        float r, g, b;
+        switch (h) {
+            case 0:
+                r = 1;
+                g = f;
+                b = 0;
+                break;
+            case 1:
+                r = 1 - f;
+                g = 1;
+                b = 0;
+                break;
+            case 2:
+                r = 0;
+                g = 1;
+                b = f;
+                break;
+            case 3:
+                r = 0;
+                g = 1 - f;
+                b = 1;
+                break;
+            case 4:
+                r = f;
+                g = 0;
+                b = 1;
+                break;
+            default:
+                r = 1;
+                g = 0;
+                b = 1 - f;
+                break;
+        }
+        return ((int) (r * 255) << 16) | ((int) (g * 255) << 8) | (int) (b * 255);
+    }
+
+    @Unique
+    private int hodgepodge$getRainbowCharOffset(int endPos) {
+        String fullText = this.text;
+        int end = Math.min(endPos, fullText.length());
+        int rainbowStart = -1;
+        for (int i = 0; i < end - 1; i++) {
+            if (fullText.charAt(i) != '§') continue;
+            char code = Character.toLowerCase(fullText.charAt(i + 1));
+            if (code == 'q') {
+                rainbowStart = i + 2;
+            } else if (ColorFormatUtils.isGradientTerminator(code)) {
+                rainbowStart = -1;
+                if (code == 'x' && i + ColorFormatUtils.SECTION_X_SEQ_LEN <= fullText.length()) {
+                    i += ColorFormatUtils.SECTION_X_SEQ_LEN - 1;
+                    continue;
+                } else if (code == 'g' && i + ColorFormatUtils.GRADIENT_SEQ_LEN <= fullText.length()) {
+                    i += ColorFormatUtils.GRADIENT_SEQ_LEN - 1;
+                    continue;
+                }
+            }
+            i++;
+        }
+        if (rainbowStart == -1 || rainbowStart >= end) return 0;
+        int count = 0;
+        for (int i = rainbowStart; i < end; i++) {
+            if (fullText.charAt(i) == '§' && i + 1 < end) {
+                i++;
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Unique
+    private static String hodgepodge$expandRainbowToPerChar(String text, int startCharIdx, String extraPrefix) {
+        StringBuilder sb = new StringBuilder(text.length() * 16);
+        if (!extraPrefix.isEmpty()) sb.append(extraPrefix);
+        int charIdx = startCharIdx;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch == '§' && i + 1 < text.length()) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (ColorFormatUtils.isGradientTerminator(code)) {
+                    sb.append(text, i, text.length());
+                    return sb.toString();
+                }
+                sb.append(ch).append(text.charAt(i + 1));
+                i++;
+            } else {
+                float hue = (charIdx * 15f) % 360f;
+                sb.append(ColorFormatUtils.buildSectionX(hodgepodge$hsvToRgb(hue)));
+                sb.append(ch);
+                charIdx++;
+            }
+        }
+        return sb.toString();
+    }
+
     @Inject(method = "drawTextBox", at = @At("HEAD"))
     private void hodgepodge$preprocessOnDrawHead(CallbackInfo ci) {
         hodgepodge$swapped = false;
         String preprocessed = hodgepodge$safePreprocess(this.text);
-        if (preprocessed.length() == this.text.length()) {
+        if (preprocessed.equals(this.text)) {
             return;
         }
 
@@ -140,15 +285,22 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         }
         String prefix = this.text.substring(0, Math.min(this.lineScrollOffset, this.text.length()));
         String activeFormat = FontRenderer.getFormatFromString(prefix);
-        if (activeFormat.isEmpty()) {
+        String activeEffects = hodgepodge$getActiveEffects(prefix);
+        String colorAndStyles = hodgepodge$stripEffectCodes(activeFormat);
+        if (colorAndStyles.isEmpty() && activeEffects.isEmpty()) {
             return beforeCursor;
         }
-        if (activeFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && activeFormat.charAt(0) == '\u00a7'
-                && activeFormat.charAt(1) == 'g') {
-            // Gradient scrolled past: expand continuation as per-char colors
-            return hodgepodge$expandScrolledGradientToPerChar(activeFormat, beforeCursor);
+        if (activeEffects.length() >= 2 && activeEffects.charAt(1) == 'q') {
+            int scrolledChars = hodgepodge$getRainbowCharOffset(this.lineScrollOffset);
+            String otherEffects = activeEffects.length() > 2 ? activeEffects.substring(2) : "";
+            return hodgepodge$expandRainbowToPerChar(beforeCursor, scrolledChars, otherEffects + colorAndStyles);
         }
-        return activeFormat + beforeCursor;
+        if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && colorAndStyles.charAt(0) == '\u00a7'
+                && colorAndStyles.charAt(1) == 'g') {
+            String expanded = hodgepodge$expandScrolledGradientToPerChar(colorAndStyles, beforeCursor);
+            return activeEffects.isEmpty() ? expanded : activeEffects + expanded;
+        }
+        return activeEffects + colorAndStyles + beforeCursor;
     }
 
     /**
@@ -164,16 +316,24 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     private String hodgepodge$fixCursorSplitColorCodes(String afterCursor) {
         String prefix = this.text.substring(0, Math.min(this.cursorPosition, this.text.length()));
         String activeFormat = FontRenderer.getFormatFromString(prefix);
-        if (activeFormat.isEmpty()) {
+        String activeEffects = hodgepodge$getActiveEffects(prefix);
+        String colorAndStyles = hodgepodge$stripEffectCodes(activeFormat);
+        if (colorAndStyles.isEmpty() && activeEffects.isEmpty()) {
             return afterCursor;
         }
-        if (activeFormat.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && activeFormat.charAt(0) == '\u00a7'
-                && activeFormat.charAt(1) == 'g') {
+        if (activeEffects.length() >= 2 && activeEffects.charAt(1) == 'q') {
+            int rainbowOffset = hodgepodge$getRainbowCharOffset(this.cursorPosition);
+            String otherEffects = activeEffects.length() > 2 ? activeEffects.substring(2) : "";
+            return hodgepodge$expandRainbowToPerChar(afterCursor, rainbowOffset, otherEffects + colorAndStyles);
+        }
+        if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && colorAndStyles.charAt(0) == '\u00a7'
+                && colorAndStyles.charAt(1) == 'g') {
             // Expand to per-char §x colors (same path as before-cursor) to avoid
             // float rounding differences between per-char and §g gradient rendering
-            return hodgepodge$expandAfterCursorGradientToPerChar(activeFormat, afterCursor);
+            String expanded = hodgepodge$expandAfterCursorGradientToPerChar(colorAndStyles, afterCursor);
+            return activeEffects.isEmpty() ? expanded : activeEffects + expanded;
         }
-        return activeFormat + afterCursor;
+        return activeEffects + colorAndStyles + afterCursor;
     }
 
     /**
@@ -381,25 +541,52 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         int ri = 0;
         int pi = 0;
 
-        while (ri < raw.length() && pi < preprocessed.length()) {
+        while (ri < raw.length()) {
             map[ri] = pi;
 
-            if (raw.charAt(ri) == '&' && preprocessed.charAt(pi) == '\u00a7') {
-                if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi + 1) == 'x') {
-                    int rawEnd = Math.min(ri + ColorFormatUtils.AMP_HEX_LEN, raw.length());
-                    for (int sub = 1; sub < rawEnd - ri; sub++) {
-                        map[ri + sub] = pi + sub * 2;
+            if (raw.charAt(ri) == '&' && ri + 1 < raw.length()) {
+                char next = Character.toLowerCase(raw.charAt(ri + 1));
+                int rawLen = 0;
+                int prepLen = 0;
+
+                if (next == 'g' && ColorFormatUtils.isAmpGradientAt(raw, ri)) {
+                    rawLen = ColorFormatUtils.AMP_GRADIENT_LEN;
+                    if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7'
+                            && Character.toLowerCase(preprocessed.charAt(pi + 1)) == 'g') {
+                        prepLen = ColorFormatUtils.GRADIENT_SEQ_LEN;
+                    } else if (pi < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7') {
+                        prepLen = 2;
                     }
-                    ri += ColorFormatUtils.AMP_HEX_LEN;
-                    pi += ColorFormatUtils.SECTION_X_SEQ_LEN;
-                } else {
-                    if (ri + 1 < raw.length()) {
-                        map[ri + 1] = pi + 1;
+                } else if (next == '#' && ColorFormatUtils.isAmpHexAt(raw, ri)) {
+                    rawLen = ColorFormatUtils.AMP_HEX_LEN;
+                    if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7'
+                            && Character.toLowerCase(preprocessed.charAt(pi + 1)) == 'x') {
+                        prepLen = ColorFormatUtils.SECTION_X_SEQ_LEN;
+                    } else if (pi < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7') {
+                        prepLen = 2;
                     }
-                    ri += 2;
-                    pi += 2;
+                } else if (ColorFormatUtils.VALID_AMP_SINGLE_CODES.indexOf(next) != -1) {
+                    rawLen = 2;
+                    if (next == 'q' || next == 'z' || next == 'v') {
+                        if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7'
+                                && Character.toLowerCase(preprocessed.charAt(pi + 1)) == next) {
+                            prepLen = 2;
+                        }
+                    } else {
+                        prepLen = 2;
+                    }
                 }
-                continue;
+
+                if (rawLen > 0) {
+                    for (int sub = 1; sub < rawLen; sub++) {
+                        if (ri + sub < raw.length()) {
+                            map[ri + sub] = pi;
+                        }
+                    }
+                    ri += rawLen;
+                    pi += prepLen;
+                    continue;
+                }
             }
 
             ri++;
@@ -461,41 +648,24 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (!this.isFocused || !FontRenderingCompat.HAS_PREPROCESS_TEXT) return;
         if (this.text == null || this.text.indexOf('&') == -1) return;
 
-        if (keyCode == 203) { // LEFT
+        if (keyCode == 203 || keyCode == 205) { // LEFT or RIGHT
+            int dir = keyCode == 205 ? 1 : -1;
+            boolean forward = dir > 0;
             int target;
             if (GuiScreen.isShiftKeyDown()) {
                 if (GuiScreen.isCtrlKeyDown()) {
-                    target = this.getNthWordFromCursor(-1);
+                    target = this.getNthWordFromCursor(dir);
                 } else {
-                    target = this.getSelectionEnd() - 1;
+                    target = this.getSelectionEnd() + dir;
                 }
-                target = hodgepodge$snapPastAmpCodes(this.text, target, false);
+                target = hodgepodge$snapPastAmpCodes(this.text, target, forward);
                 this.setSelectionPos(target);
             } else if (GuiScreen.isCtrlKeyDown()) {
-                target = this.getNthWordFromCursor(-1);
-                target = hodgepodge$snapPastAmpCodes(this.text, target, false);
+                target = this.getNthWordFromCursor(dir);
+                target = hodgepodge$snapPastAmpCodes(this.text, target, forward);
                 this.setCursorPosition(target);
             } else {
-                target = hodgepodge$snapPastAmpCodes(this.text, this.selectionEnd - 1, false);
-                this.setCursorPosition(target);
-            }
-            cir.setReturnValue(true);
-        } else if (keyCode == 205) { // RIGHT
-            int target;
-            if (GuiScreen.isShiftKeyDown()) {
-                if (GuiScreen.isCtrlKeyDown()) {
-                    target = this.getNthWordFromCursor(1);
-                } else {
-                    target = this.getSelectionEnd() + 1;
-                }
-                target = hodgepodge$snapPastAmpCodes(this.text, target, true);
-                this.setSelectionPos(target);
-            } else if (GuiScreen.isCtrlKeyDown()) {
-                target = this.getNthWordFromCursor(1);
-                target = hodgepodge$snapPastAmpCodes(this.text, target, true);
-                this.setCursorPosition(target);
-            } else {
-                target = hodgepodge$snapPastAmpCodes(this.text, this.selectionEnd + 1, true);
+                target = hodgepodge$snapPastAmpCodes(this.text, this.selectionEnd + dir, forward);
                 this.setCursorPosition(target);
             }
             cir.setReturnValue(true);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField_FixColorScroll.java
@@ -78,7 +78,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     private static String hodgepodge$getActiveEffects(String text) {
         boolean wave = false, dinnerbone = false, rainbow = false;
         for (int i = 0; i < text.length() - 1; i++) {
-            if (text.charAt(i) == '§') {
+            if (text.charAt(i) == ColorFormatUtils.SECTION) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 if (code == 'r') {
                     wave = false;
@@ -98,9 +98,9 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         }
         if (!wave && !dinnerbone && !rainbow) return "";
         StringBuilder sb = new StringBuilder(6);
-        if (rainbow) sb.append('§').append('q');
-        if (wave) sb.append('§').append('z');
-        if (dinnerbone) sb.append('§').append('v');
+        if (rainbow) sb.append(ColorFormatUtils.SECTION).append('q');
+        if (wave) sb.append(ColorFormatUtils.SECTION).append('z');
+        if (dinnerbone) sb.append(ColorFormatUtils.SECTION).append('v');
         return sb.toString();
     }
 
@@ -109,7 +109,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (format.indexOf('q') == -1 && format.indexOf('z') == -1 && format.indexOf('v') == -1) return format;
         StringBuilder sb = new StringBuilder(format.length());
         for (int i = 0; i < format.length() - 1; i++) {
-            if (format.charAt(i) == '§') {
+            if (format.charAt(i) == ColorFormatUtils.SECTION) {
                 char code = Character.toLowerCase(format.charAt(i + 1));
                 if (code != 'q' && code != 'z' && code != 'v') {
                     sb.append(format, i, i + 2);
@@ -123,7 +123,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
     @Unique
     private static boolean hodgepodge$formatHasBold(String format) {
         for (int i = 0; i < format.length() - 1; i++) {
-            if (format.charAt(i) == '§' && Character.toLowerCase(format.charAt(i + 1)) == 'l') {
+            if (format.charAt(i) == ColorFormatUtils.SECTION && Character.toLowerCase(format.charAt(i + 1)) == 'l') {
                 return true;
             }
         }
@@ -164,7 +164,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         int end = Math.min(endPos, fullText.length());
         int rainbowStart = -1;
         for (int i = 0; i < end - 1; i++) {
-            if (fullText.charAt(i) != '§') continue;
+            if (fullText.charAt(i) != ColorFormatUtils.SECTION) continue;
             char code = Character.toLowerCase(fullText.charAt(i + 1));
             if (code == 'q') {
                 rainbowStart = i + 2;
@@ -183,7 +183,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         if (rainbowStart == -1 || rainbowStart >= end) return 0;
         int count = 0;
         for (int i = rainbowStart; i < end; i++) {
-            if (fullText.charAt(i) == '§' && i + 1 < end) {
+            if (fullText.charAt(i) == ColorFormatUtils.SECTION && i + 1 < end) {
                 i++;
             } else {
                 count++;
@@ -199,7 +199,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         int charIdx = startCharIdx;
         for (int i = 0; i < text.length(); i++) {
             char ch = text.charAt(i);
-            if (ch == '§' && i + 1 < text.length()) {
+            if (ch == ColorFormatUtils.SECTION && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 if (ColorFormatUtils.isGradientTerminator(code)) {
                     sb.append(text, i, text.length());
@@ -292,7 +292,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             return "\u00a7r"
                     + hodgepodge$expandRainbowToPerChar(beforeCursor, scrolledChars, otherEffects + colorAndStyles);
         }
-        if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && colorAndStyles.charAt(0) == '\u00a7'
+        if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN
+                && colorAndStyles.charAt(0) == ColorFormatUtils.SECTION
                 && colorAndStyles.charAt(1) == 'g') {
             String expanded = hodgepodge$expandGradientSegment(colorAndStyles, beforeCursor, this.lineScrollOffset);
             return "\u00a7r" + (activeEffects.isEmpty() ? expanded : activeEffects + expanded);
@@ -324,7 +325,8 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
             return "\u00a7r"
                     + hodgepodge$expandRainbowToPerChar(afterCursor, rainbowOffset, otherEffects + colorAndStyles);
         }
-        if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN && colorAndStyles.charAt(0) == '\u00a7'
+        if (colorAndStyles.length() >= ColorFormatUtils.GRADIENT_SEQ_LEN
+                && colorAndStyles.charAt(0) == ColorFormatUtils.SECTION
                 && colorAndStyles.charAt(1) == 'g') {
             // Expand to per-char §x colors (same path as before-cursor) to avoid
             // float rounding differences between per-char and §g gradient rendering
@@ -393,7 +395,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         int gradCharIdx = startCharIdx;
         for (int i = 0; i < visibleText.length(); i++) {
             char ch = visibleText.charAt(i);
-            if (ch == '\u00a7' && i + 1 < visibleText.length()) {
+            if (ch == ColorFormatUtils.SECTION && i + 1 < visibleText.length()) {
                 char code = Character.toLowerCase(visibleText.charAt(i + 1));
                 if (ColorFormatUtils.isGradientTerminator(code)) {
                     sb.append(visibleText, i, visibleText.length());
@@ -427,7 +429,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         int gradCharIdx = startCharIdx;
         for (int i = gradIdx + ColorFormatUtils.GRADIENT_SEQ_LEN; i < text.length(); i++) {
             char ch = text.charAt(i);
-            if (ch == '\u00a7' && i + 1 < text.length()) {
+            if (ch == ColorFormatUtils.SECTION && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 // Gradient terminator: copy rest as-is
                 if (ColorFormatUtils.isGradientTerminator(code)) {
@@ -460,7 +462,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         // Look back to see if we're inside a §x§R§R§G§G§B§B sequence
         for (int lb = 1; lb < ColorFormatUtils.SECTION_X_SEQ_LEN && offset - lb >= 0; lb++) {
             int candidate = offset - lb;
-            if (candidate + 1 < text.length() && text.charAt(candidate) == '\u00a7'
+            if (candidate + 1 < text.length() && text.charAt(candidate) == ColorFormatUtils.SECTION
                     && Character.toLowerCase(text.charAt(candidate + 1)) == 'x') {
                 int seqEnd = candidate + ColorFormatUtils.SECTION_X_SEQ_LEN;
                 if (offset < seqEnd && seqEnd <= text.length()) {
@@ -471,7 +473,7 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
         }
 
         // Check if we're between § and its pair char (simple 2-char format like §c)
-        if (text.charAt(offset - 1) == '\u00a7') {
+        if (text.charAt(offset - 1) == ColorFormatUtils.SECTION) {
             return Math.min(offset + 1, text.length());
         }
 
@@ -494,24 +496,24 @@ public abstract class MixinGuiTextField_FixColorScroll extends Gui {
 
                 if (next == 'g' && ColorFormatUtils.isAmpGradientAt(raw, ri)) {
                     rawLen = ColorFormatUtils.AMP_GRADIENT_LEN;
-                    if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7'
+                    if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == ColorFormatUtils.SECTION
                             && Character.toLowerCase(preprocessed.charAt(pi + 1)) == 'g') {
                         prepLen = ColorFormatUtils.GRADIENT_SEQ_LEN;
-                    } else if (pi < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7') {
+                    } else if (pi < preprocessed.length() && preprocessed.charAt(pi) == ColorFormatUtils.SECTION) {
                         prepLen = 2;
                     }
                 } else if (next == '#' && ColorFormatUtils.isAmpHexAt(raw, ri)) {
                     rawLen = ColorFormatUtils.AMP_HEX_LEN;
-                    if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7'
+                    if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == ColorFormatUtils.SECTION
                             && Character.toLowerCase(preprocessed.charAt(pi + 1)) == 'x') {
                         prepLen = ColorFormatUtils.SECTION_X_SEQ_LEN;
-                    } else if (pi < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7') {
+                    } else if (pi < preprocessed.length() && preprocessed.charAt(pi) == ColorFormatUtils.SECTION) {
                         prepLen = 2;
                     }
                 } else if (ColorFormatUtils.VALID_AMP_SINGLE_CODES.indexOf(next) != -1) {
                     rawLen = 2;
                     if (next == 'q' || next == 'z' || next == 'v') {
-                        if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == '\u00a7'
+                        if (pi + 1 < preprocessed.length() && preprocessed.charAt(pi) == ColorFormatUtils.SECTION
                                 && Character.toLowerCase(preprocessed.charAt(pi + 1)) == next) {
                             prepLen = 2;
                         }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -48,7 +48,7 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
                     continue;
                 }
             }
-            if (ch == '\u00a7' && i + 1 < len) {
+            if (ch == ColorFormatUtils.SECTION && i + 1 < len) {
                 i++;
                 continue;
             }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_AnvilColorCodes.java
@@ -18,18 +18,6 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
     /** Raw length cap we allow past vanilla's limit so {@code &} color codes can fit. Abuse guard. */
     private static final int ANVIL_RAW_LIMIT = 256;
 
-    // Note: 'g' excluded — &g only valid as part of &g&#RRGGBB&#RRGGBB (handled separately below)
-    private static final String HODGEPODGE$VALID_CODES = "0123456789abcdefklmnorqzv";
-
-    /**
-     * Vanilla checks {@code s.length() <= ANVIL_VISIBLE_LIMIT} for anvil item names and silently drops the name if
-     * exceeded. With color codes like {@code &#FF0000} or {@code &z}, the raw string is longer than the visible text.
-     * Allow longer raw strings for format codes, but enforce:
-     * <ul>
-     * <li>visible chars &lt;= {@value #ANVIL_VISIBLE_LIMIT} (same as vanilla's intent)</li>
-     * <li>raw length &lt;= {@value #ANVIL_RAW_LIMIT} (safety cap against abuse)</li>
-     * </ul>
-     */
     @Redirect(
             method = "processVanilla250Packet",
             at = @At(value = "INVOKE", target = "Ljava/lang/String;length()I", ordinal = 0))
@@ -39,66 +27,27 @@ public class MixinNetHandlerPlayServer_AnvilColorCodes {
         return hodgepodge$countVisibleChars(name);
     }
 
-    /**
-     * Count visible characters in raw text, skipping valid {@code &} format codes and {@code §} format pairs. Does not
-     * depend on a registered preprocessor.
-     */
     @Unique
     private static int hodgepodge$countVisibleChars(String text) {
         int count = 0;
         int len = text.length();
         for (int i = 0; i < len; i++) {
             char ch = text.charAt(i);
-            // &#RRGGBB
-            if (ch == '&' && i + ColorFormatUtils.AMP_HEX_LEN - 1 < len && text.charAt(i + 1) == '#') {
-                boolean valid = true;
-                for (int j = 2; j < ColorFormatUtils.AMP_HEX_LEN; j++) {
-                    if (Character.digit(text.charAt(i + j), 16) == -1) {
-                        valid = false;
-                        break;
-                    }
-                }
-                if (valid) {
-                    i += ColorFormatUtils.AMP_HEX_LEN - 1;
-                    continue;
-                }
-            }
-            // &g&#RRGGBB&#RRGGBB gradient
-            if (ch == '&' && i + ColorFormatUtils.AMP_GRADIENT_LEN - 1 < len
-                    && Character.toLowerCase(text.charAt(i + 1)) == 'g'
-                    && text.charAt(i + 2) == '&'
-                    && text.charAt(i + 3) == '#'
-                    && text.charAt(i + 2 + ColorFormatUtils.AMP_HEX_LEN) == '&'
-                    && text.charAt(i + 3 + ColorFormatUtils.AMP_HEX_LEN) == '#') {
-                boolean v1 = true, v2 = true;
-                for (int j = 4; j < 2 + ColorFormatUtils.AMP_HEX_LEN; j++) {
-                    if (Character.digit(text.charAt(i + j), 16) == -1) {
-                        v1 = false;
-                        break;
-                    }
-                }
-                if (v1) {
-                    for (int j = 4 + ColorFormatUtils.AMP_HEX_LEN; j < ColorFormatUtils.AMP_GRADIENT_LEN; j++) {
-                        if (Character.digit(text.charAt(i + j), 16) == -1) {
-                            v2 = false;
-                            break;
-                        }
-                    }
-                }
-                if (v1 && v2) {
+            if (ch == '&' && i + 1 < len) {
+                char next = Character.toLowerCase(text.charAt(i + 1));
+                if (next == 'g' && ColorFormatUtils.isAmpGradientAt(text, i)) {
                     i += ColorFormatUtils.AMP_GRADIENT_LEN - 1;
                     continue;
                 }
-            }
-            // &X single format code (2 chars)
-            if (ch == '&' && i + 1 < len) {
-                char code = Character.toLowerCase(text.charAt(i + 1));
-                if (HODGEPODGE$VALID_CODES.indexOf(code) != -1) {
+                if (next == '#' && ColorFormatUtils.isAmpHexAt(text, i)) {
+                    i += ColorFormatUtils.AMP_HEX_LEN - 1;
+                    continue;
+                }
+                if (ColorFormatUtils.VALID_AMP_SINGLE_CODES.indexOf(next) != -1) {
                     i++;
                     continue;
                 }
             }
-            // §X format pair (2 chars)
             if (ch == '\u00a7' && i + 1 < len) {
                 i++;
                 continue;

--- a/src/main/java/com/mitchej123/hodgepodge/util/ChatComponentItemTranslation.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ChatComponentItemTranslation.java
@@ -1,7 +1,6 @@
 package com.mitchej123.hodgepodge.util;
 
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 import net.minecraft.item.Item;
 import net.minecraft.util.ChatComponentStyle;
@@ -9,8 +8,6 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.util.StatCollector;
 
 public class ChatComponentItemTranslation extends ChatComponentStyle {
-
-    private static final Pattern FORMATTING_CODE_PATTERN = Pattern.compile("(?i)\u00a7[0-9A-FK-OR]");
 
     private final Item item;
 
@@ -54,7 +51,7 @@ public class ChatComponentItemTranslation extends ChatComponentStyle {
     }
 
     private static String getTextWithoutFormattingCodes(String text) {
-        return text == null ? null : FORMATTING_CODE_PATTERN.matcher(text).replaceAll("");
+        return StringUtil.removeFormattingCodes(text);
     }
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
@@ -5,6 +5,8 @@ public final class ColorFormatUtils {
 
     private ColorFormatUtils() {}
 
+    public static final char SECTION = '§';
+
     /** Length of a {@code §x§R§R§G§G§B§B} RGB sequence. */
     public static final int SECTION_X_SEQ_LEN = 14;
 
@@ -67,13 +69,12 @@ public final class ColorFormatUtils {
 
     /** Build a {@code §x§R§R§G§G§B§B} sequence from an RGB int. */
     public static String buildSectionX(int rgb) {
-        char S = '\u00a7';
         int r = (rgb >> 16) & 0xFF, g = (rgb >> 8) & 0xFF, b = rgb & 0xFF;
-        return new StringBuilder(SECTION_X_SEQ_LEN).append(S).append('x').append(S)
-                .append(Character.forDigit((r >> 4) & 0xF, 16)).append(S).append(Character.forDigit(r & 0xF, 16))
-                .append(S).append(Character.forDigit((g >> 4) & 0xF, 16)).append(S)
-                .append(Character.forDigit(g & 0xF, 16)).append(S).append(Character.forDigit((b >> 4) & 0xF, 16))
-                .append(S).append(Character.forDigit(b & 0xF, 16)).toString();
+        return new StringBuilder(SECTION_X_SEQ_LEN).append(SECTION).append('x').append(SECTION)
+                .append(Character.forDigit((r >> 4) & 0xF, 16)).append(SECTION).append(Character.forDigit(r & 0xF, 16))
+                .append(SECTION).append(Character.forDigit((g >> 4) & 0xF, 16)).append(SECTION)
+                .append(Character.forDigit(g & 0xF, 16)).append(SECTION).append(Character.forDigit((b >> 4) & 0xF, 16))
+                .append(SECTION).append(Character.forDigit(b & 0xF, 16)).toString();
     }
 
     /** Check if all characters from {@code from} to {@code to} (inclusive) are hex digits. */
@@ -151,7 +152,7 @@ public final class ColorFormatUtils {
     public static int countVisibleInGradient(String text, int startIdx) {
         int count = 0;
         for (int i = startIdx; i < text.length(); i++) {
-            if (text.charAt(i) == '§' && i + 1 < text.length()) {
+            if (text.charAt(i) == ColorFormatUtils.SECTION && i + 1 < text.length()) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 if (isGradientTerminator(code)) {
                     break;
@@ -169,7 +170,7 @@ public final class ColorFormatUtils {
         int count = 0;
         int limit = Math.min(endIdx, text.length());
         for (int i = startIdx; i < limit; i++) {
-            if (text.charAt(i) == '§' && i + 1 < limit) {
+            if (text.charAt(i) == ColorFormatUtils.SECTION && i + 1 < limit) {
                 char code = Character.toLowerCase(text.charAt(i + 1));
                 if (isGradientTerminator(code)) {
                     break;

--- a/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
@@ -23,6 +23,9 @@ public final class ColorFormatUtils {
     /** Length of a raw {@code &g&#RRGGBB&#RRGGBB} ampersand-gradient sequence. */
     public static final int AMP_GRADIENT_LEN = 2 + AMP_HEX_LEN + AMP_HEX_LEN;
 
+    /** Valid single {@code &} codes (excludes {@code g} which only converts as {@code &g&#RRGGBB&#RRGGBB}). */
+    public static final String VALID_AMP_SINGLE_CODES = "0123456789abcdefklmnorqzv";
+
     /**
      * Codes that terminate an active gradient: reset ({@code r}), legacy colors ({@code 0}-{@code 9}, {@code a}-{@code
      * f}), RGB ({@code x}), rainbow ({@code q}), new gradient ({@code g}). Style codes ({@code k}-{@code o}) and other
@@ -71,6 +74,29 @@ public final class ColorFormatUtils {
                 .append(S).append(Character.forDigit((g >> 4) & 0xF, 16)).append(S)
                 .append(Character.forDigit(g & 0xF, 16)).append(S).append(Character.forDigit((b >> 4) & 0xF, 16))
                 .append(S).append(Character.forDigit(b & 0xF, 16)).toString();
+    }
+
+    /** Check if all characters from {@code from} to {@code to} (inclusive) are hex digits. */
+    public static boolean allHex(String text, int from, int to) {
+        for (int j = from; j <= to; j++) {
+            if (Character.digit(text.charAt(j), 16) == -1) return false;
+        }
+        return true;
+    }
+
+    /** Check if a valid {@code &#RRGGBB} (8-char) ampersand-hex code starts at {@code idx}. */
+    public static boolean isAmpHexAt(String text, int idx) {
+        return idx + AMP_HEX_LEN <= text.length() && text.charAt(idx + 1) == '#' && allHex(text, idx + 2, idx + 7);
+    }
+
+    /** Check if a valid {@code &g&#RRGGBB&#RRGGBB} (18-char) ampersand-gradient starts at {@code idx}. */
+    public static boolean isAmpGradientAt(String text, int idx) {
+        return idx + AMP_GRADIENT_LEN <= text.length() && text.charAt(idx + 2) == '&'
+                && text.charAt(idx + 3) == '#'
+                && text.charAt(idx + 10) == '&'
+                && text.charAt(idx + 11) == '#'
+                && allHex(text, idx + 4, idx + 9)
+                && allHex(text, idx + 12, idx + 17);
     }
 
     /** Linearly interpolate between two RGB ints at parameter {@code t} in [0, 1]. */

--- a/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/ColorFormatUtils.java
@@ -106,4 +106,79 @@ public final class ColorFormatUtils {
         int b = (int) ((from & 0xFF) * (1 - t) + (to & 0xFF) * t);
         return (r << 16) | (g << 8) | b;
     }
+
+    /** Convert a hue (0-360) at full saturation/value to an RGB int. */
+    public static int hsvToRgb(float hue) {
+        int h = (int) (hue / 60f) % 6;
+        float f = hue / 60f - h;
+        float r, g, b;
+        switch (h) {
+            case 0:
+                r = 1;
+                g = f;
+                b = 0;
+                break;
+            case 1:
+                r = 1 - f;
+                g = 1;
+                b = 0;
+                break;
+            case 2:
+                r = 0;
+                g = 1;
+                b = f;
+                break;
+            case 3:
+                r = 0;
+                g = 1 - f;
+                b = 1;
+                break;
+            case 4:
+                r = f;
+                g = 0;
+                b = 1;
+                break;
+            default:
+                r = 1;
+                g = 0;
+                b = 1 - f;
+                break;
+        }
+        return ((int) (r * 255) << 16) | ((int) (g * 255) << 8) | (int) (b * 255);
+    }
+
+    /** Count visible chars from {@code startIdx}, stopping at gradient-terminating codes. */
+    public static int countVisibleInGradient(String text, int startIdx) {
+        int count = 0;
+        for (int i = startIdx; i < text.length(); i++) {
+            if (text.charAt(i) == '§' && i + 1 < text.length()) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (isGradientTerminator(code)) {
+                    break;
+                }
+                i++;
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Count visible chars from {@code startIdx} to {@code endIdx}, stopping at gradient-terminating codes. */
+    public static int countVisibleBounded(String text, int startIdx, int endIdx) {
+        int count = 0;
+        int limit = Math.min(endIdx, text.length());
+        for (int i = startIdx; i < limit; i++) {
+            if (text.charAt(i) == '§' && i + 1 < limit) {
+                char code = Character.toLowerCase(text.charAt(i + 1));
+                if (isGradientTerminator(code)) {
+                    break;
+                }
+                i++;
+            } else {
+                count++;
+            }
+        }
+        return count;
+    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/FontRenderingCompat.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/FontRenderingCompat.java
@@ -2,6 +2,8 @@ package com.mitchej123.hodgepodge.util;
 
 import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
 
+import cpw.mods.fml.common.Loader;
+
 /** Checks for GTNHLib font rendering methods that may not exist in older versions. */
 public class FontRenderingCompat {
 
@@ -19,5 +21,12 @@ public class FontRenderingCompat {
     /** Only call when {@link #HAS_PREPROCESS_TEXT} is true. */
     public static String preprocessText(String s) {
         return FontRendering.preprocessText(s);
+    }
+
+    /** Register the legacy fallback preprocessor if Angelica is not installed. */
+    public static void registerFallbackIfNoAngelica() {
+        if (!HAS_PREPROCESS_TEXT) return;
+        if (Loader.isModLoaded("angelica")) return;
+        FontRendering.setTextPreprocessor(new LegacyColorFallback());
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/util/LegacyColorFallback.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/LegacyColorFallback.java
@@ -1,0 +1,163 @@
+package com.mitchej123.hodgepodge.util;
+
+import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
+
+/**
+ * Fallback text preprocessor for when Angelica is not installed. Converts extended color codes to their nearest vanilla
+ * equivalents so text renders with approximate colors instead of garbage.
+ */
+public class LegacyColorFallback implements FontRendering.TextPreprocessor {
+
+    private static final char SECTION = '§';
+
+    private static final int[] VANILLA_COLORS = { 0x000000, // §0
+            0x0000AA, // §1
+            0x00AA00, // §2
+            0x00AAAA, // §3
+            0xAA0000, // §4
+            0xAA00AA, // §5
+            0xFFAA00, // §6
+            0xAAAAAA, // §7
+            0x555555, // §8
+            0x5555FF, // §9
+            0x55FF55, // §a
+            0x55FFFF, // §b
+            0xFF5555, // §c
+            0xFF55FF, // §d
+            0xFFFF55, // §e
+            0xFFFFFF, // §f
+    };
+
+    private static final char[] VANILLA_CODES = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd',
+            'e', 'f' };
+
+    @Override
+    public String apply(String text) {
+        if (text == null || text.length() < 2) return text;
+        StringBuilder sb = new StringBuilder(text.length());
+        int len = text.length();
+
+        for (int i = 0; i < len; i++) {
+            char c = text.charAt(i);
+
+            if (c == SECTION && i + 1 < len) {
+                char next = Character.toLowerCase(text.charAt(i + 1));
+
+                if (next == 'x' && i + 13 < len) {
+                    int rgb = parseHexPairs(text, i + 2, 6);
+                    if (rgb != -1) {
+                        sb.append(SECTION).append(nearestVanilla(rgb));
+                        i += 13;
+                        continue;
+                    }
+                } else if (next == 'g' && i + 29 < len) {
+                    int startRgb = parseSectionX(text, i + 2);
+                    if (startRgb != -1) {
+                        sb.append(SECTION).append(nearestVanilla(startRgb));
+                        i += 29;
+                        continue;
+                    }
+                } else if (next == 'q' || next == 'z' || next == 'v') {
+                    i += 1;
+                    continue;
+                }
+            } else if (c == '&' && i + 1 < len) {
+                char next = Character.toLowerCase(text.charAt(i + 1));
+
+                if (next == '#' && i + 7 < len) {
+                    int rgb = parseHex6(text, i + 2);
+                    if (rgb != -1) {
+                        sb.append(SECTION).append(nearestVanilla(rgb));
+                        i += 7;
+                        continue;
+                    }
+                } else if (next == 'g' && i + 17 < len && text.charAt(i + 2) == '&' && text.charAt(i + 3) == '#') {
+                    int rgb = parseHex6(text, i + 4);
+                    if (rgb != -1) {
+                        sb.append(SECTION).append(nearestVanilla(rgb));
+                        i += 17;
+                        continue;
+                    }
+                } else if (next == 'q' || next == 'z' || next == 'v') {
+                    i += 1;
+                    continue;
+                } else if (isVanillaCode(next)) {
+                    sb.append(SECTION).append(next);
+                    i += 1;
+                    continue;
+                }
+            }
+
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean handlesAmpCodes() {
+        return true;
+    }
+
+    private static char nearestVanilla(int rgb) {
+        int r = (rgb >> 16) & 0xFF;
+        int g = (rgb >> 8) & 0xFF;
+        int b = rgb & 0xFF;
+        int bestIdx = 0;
+        int bestDist = Integer.MAX_VALUE;
+        for (int i = 0; i < VANILLA_COLORS.length; i++) {
+            int vr = (VANILLA_COLORS[i] >> 16) & 0xFF;
+            int vg = (VANILLA_COLORS[i] >> 8) & 0xFF;
+            int vb = VANILLA_COLORS[i] & 0xFF;
+            int dr = r - vr;
+            int dg = g - vg;
+            int db = b - vb;
+            int dist = dr * dr + dg * dg + db * db;
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestIdx = i;
+            }
+        }
+        return VANILLA_CODES[bestIdx];
+    }
+
+    private static int parseSectionX(String str, int start) {
+        if (start + 14 > str.length()) return -1;
+        if (str.charAt(start) != SECTION || Character.toLowerCase(str.charAt(start + 1)) != 'x') return -1;
+        return parseHexPairs(str, start + 2, 6);
+    }
+
+    private static int parseHexPairs(String str, int start, int count) {
+        if (start + count * 2 > str.length()) return -1;
+        int result = 0;
+        for (int k = 0; k < count; k++) {
+            int pos = start + k * 2;
+            if (str.charAt(pos) != SECTION) return -1;
+            int hex = hexValue(str.charAt(pos + 1));
+            if (hex == -1) return -1;
+            result = (result << 4) | hex;
+        }
+        return result;
+    }
+
+    private static int parseHex6(String str, int start) {
+        if (start + 6 > str.length()) return -1;
+        int result = 0;
+        for (int k = 0; k < 6; k++) {
+            int hex = hexValue(str.charAt(start + k));
+            if (hex == -1) return -1;
+            result = (result << 4) | hex;
+        }
+        return result;
+    }
+
+    private static int hexValue(char c) {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    }
+
+    private static boolean isVanillaCode(char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'k' && c <= 'o') || c == 'r';
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/LegacyColorFallback.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/LegacyColorFallback.java
@@ -43,18 +43,18 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
             if (c == SECTION && i + 1 < len) {
                 char next = Character.toLowerCase(text.charAt(i + 1));
 
-                if (next == 'x' && i + 13 < len) {
+                if (next == 'x' && i + ColorFormatUtils.SECTION_X_SEQ_LEN <= len) {
                     int rgb = parseHexPairs(text, i + 2, 6);
                     if (rgb != -1) {
                         sb.append(SECTION).append(nearestVanilla(rgb));
-                        i += 13;
+                        i += ColorFormatUtils.SECTION_X_SEQ_LEN - 1;
                         continue;
                     }
-                } else if (next == 'g' && i + 29 < len) {
+                } else if (next == 'g' && i + ColorFormatUtils.GRADIENT_SEQ_LEN <= len) {
                     int startRgb = parseSectionX(text, i + 2);
                     if (startRgb != -1) {
                         sb.append(SECTION).append(nearestVanilla(startRgb));
-                        i += 29;
+                        i += ColorFormatUtils.GRADIENT_SEQ_LEN - 1;
                         continue;
                     }
                 } else if (next == 'q' || next == 'z' || next == 'v') {
@@ -64,28 +64,31 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
             } else if (c == '&' && i + 1 < len) {
                 char next = Character.toLowerCase(text.charAt(i + 1));
 
-                if (next == '#' && i + 7 < len) {
+                if (next == '#' && i + ColorFormatUtils.AMP_HEX_LEN <= len) {
                     int rgb = parseHex6(text, i + 2);
                     if (rgb != -1) {
                         sb.append(SECTION).append(nearestVanilla(rgb));
-                        i += 7;
+                        i += ColorFormatUtils.AMP_HEX_LEN - 1;
                         continue;
                     }
-                } else if (next == 'g' && i + 17 < len && text.charAt(i + 2) == '&' && text.charAt(i + 3) == '#') {
-                    int rgb = parseHex6(text, i + 4);
-                    if (rgb != -1) {
-                        sb.append(SECTION).append(nearestVanilla(rgb));
-                        i += 17;
+                } else if (next == 'g' && i + ColorFormatUtils.AMP_GRADIENT_LEN <= len
+                        && text.charAt(i + 2) == '&'
+                        && text.charAt(i + 3) == '#') {
+                            int rgb = parseHex6(text, i + 4);
+                            if (rgb != -1) {
+                                sb.append(SECTION).append(nearestVanilla(rgb));
+                                i += ColorFormatUtils.AMP_GRADIENT_LEN - 1;
+                                continue;
+                            }
+                        } else
+                    if (next == 'q' || next == 'z' || next == 'v') {
+                        i += 1;
+                        continue;
+                    } else if (isVanillaCode(next)) {
+                        sb.append(SECTION).append(next);
+                        i += 1;
                         continue;
                     }
-                } else if (next == 'q' || next == 'z' || next == 'v') {
-                    i += 1;
-                    continue;
-                } else if (isVanillaCode(next)) {
-                    sb.append(SECTION).append(next);
-                    i += 1;
-                    continue;
-                }
             }
 
             sb.append(c);
@@ -121,7 +124,7 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
     }
 
     private static int parseSectionX(String str, int start) {
-        if (start + 14 > str.length()) return -1;
+        if (start + ColorFormatUtils.SECTION_X_SEQ_LEN > str.length()) return -1;
         if (str.charAt(start) != SECTION || Character.toLowerCase(str.charAt(start + 1)) != 'x') return -1;
         return parseHexPairs(str, start + 2, 6);
     }

--- a/src/main/java/com/mitchej123/hodgepodge/util/LegacyColorFallback.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/LegacyColorFallback.java
@@ -8,8 +8,6 @@ import com.gtnewhorizon.gtnhlib.util.font.FontRendering;
  */
 public class LegacyColorFallback implements FontRendering.TextPreprocessor {
 
-    private static final char SECTION = '§';
-
     private static final int[] VANILLA_COLORS = { 0x000000, // §0
             0x0000AA, // §1
             0x00AA00, // §2
@@ -40,20 +38,20 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
         for (int i = 0; i < len; i++) {
             char c = text.charAt(i);
 
-            if (c == SECTION && i + 1 < len) {
+            if (c == ColorFormatUtils.SECTION && i + 1 < len) {
                 char next = Character.toLowerCase(text.charAt(i + 1));
 
                 if (next == 'x' && i + ColorFormatUtils.SECTION_X_SEQ_LEN <= len) {
                     int rgb = parseHexPairs(text, i + 2, 6);
                     if (rgb != -1) {
-                        sb.append(SECTION).append(nearestVanilla(rgb));
+                        sb.append(ColorFormatUtils.SECTION).append(nearestVanilla(rgb));
                         i += ColorFormatUtils.SECTION_X_SEQ_LEN - 1;
                         continue;
                     }
                 } else if (next == 'g' && i + ColorFormatUtils.GRADIENT_SEQ_LEN <= len) {
                     int startRgb = parseSectionX(text, i + 2);
                     if (startRgb != -1) {
-                        sb.append(SECTION).append(nearestVanilla(startRgb));
+                        sb.append(ColorFormatUtils.SECTION).append(nearestVanilla(startRgb));
                         i += ColorFormatUtils.GRADIENT_SEQ_LEN - 1;
                         continue;
                     }
@@ -67,7 +65,7 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
                 if (next == '#' && i + ColorFormatUtils.AMP_HEX_LEN <= len) {
                     int rgb = parseHex6(text, i + 2);
                     if (rgb != -1) {
-                        sb.append(SECTION).append(nearestVanilla(rgb));
+                        sb.append(ColorFormatUtils.SECTION).append(nearestVanilla(rgb));
                         i += ColorFormatUtils.AMP_HEX_LEN - 1;
                         continue;
                     }
@@ -76,7 +74,7 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
                         && text.charAt(i + 3) == '#') {
                             int rgb = parseHex6(text, i + 4);
                             if (rgb != -1) {
-                                sb.append(SECTION).append(nearestVanilla(rgb));
+                                sb.append(ColorFormatUtils.SECTION).append(nearestVanilla(rgb));
                                 i += ColorFormatUtils.AMP_GRADIENT_LEN - 1;
                                 continue;
                             }
@@ -85,7 +83,7 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
                         i += 1;
                         continue;
                     } else if (isVanillaCode(next)) {
-                        sb.append(SECTION).append(next);
+                        sb.append(ColorFormatUtils.SECTION).append(next);
                         i += 1;
                         continue;
                     }
@@ -125,7 +123,8 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
 
     private static int parseSectionX(String str, int start) {
         if (start + ColorFormatUtils.SECTION_X_SEQ_LEN > str.length()) return -1;
-        if (str.charAt(start) != SECTION || Character.toLowerCase(str.charAt(start + 1)) != 'x') return -1;
+        if (str.charAt(start) != ColorFormatUtils.SECTION || Character.toLowerCase(str.charAt(start + 1)) != 'x')
+            return -1;
         return parseHexPairs(str, start + 2, 6);
     }
 
@@ -134,7 +133,7 @@ public class LegacyColorFallback implements FontRendering.TextPreprocessor {
         int result = 0;
         for (int k = 0; k < count; k++) {
             int pos = start + k * 2;
-            if (str.charAt(pos) != SECTION) return -1;
+            if (str.charAt(pos) != ColorFormatUtils.SECTION) return -1;
             int hex = hexValue(str.charAt(pos + 1));
             if (hex == -1) return -1;
             result = (result << 4) | hex;

--- a/src/main/java/com/mitchej123/hodgepodge/util/StringUtil.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/StringUtil.java
@@ -12,7 +12,7 @@ public class StringUtil {
         int count = 0;
         for (int i = 0; i < len; i++) {
             final char c = chars[i];
-            if (c == '§' && i + 1 < len && "0123456789abcdefklmnorABCDEFKLMNOR".indexOf(chars[i + 1]) != -1) {
+            if (c == '§' && i + 1 < len && "0123456789abcdefgklmnorqvxzABCDEFGKLMNORQVXZ".indexOf(chars[i + 1]) != -1) {
                 i++;
                 continue;
             }

--- a/src/main/java/com/mitchej123/hodgepodge/util/StringUtil.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/StringUtil.java
@@ -12,7 +12,8 @@ public class StringUtil {
         int count = 0;
         for (int i = 0; i < len; i++) {
             final char c = chars[i];
-            if (c == '§' && i + 1 < len && "0123456789abcdefgklmnorqvxzABCDEFGKLMNORQVXZ".indexOf(chars[i + 1]) != -1) {
+            if (c == ColorFormatUtils.SECTION && i + 1 < len
+                    && "0123456789abcdefgklmnorqvxzABCDEFGKLMNORQVXZ".indexOf(chars[i + 1]) != -1) {
                 i++;
                 continue;
             }

--- a/src/test/java/hodgepodge/StringUtilsTest.java
+++ b/src/test/java/hodgepodge/StringUtilsTest.java
@@ -26,4 +26,25 @@ public class StringUtilsTest {
         }
     }
 
+    @Test
+    void testRemoveExtendedFormattingCodes() {
+        // §x RGB color (14-char sequence decomposes into 7 pairs: §x §F §F §6 §B §4 §A)
+        assertEquals("Coral", StringUtil.removeFormattingCodes("§x§F§F§6§B§4§ACoral"));
+        // §g gradient (30-char sequence: §g + two §x blocks)
+        assertEquals("Fire", StringUtil.removeFormattingCodes("§g§x§F§F§0§0§0§0§x§F§F§D§7§0§0Fire"));
+        // §q rainbow
+        assertEquals("Rainbow", StringUtil.removeFormattingCodes("§qRainbow"));
+        // §z wave
+        assertEquals("Wave", StringUtil.removeFormattingCodes("§zWave"));
+        // §v dinnerbone
+        assertEquals("Flip", StringUtil.removeFormattingCodes("§vFlip"));
+        // Mixed vanilla + extended
+        assertEquals("Hello World!", StringUtil.removeFormattingCodes("§x§F§F§0§0§0§0Hello §qWorld§r!"));
+        // Case-insensitive: uppercase extended codes
+        assertEquals("test", StringUtil.removeFormattingCodes("§Xtest"));
+        assertEquals("test", StringUtil.removeFormattingCodes("§Qtest"));
+        assertEquals("test", StringUtil.removeFormattingCodes("§Ztest"));
+        assertEquals("test", StringUtil.removeFormattingCodes("§Vtest"));
+        assertEquals("test", StringUtil.removeFormattingCodes("§Gtest"));
+    }
 }


### PR DESCRIPTION
- fix position map off-by-one for &#RRGGBB (8 chars, was consuming 7)
- arrow keys skip over & format codes as atomic units
- backspace/delete on format codes removes the entire code
- consolidate format code validation into ColorFormatUtils (i forgot those)