### PR TITLE
[Memory-opti:static allocations:31 MB] Caches the advanced Model renderers to speedup loading and avoid wasting memory with duplicate models

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -108,5 +108,10 @@ public class MemoryConfig {
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart
         public boolean fixWitcheryEnumValuesSpam;
+
+        @Config.Comment("Caches the advanced Model renderers to speedup loading and avoid wasting memory with duplicate models")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean cacheAdvancedModels;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1003,6 +1003,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("forge.MixinWavefrontObject_OptimizeModelLoading")
             .setApplyIf(() -> SpeedupsConfig.optimizeWavefrontObjectModelLoading)
             .setPhase(Phase.EARLY)),
+    CACHE_ADVANCED_MODEL_LOADER(new MixinBuilder()
+            .addClientMixins("forge.MixinAdvancedModelLoader_CacheModels")
+            .setApplyIf(() -> MemoryConfig.allocs.cacheAdvancedModels)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinAdvancedModelLoader_CacheModels.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinAdvancedModelLoader_CacheModels.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.AdvancedModelLoader;
+import net.minecraftforge.client.model.IModelCustom;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+
+@Mixin(value = AdvancedModelLoader.class, remap = false)
+public class MixinAdvancedModelLoader_CacheModels {
+
+    @Unique
+    private static final Map<ResourceLocation, WeakReference<IModelCustom>> hp$ModelCache = new ConcurrentHashMap<>();
+
+    @Inject(method = "loadModel", at = @At("HEAD"), cancellable = true)
+    private static void returnCachedModel(ResourceLocation resource, CallbackInfoReturnable<IModelCustom> cir) {
+        final WeakReference<IModelCustom> cachedRef = hp$ModelCache.get(resource);
+        if (cachedRef != null) {
+            final IModelCustom cachedModel = cachedRef.get();
+            if (cachedModel != null) {
+                cir.setReturnValue(cachedModel);
+            }
+        }
+    }
+
+    @ModifyReturnValue(method = "loadModel", at = @At("RETURN"))
+    private static IModelCustom cacheModel(IModelCustom original, ResourceLocation resource) {
+        hp$ModelCache.put(resource, new WeakReference<>(original));
+        return original;
+    }
+}


### PR DESCRIPTION
Saves 31MO of RAM in the full pack and speedups pack loading

Before:
<img width="777" height="55" alt="image" src="https://github.com/user-attachments/assets/ccd0e40e-964f-4514-b2a9-241c4cc1d127" />

After:
<img width="777" height="56" alt="image" src="https://github.com/user-attachments/assets/d56c9805-74bf-4686-b98e-18056029ba9f" />
