### PR TITLE
IC2 tin cans now run their food logic on the client as well

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -698,6 +698,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixIc2KeybindsIgnoreKeyState;
 
+    @Config.Comment("Fix IC2 filled tin cans not running logic on both client and server")
+    @Config.DefaultBoolean(true)
+    public static boolean fixIc2TinCan;
+
     // Journey Map
 
     @Config.Comment("Prevents journeymap from using illegal character in file paths")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1101,6 +1101,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixIc2KeybindsIgnoreKeyState)
             .addRequiredMod(TargetedMod.IC2)
             .setPhase(Phase.LATE)),
+    IC2_TIN_CAN(new MixinBuilder("Fix IC2 filled tin cans not running logic on both client and server")
+            .addCommonMixins("ic2.MixinIc2TinCan")
+            .setApplyIf(() -> FixesConfig.fixIc2TinCan)
+            .addRequiredMod(TargetedMod.IC2)
+            .setPhase(Phase.LATE)),
 
     // Disable update checkers
     COFH_CORE_UPDATE_CHECK(new MixinBuilder("Yeet COFH Core Update Check")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIc2TinCan.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/ic2/MixinIc2TinCan.java
@@ -1,0 +1,50 @@
+package com.mitchej123.hodgepodge.mixins.late.ic2;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import ic2.core.IC2;
+import ic2.core.Ic2Items;
+import ic2.core.Platform;
+import ic2.core.item.ItemTinCan;
+import ic2.core.util.StackUtil;
+
+@Mixin(value = ItemTinCan.class)
+public class MixinIc2TinCan {
+
+    @Redirect(
+            method = "onItemRightClick",
+            at = @At(value = "INVOKE", target = "Lic2/core/Platform;isSimulating()Z", remap = false))
+    public boolean hodgepodge$isSimulating(Platform instance) {
+        // Allow onEaten to always run regardless of if we are on the client or the server
+        return true;
+    }
+
+    /**
+     * @author tiffit
+     * @reason Add checks to only run some code on the server
+     */
+    @Overwrite(remap = false)
+    public ItemStack onEaten(EntityPlayer player, ItemStack itemStack) {
+        boolean isServer = IC2.platform.isSimulating();
+        int needFood = 20 - player.getFoodStats().getFoodLevel();
+        if (needFood > 0) {
+            int toConsume = Math.min(needFood, itemStack.stackSize);
+            if (StackUtil.storeInventoryItem(new ItemStack(Ic2Items.tinCan.getItem(), toConsume), player, true)) {
+                player.getFoodStats().addStats(toConsume, (float) toConsume);
+                if (isServer) {
+                    itemStack.stackSize -= toConsume;
+                    StackUtil.storeInventoryItem(new ItemStack(Ic2Items.tinCan.getItem(), toConsume), player, false);
+                    IC2.platform.playSoundSp("Tools/eat.ogg", 1.0F, 1.0F);
+                }
+            }
+        }
+
+        return itemStack;
+    }
+}


### PR DESCRIPTION
Nutrition requires non-typical food items (such as ic2 tin cans) to add food to the client as well. This change makes it behave like the healing axe where the nutrition values won't go over 50%

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18916