### PR TITLE
Optimize wavefront object model loading by 1.2s

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -216,6 +216,11 @@ public class SpeedupsConfig {
     @Config.DefaultBoolean(true)
     public static boolean asyncBatchedNBTParsing;
 
+    @Config.Comment("Reduce regex overhead when loading object models")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean optimizeWavefrontObjectModelLoading;
+
     // Biomes O' Plenty
 
     @Config.Comment("Speedup biome fog rendering in BiomesOPlenty")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -14,7 +14,7 @@ import com.mitchej123.hodgepodge.config.TweaksConfig;
 public enum Mixins implements IMixins {
 
     // spotless:off
-    // Vanilla Fixes
+    // region Vanilla Fixes
     ONLY_LOAD_LANGUAGES_ONCE_PER_FILE(new MixinBuilder()
             .addCommonMixins("minecraft.MixinLanguageRegistry")
             .setApplyIf(() -> FixesConfig.onlyLoadLanguagesOnce)
@@ -999,8 +999,13 @@ public enum Mixins implements IMixins {
             .addCommonMixins("forge.MixinFakePlayer")
             .setApplyIf(() -> FixesConfig.fixFakePlayerChatCrash)
             .setPhase(Phase.EARLY)),
+    OPTIMIZE_WAVEFRONT_OBJECT_MODEL_LOADING(new MixinBuilder("Reduce regex overhead when loading object models")
+            .addClientMixins("forge.MixinWavefrontObject_OptimizeModelLoading")
+            .setApplyIf(() -> SpeedupsConfig.optimizeWavefrontObjectModelLoading)
+            .setPhase(Phase.EARLY)),
+    // endregion
 
-    // Ic2 adjustments
+    // region Ic2 adjustments
     IC2_UNPROTECTED_GET_BLOCK_FIX(new MixinBuilder("IC2 Kinetic Fix")
             .addCommonMixins("ic2.MixinIc2WaterKinetic")
             .setApplyIf(() -> FixesConfig.fixIc2UnprotectedGetBlock)
@@ -1101,6 +1106,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixIc2KeybindsIgnoreKeyState)
             .addRequiredMod(TargetedMod.IC2)
             .setPhase(Phase.LATE)),
+    // endregion
 
     // Disable update checkers
     COFH_CORE_UPDATE_CHECK(new MixinBuilder("Yeet COFH Core Update Check")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinWavefrontObject_OptimizeModelLoading.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinWavefrontObject_OptimizeModelLoading.java
@@ -1,48 +1,266 @@
 package com.mitchej123.hodgepodge.mixins.early.forge;
 
 import net.minecraftforge.client.model.obj.WavefrontObject;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.libraries.com.google.common.base.CharMatcher;
 
-import java.util.regex.Pattern;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.libraries.com.google.common.base.CharMatcher;
 
 @Mixin(value = WavefrontObject.class, remap = false)
 public class MixinWavefrontObject_OptimizeModelLoading {
-
-    @Shadow private static Pattern vertexPattern;
-    @Shadow private static Pattern vertexNormalPattern;
-    @Shadow private static Pattern textureCoordinatePattern;
-    @Shadow private static Pattern face_V_VT_VN_Pattern;
-    @Shadow private static Pattern face_V_VT_Pattern;
-    @Shadow private static Pattern face_V_VN_Pattern;
-    @Shadow private static Pattern face_V_Pattern;
-    @Shadow private static Pattern groupObjectPattern;
-
-    @Inject(method = "<clinit>", at = @At("RETURN"))
-    private static void optimizePatterns(CallbackInfo ci) {
-        vertexPattern = Pattern.compile("v(?: -?\\d++(?:\\.\\d++)?){3,4}");
-        vertexNormalPattern = Pattern.compile("vn(?: -?\\d++(?:\\.\\d++)?){3,4}");
-        textureCoordinatePattern = Pattern.compile("vt(?: -?\\d++(?:\\.\\d++)?){2,3}");
-        face_V_VT_VN_Pattern = Pattern.compile("f(?: \\d++/\\d++/\\d++){3,4}");
-        face_V_VT_Pattern = Pattern.compile("f(?: \\d++/\\d++){3,4}");
-        face_V_VN_Pattern = Pattern.compile("f(?: \\d++//\\d++){3,4}");
-        face_V_Pattern = Pattern.compile("f(?: \\d++){3,4}");
-        groupObjectPattern = Pattern.compile("[go] [\\w.]++");
-    }
 
     @Redirect(
             method = "loadObjModel(Ljava/io/InputStream;)V",
             at = @At(
                     value = "INVOKE",
-                    target = "Ljava/lang/String;replaceAll(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"
-            )
-    )
+                    target = "Ljava/lang/String;replaceAll(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"))
     private String optimizedWhitespaceReplacement(String original, String regex, String replacement) {
         return CharMatcher.whitespace().trimAndCollapseFrom(original, ' ');
     }
+
+    // region regex replacements
+    /**
+     * Regex: Pattern.compile("v(?: -?\\d++(?:\\.\\d++)?){3,4}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidVertexLine(String str) {
+        return hodgepodge$isNumericLine(str, "v ", 3, 4);
+    }
+
+    /**
+     * Regex: Pattern.compile("vn(?: -?\\d++(?:\\.\\d++)?){3,4}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidVertexNormalLine(String str) {
+        return hodgepodge$isNumericLine(str, "vn ", 3, 4);
+    }
+
+    /**
+     * Regex: Pattern.compile("vt(?: -?\\d++(?:\\.\\d++)?){2,3}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidTextureCoordinateLine(String str) {
+        return hodgepodge$isNumericLine(str, "vt ", 2, 3);
+    }
+
+    /**
+     * Regex: Pattern.compile("f(?: \\d++/\\d++/\\d++){3,4}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidFace_V_VT_VN_Line(String str) {
+        if (!str.startsWith("f ")) return false;
+
+        int groupCount = 0;
+        int i = 2;
+
+        while (i < str.length()) {
+            int firstSlash = str.indexOf('/', i);
+            int secondSlash = str.indexOf('/', firstSlash + 1);
+            int space = str.indexOf(' ', i);
+            if (space == -1) space = str.length();
+
+            if (firstSlash == -1 || secondSlash == -1) return false;
+            if (firstSlash <= i || secondSlash <= firstSlash + 1 || secondSlash >= space - 1) return false;
+            if (!hodgepodge$isDigits(str, i, firstSlash) || !hodgepodge$isDigits(str, firstSlash + 1, secondSlash)
+                    || !hodgepodge$isDigits(str, secondSlash + 1, space))
+                return false;
+
+            groupCount++;
+            if (groupCount > 4) return false;
+            i = space + 1;
+        }
+
+        return groupCount >= 3;
+    }
+
+    /**
+     * Regex: Pattern.compile("f(?: \\d++/\\d++){3,4}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidFace_V_VT_Line(String str) {
+        if (!str.startsWith("f ")) return false;
+
+        int groupCount = 0;
+        int i = 2;
+
+        while (i < str.length()) {
+            int slash = str.indexOf('/', i);
+            int space = str.indexOf(' ', i);
+            if (space == -1) space = str.length();
+
+            if (slash <= i || slash >= space - 1) return false;
+            if (!hodgepodge$isDigits(str, i, slash) || !hodgepodge$isDigits(str, slash + 1, space)) return false;
+
+            groupCount++;
+            if (groupCount > 4) return false;
+            i = space + 1;
+        }
+
+        return groupCount >= 3;
+    }
+
+    /**
+     * Regex: Pattern.compile("f(?: \\d++//\\d++){3,4}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidFace_V_VN_Line(String str) {
+        if (!str.startsWith("f ")) return false;
+
+        int groupCount = 0;
+        int i = 2;
+
+        while (i < str.length()) {
+            int slashes = str.indexOf("//", i);
+            int space = str.indexOf(' ', i);
+            if (space == -1) space = str.length();
+
+            if (slashes <= i || slashes >= space - 2) return false;
+            if (!hodgepodge$isDigits(str, i, slashes) || !hodgepodge$isDigits(str, slashes + 2, space)) return false;
+
+            groupCount++;
+            if (groupCount > 4) return false;
+            i = space + 1;
+        }
+
+        return groupCount >= 3;
+    }
+
+    /**
+     * Regex: Pattern.compile("f(?: \\d++){3,4}")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidFace_V_Line(String str) {
+        if (!str.startsWith("f ")) return false;
+
+        int groupCount = 0;
+        int i = 2;
+
+        while (i < str.length()) {
+            int space = str.indexOf(' ', i);
+            if (space == -1) space = str.length();
+
+            if (!hodgepodge$isDigits(str, i, space)) return false;
+
+            groupCount++;
+            if (groupCount > 4) return false;
+            i = space + 1;
+        }
+
+        return groupCount >= 3;
+    }
+
+    /**
+     * Regex: Pattern.compile("[go] [\\w.]++")
+     * 
+     * @author danyadev
+     * @reason superior implementation
+     */
+    @Overwrite
+    private static boolean isValidGroupObjectLine(String str) {
+        if (str.length() < 3) return false;
+        if (str.charAt(0) != 'g' && str.charAt(0) != 'o') return false;
+        if (str.charAt(1) != ' ') return false;
+
+        for (int i = 2; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '.') {
+                continue;
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    @Unique
+    private static boolean hodgepodge$isDigits(String str, int from, int to) {
+        if (from >= to) return false;
+
+        for (int i = from; i < to; i++) {
+            char c = str.charAt(i);
+            if (c < '0' || c > '9') return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the end index of the number or -1 if it's not a valid number
+     */
+    @Unique
+    private static int hodgepodge$scanNumber(String str, int from) {
+        if (from >= str.length()) return -1;
+        if (str.charAt(from) == '-') from++;
+        if (from >= str.length()) return -1;
+
+        int intStart = from;
+        while (from < str.length()) {
+            char c = str.charAt(from);
+            if (c < '0' || c > '9') break;
+            from++;
+        }
+        if (from == intStart) return -1;
+
+        if (from < str.length() && str.charAt(from) == '.') {
+            from++;
+            int fracStart = from;
+            while (from < str.length()) {
+                char c = str.charAt(from);
+                if (c < '0' || c > '9') break;
+                from++;
+            }
+            if (from == fracStart) return -1;
+        }
+
+        return from;
+    }
+
+    // For example, prefix = "v ", minGroups = 3, maxGroups = 4.
+    // This is the correct line: "v 1 -3 1.25"
+    @Unique
+    private static boolean hodgepodge$isNumericLine(String str, String prefix, int minGroups, int maxGroups) {
+        if (!str.startsWith(prefix)) return false;
+
+        int groupCount = 0;
+        int i = prefix.length();
+
+        while (i < str.length()) {
+            int next = str.indexOf(' ', i);
+            if (next == -1) next = str.length();
+
+            int end = hodgepodge$scanNumber(str, i);
+            if (end != next) return false;
+
+            groupCount++;
+            if (groupCount > maxGroups) return false;
+            i = next + 1;
+        }
+
+        return groupCount >= minGroups;
+    }
+    // endregion
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinWavefrontObject_OptimizeModelLoading.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinWavefrontObject_OptimizeModelLoading.java
@@ -7,7 +7,6 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.libraries.com.google.common.base.CharMatcher;
 
 @Mixin(value = WavefrontObject.class, remap = false)
 public class MixinWavefrontObject_OptimizeModelLoading {
@@ -17,11 +16,32 @@ public class MixinWavefrontObject_OptimizeModelLoading {
             at = @At(
                     value = "INVOKE",
                     target = "Ljava/lang/String;replaceAll(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"))
-    private String optimizedWhitespaceReplacement(String original, String regex, String replacement) {
-        return CharMatcher.whitespace().trimAndCollapseFrom(original, ' ');
+    private String optimizedCollapseWhitespace(String string, String regex, String replacement) {
+        final int length = string.length();
+        final StringBuilder normalized = new StringBuilder(length);
+        boolean pendingSpace = false;
+        boolean changed = false;
+
+        for (int i = 0; i < length; i++) {
+            final char c = string.charAt(i);
+
+            if (c == ' ' || c == '\t' || c == '\r') {
+                changed |= pendingSpace || c != ' ';
+                pendingSpace = true;
+                continue;
+            }
+
+            if (pendingSpace) {
+                normalized.append(' ');
+                pendingSpace = false;
+            }
+
+            normalized.append(c);
+        }
+
+        return changed ? normalized.toString() : string;
     }
 
-    // region regex replacements
     /**
      * Regex: Pattern.compile("v(?: -?\\d++(?:\\.\\d++)?){3,4}")
      * 
@@ -65,14 +85,15 @@ public class MixinWavefrontObject_OptimizeModelLoading {
     private static boolean isValidFace_V_VT_VN_Line(String str) {
         if (!str.startsWith("f ")) return false;
 
+        int length = str.length();
         int groupCount = 0;
         int i = 2;
 
-        while (i < str.length()) {
+        while (i < length) {
             int firstSlash = str.indexOf('/', i);
             int secondSlash = str.indexOf('/', firstSlash + 1);
             int space = str.indexOf(' ', i);
-            if (space == -1) space = str.length();
+            if (space == -1) space = length;
 
             if (firstSlash == -1 || secondSlash == -1) return false;
             if (firstSlash <= i || secondSlash <= firstSlash + 1 || secondSlash >= space - 1) return false;
@@ -98,13 +119,14 @@ public class MixinWavefrontObject_OptimizeModelLoading {
     private static boolean isValidFace_V_VT_Line(String str) {
         if (!str.startsWith("f ")) return false;
 
+        int length = str.length();
         int groupCount = 0;
         int i = 2;
 
-        while (i < str.length()) {
+        while (i < length) {
             int slash = str.indexOf('/', i);
             int space = str.indexOf(' ', i);
-            if (space == -1) space = str.length();
+            if (space == -1) space = length;
 
             if (slash <= i || slash >= space - 1) return false;
             if (!hodgepodge$isDigits(str, i, slash) || !hodgepodge$isDigits(str, slash + 1, space)) return false;
@@ -127,13 +149,14 @@ public class MixinWavefrontObject_OptimizeModelLoading {
     private static boolean isValidFace_V_VN_Line(String str) {
         if (!str.startsWith("f ")) return false;
 
+        int length = str.length();
         int groupCount = 0;
         int i = 2;
 
-        while (i < str.length()) {
+        while (i < length) {
             int slashes = str.indexOf("//", i);
             int space = str.indexOf(' ', i);
-            if (space == -1) space = str.length();
+            if (space == -1) space = length;
 
             if (slashes <= i || slashes >= space - 2) return false;
             if (!hodgepodge$isDigits(str, i, slashes) || !hodgepodge$isDigits(str, slashes + 2, space)) return false;
@@ -156,12 +179,13 @@ public class MixinWavefrontObject_OptimizeModelLoading {
     private static boolean isValidFace_V_Line(String str) {
         if (!str.startsWith("f ")) return false;
 
+        int length = str.length();
         int groupCount = 0;
         int i = 2;
 
-        while (i < str.length()) {
+        while (i < length) {
             int space = str.indexOf(' ', i);
-            if (space == -1) space = str.length();
+            if (space == -1) space = length;
 
             if (!hodgepodge$isDigits(str, i, space)) return false;
 
@@ -181,11 +205,13 @@ public class MixinWavefrontObject_OptimizeModelLoading {
      */
     @Overwrite
     private static boolean isValidGroupObjectLine(String str) {
-        if (str.length() < 3) return false;
+        int length = str.length();
+
+        if (length < 3) return false;
         if (str.charAt(0) != 'g' && str.charAt(0) != 'o') return false;
         if (str.charAt(1) != ' ') return false;
 
-        for (int i = 2; i < str.length(); i++) {
+        for (int i = 2; i < length; i++) {
             char c = str.charAt(i);
             if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '.') {
                 continue;
@@ -213,22 +239,24 @@ public class MixinWavefrontObject_OptimizeModelLoading {
      */
     @Unique
     private static int hodgepodge$scanNumber(String str, int from) {
-        if (from >= str.length()) return -1;
+        int length = str.length();
+
+        if (from >= length) return -1;
         if (str.charAt(from) == '-') from++;
-        if (from >= str.length()) return -1;
+        if (from >= length) return -1;
 
         int intStart = from;
-        while (from < str.length()) {
+        while (from < length) {
             char c = str.charAt(from);
             if (c < '0' || c > '9') break;
             from++;
         }
         if (from == intStart) return -1;
 
-        if (from < str.length() && str.charAt(from) == '.') {
+        if (from < length && str.charAt(from) == '.') {
             from++;
             int fracStart = from;
-            while (from < str.length()) {
+            while (from < length) {
                 char c = str.charAt(from);
                 if (c < '0' || c > '9') break;
                 from++;
@@ -245,12 +273,13 @@ public class MixinWavefrontObject_OptimizeModelLoading {
     private static boolean hodgepodge$isNumericLine(String str, String prefix, int minGroups, int maxGroups) {
         if (!str.startsWith(prefix)) return false;
 
-        int groupCount = 0;
+        int length = str.length();
         int i = prefix.length();
+        int groupCount = 0;
 
-        while (i < str.length()) {
+        while (i < length) {
             int next = str.indexOf(' ', i);
-            if (next == -1) next = str.length();
+            if (next == -1) next = length;
 
             int end = hodgepodge$scanNumber(str, i);
             if (end != next) return false;
@@ -262,5 +291,4 @@ public class MixinWavefrontObject_OptimizeModelLoading {
 
         return groupCount >= minGroups;
     }
-    // endregion
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinWavefrontObject_OptimizeModelLoading.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinWavefrontObject_OptimizeModelLoading.java
@@ -1,0 +1,48 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraftforge.client.model.obj.WavefrontObject;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.libraries.com.google.common.base.CharMatcher;
+
+import java.util.regex.Pattern;
+
+@Mixin(value = WavefrontObject.class, remap = false)
+public class MixinWavefrontObject_OptimizeModelLoading {
+
+    @Shadow private static Pattern vertexPattern;
+    @Shadow private static Pattern vertexNormalPattern;
+    @Shadow private static Pattern textureCoordinatePattern;
+    @Shadow private static Pattern face_V_VT_VN_Pattern;
+    @Shadow private static Pattern face_V_VT_Pattern;
+    @Shadow private static Pattern face_V_VN_Pattern;
+    @Shadow private static Pattern face_V_Pattern;
+    @Shadow private static Pattern groupObjectPattern;
+
+    @Inject(method = "<clinit>", at = @At("RETURN"))
+    private static void optimizePatterns(CallbackInfo ci) {
+        vertexPattern = Pattern.compile("v(?: -?\\d++(?:\\.\\d++)?){3,4}");
+        vertexNormalPattern = Pattern.compile("vn(?: -?\\d++(?:\\.\\d++)?){3,4}");
+        textureCoordinatePattern = Pattern.compile("vt(?: -?\\d++(?:\\.\\d++)?){2,3}");
+        face_V_VT_VN_Pattern = Pattern.compile("f(?: \\d++/\\d++/\\d++){3,4}");
+        face_V_VT_Pattern = Pattern.compile("f(?: \\d++/\\d++){3,4}");
+        face_V_VN_Pattern = Pattern.compile("f(?: \\d++//\\d++){3,4}");
+        face_V_Pattern = Pattern.compile("f(?: \\d++){3,4}");
+        groupObjectPattern = Pattern.compile("[go] [\\w.]++");
+    }
+
+    @Redirect(
+            method = "loadObjModel(Ljava/io/InputStream;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/lang/String;replaceAll(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"
+            )
+    )
+    private String optimizedWhitespaceReplacement(String original, String regex, String replacement) {
+        return CharMatcher.whitespace().trimAndCollapseFrom(original, ' ');
+    }
+}


### PR DESCRIPTION
Some slow regexps made everything 3x slower again... I started with optimizing regexps, because they were awful, and it gave some performance boost already. And then since they turned out to be simple I've decided to rewrite them into plain text parsers

| Before | After |
|:-:|:-:|
| 3.62% / 1868ms | 1.2% / 633ms |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/28197d05-d2bd-4b48-8999-c86d9dc1f689" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0bbfbdb7-391a-4e82-9909-44b9572f03f5" /> |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/accbefac-b9e0-4859-aeab-ac064868f43e" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1521b81b-ec82-4ce7-9422-e8898142ac96" /> |

Most affected mods: BiblioCraft, Galacticraft, Draconic Evolution, Witching Gadgets, AE2FC, Automagy