### PR TITLE
Disable mixin for MrTJPCoreMod for version >= 1.1.3

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -400,7 +400,7 @@ public class TweaksConfig {
     // ProjectRed
 
     @Config.Comment("Fix Project Red components popping off on unloaded chunks")
-    @Config.DefaultBoolean(false)
+    @Config.DefaultBoolean(true)
     public static boolean fixComponentsPoppingOff;
 
     @Config.Comment("Fix hotbars being dark when Project Red is installed")

--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -400,7 +400,7 @@ public class TweaksConfig {
     // ProjectRed
 
     @Config.Comment("Fix Project Red components popping off on unloaded chunks")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     public static boolean fixComponentsPoppingOff;
 
     @Config.Comment("Fix hotbars being dark when Project Red is installed")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1389,12 +1389,12 @@ public enum Mixins implements IMixins {
     FIX_HUD_LIGHTING_GLITCH(new MixinBuilder("HUD Lighting glitch")
             .addCommonMixins("mrtjpcore.MixinFXEngine")
             .setApplyIf(() -> TweaksConfig.fixHudLightingGlitch)
-            .addRequiredMod(TargetedMod.MRTJPCORE)
+            .addRequiredMod(TargetedMod.MRTJPCORE_V_BEFORE_113)
             .setPhase(Phase.LATE)),
     FIX_POPPING_OFF(new MixinBuilder()
             .addCommonMixins("mrtjpcore.MixinPlacementLib")
             .setApplyIf(() -> TweaksConfig.fixComponentsPoppingOff)
-            .addRequiredMod(TargetedMod.MRTJPCORE)
+            .addRequiredMod(TargetedMod.MRTJPCORE_V_BEFORE_113)
             .setPhase(Phase.LATE)),
 
     // Automagy

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -64,7 +64,8 @@ public enum TargetedMod implements ITargetMod {
     MODERNKEYBINDING(null, null, "committee.nova.mkb.ModernKeyBinding"),
     MODULARPOWERSUITS("powersuits"),
     MORPHEUS("Morpheus"),
-    MRTJPCORE("MrTJPCoreMod"),
+    MRTJPCORE(new TargetModBuilder().setTargetClass("mrtjp.core.handler.MrTJPCoreMod")
+            .testModVersion("MrTJPCoreMod", version -> isVersionLessThan(version, "1.1.2-pre"))),
     NOTENOUGHITEMS("codechicken.nei.asm.NEICorePlugin", "NotEnoughItems"),
     OPTIFINE("optifine.OptiFineForgeTweaker", "Optifine"),
     PORTAL_GUN("PortalGun"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -64,8 +64,8 @@ public enum TargetedMod implements ITargetMod {
     MODERNKEYBINDING(null, null, "committee.nova.mkb.ModernKeyBinding"),
     MODULARPOWERSUITS("powersuits"),
     MORPHEUS("Morpheus"),
-    MRTJPCORE(new TargetModBuilder().setTargetClass("mrtjp.core.handler.MrTJPCoreMod")
-            .testModVersion("MrTJPCoreMod", version -> isVersionLessThan(version, "1.1.2-pre"))),
+    MRTJPCORE_V_BEFORE_113(new TargetModBuilder().setTargetClass("mrtjp.core.handler.MrTJPCoreMod")
+            .testModVersion("MrTJPCoreMod", version -> isVersionLessThan(version, "1.1.3"))),
     NOTENOUGHITEMS("codechicken.nei.asm.NEICorePlugin", "NotEnoughItems"),
     OPTIFINE("optifine.OptiFineForgeTweaker", "Optifine"),
     PORTAL_GUN("PortalGun"),


### PR DESCRIPTION
The gtnh fork have both mixins applied already to the code and the duplicated mixins crashes the dev environment for projectred. It should probably not do that

See https://github.com/GTNewHorizons/MrTJPCore/compare/1.1.1...1.1.2-pre for the version.
