### PR TITLE
Fix portals not spawning when changing dimension

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -818,12 +818,16 @@ public enum Mixins implements IMixins {
             .addExcludedMod(TargetedMod.BUKKIT)
             .setPhase(Phase.EARLY)),
     ENTITY_CHUNK_LOAD_GUARD(new MixinBuilder("Prevent entity ticks from triggering chunk generation")
-            .addCommonMixins("minecraft.fastload.MixinChunkProviderServer_EntityGuard")
+            .addCommonMixins(
+                    "minecraft.fastload.MixinChunkProviderServer_EntityGuard",
+                    "minecraft.fastload.ServerConfigurationManager_FixTeleporter")
             .setApplyIf(() -> SpeedupsConfig.preventEntityChunkLoading)
             .addExcludedMod(TargetedMod.BUKKIT)
             .setPhase(Phase.EARLY)),
     ENTITY_CHUNK_LOAD_GUARD_BUKKIT(new MixinBuilder("Prevent entity ticks from triggering chunk generation (Bukkit)")
-            .addCommonMixins("minecraft.fastload.MixinChunkProviderServer_EntityGuard_Bukkit")
+            .addCommonMixins(
+                    "minecraft.fastload.MixinChunkProviderServer_EntityGuard_Bukkit",
+                    "minecraft.fastload.ServerConfigurationManager_FixTeleporter")
             .setApplyIf(() -> SpeedupsConfig.preventEntityChunkLoading)
             .addRequiredMod(TargetedMod.BUKKIT)
             .setPhase(Phase.EARLY)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/ServerConfigurationManager_FixTeleporter.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/fastload/ServerConfigurationManager_FixTeleporter.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.fastload;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.management.ServerConfigurationManager;
+import net.minecraft.world.Teleporter;
+import net.minecraft.world.WorldServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+
+@Mixin(value = ServerConfigurationManager.class, remap = false)
+public class ServerConfigurationManager_FixTeleporter {
+
+    @Inject(
+            method = "transferEntityToWorld(Lnet/minecraft/entity/Entity;ILnet/minecraft/world/WorldServer;Lnet/minecraft/world/WorldServer;Lnet/minecraft/world/Teleporter;)V",
+            at = @At("HEAD"))
+    private void setFinding(Entity entityIn, int originDim, WorldServer origin, WorldServer destination,
+            Teleporter teleporter, CallbackInfo ci, @Share("prevFindingSpawnPoint") LocalBooleanRef prev) {
+        prev.set(destination.findingSpawnPoint);
+        destination.findingSpawnPoint = true;
+    }
+
+    @Inject(
+            method = "transferEntityToWorld(Lnet/minecraft/entity/Entity;ILnet/minecraft/world/WorldServer;Lnet/minecraft/world/WorldServer;Lnet/minecraft/world/Teleporter;)V",
+            at = @At("RETURN"))
+    private void tail(Entity entityIn, int originDim, WorldServer origin, WorldServer destination,
+            Teleporter teleporter, CallbackInfo ci, @Share("prevFindingSpawnPoint") LocalBooleanRef prev) {
+        destination.findingSpawnPoint = prev.get();
+    }
+}


### PR DESCRIPTION
Fix : https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23980

I simply set `word#findingSpawnPoint` to true when teleporting an entity to a dimension, this way all the chunkloading goes throught normally.

Tested in full pack on the following dimensions :
- nether
- end
- deep dark
- twilight forest
- thaumcraft eldrich thing
- toxic everglades
- personal dimension
- the last millenium