### PR TITLE
[Memory-opti:fix leak] Fix 16 world client leaks in bibliocraft's TESR

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -105,6 +105,11 @@ public class MemoryConfig {
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart
         public boolean fixWorldMapStorageLeak;
+
+        @Config.Comment("Fix memory leaks in bibliocraft's tile entity renderers")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixBibliocraftTESRWorldLeak;
     }
 
     public static class AllocationFixes {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1755,6 +1755,26 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.noPauseGuiClipboard)
             .addRequiredMod(TargetedMod.BIBLIOCRAFT)
             .setPhase(Phase.LATE)),
+    BIBLIOCRAFT_FIX_TESR_WORLD_LEAK(new MixinBuilder()
+            .addClientMixins(
+                    "bibliocraft.leaks.MixinTileEntityArmorStandRenderer",
+                    "bibliocraft.leaks.MixinTileEntityClipboardRenderer",
+                    "bibliocraft.leaks.MixinTileEntityClockRenderer",
+                    "bibliocraft.leaks.MixinTileEntityFancySignRenderer",
+                    "bibliocraft.leaks.MixinTileEntityFancyWorkbenchRenderer",
+                    "bibliocraft.leaks.MixinTileEntityFurniturePanelerRenderer",
+                    "bibliocraft.leaks.MixinTileEntityLampRenderer",
+                    "bibliocraft.leaks.MixinTileEntityLanternRenderer",
+                    "bibliocraft.leaks.MixinTileEntityPaintingRenderer",
+                    "bibliocraft.leaks.MixinTileEntityPaintPressRenderer",
+                    "bibliocraft.leaks.MixinTileEntityPotionShelfRenderer",
+                    "bibliocraft.leaks.MixinTileEntityPrintPressRenderer",
+                    "bibliocraft.leaks.MixinTileEntitySwordPedestalRenderer",
+                    "bibliocraft.leaks.MixinTileEntityTableRenderer",
+                    "bibliocraft.leaks.MixinTileEntityTypeSetRenderer",
+                    "bibliocraft.leaks.MixinTileEntityTypewriterRenderer")
+            .setApplyIf(() -> MemoryConfig.leaks.fixBibliocraftTESRWorldLeak)
+            .setPhase(Phase.LATE)),
     ZTONES_PACKET_FIX(new MixinBuilder("Packet Fix")
             .addCommonMixins("ztones.MixinZtonesPatchPacketExploits")
             .setApplyIf(() -> FixesConfig.fixZTonesPackets)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityArmorStandRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityArmorStandRenderer.java
@@ -1,0 +1,20 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityArmorStandRenderer;
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(TileEntityArmorStandRenderer.class)
+public abstract class MixinTileEntityArmorStandRenderer extends TileEntitySpecialRenderer {
+
+    @Shadow(remap = false)
+    private AbstractClientPlayer steve;
+
+    @Override
+    public void func_147496_a(World world) {
+        this.steve = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityArmorStandRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityArmorStandRenderer.java
@@ -1,11 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityArmorStandRenderer;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+
+import jds.bibliocraft.rendering.TileEntityArmorStandRenderer;
 
 @Mixin(TileEntityArmorStandRenderer.class)
 public abstract class MixinTileEntityArmorStandRenderer extends TileEntitySpecialRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClipboardRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClipboardRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityClipboardRenderer;
+import jds.bibliocraft.tileentities.TileEntityClipboard;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityClipboardRenderer.class)
+public class MixinTileEntityClipboardRenderer {
+
+    @Shadow
+    private TileEntityClipboard tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClipboardRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClipboardRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityClipboardRenderer;
-import jds.bibliocraft.tileentities.TileEntityClipboard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityClipboardRenderer;
+import jds.bibliocraft.tileentities.TileEntityClipboard;
 
 @Mixin(TileEntityClipboardRenderer.class)
 public class MixinTileEntityClipboardRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClockRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClockRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityClockRenderer;
+import jds.bibliocraft.tileentities.TileEntityClock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityClockRenderer.class)
+public class MixinTileEntityClockRenderer {
+
+    @Shadow
+    private TileEntityClock tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClockRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityClockRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityClockRenderer;
-import jds.bibliocraft.tileentities.TileEntityClock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityClockRenderer;
+import jds.bibliocraft.tileentities.TileEntityClock;
 
 @Mixin(TileEntityClockRenderer.class)
 public class MixinTileEntityClockRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancySignRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancySignRenderer.java
@@ -1,0 +1,20 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityFancySignRenderer;
+import jds.bibliocraft.tileentities.TileEntityFancySign;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityFancySignRenderer.class)
+public class MixinTileEntityFancySignRenderer {
+
+    @Shadow private TileEntityFancySign tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancySignRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancySignRenderer.java
@@ -1,17 +1,19 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityFancySignRenderer;
-import jds.bibliocraft.tileentities.TileEntityFancySign;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import jds.bibliocraft.rendering.TileEntityFancySignRenderer;
+import jds.bibliocraft.tileentities.TileEntityFancySign;
+
 @Mixin(TileEntityFancySignRenderer.class)
 public class MixinTileEntityFancySignRenderer {
 
-    @Shadow private TileEntityFancySign tile;
+    @Shadow
+    private TileEntityFancySign tile;
 
     @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
     private void clearRef(CallbackInfo ci) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancyWorkbenchRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancyWorkbenchRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityFancyWorkbenchRenderer;
+import jds.bibliocraft.tileentities.TileEntityFancyWorkbench;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityFancyWorkbenchRenderer.class)
+public class MixinTileEntityFancyWorkbenchRenderer {
+
+    @Shadow
+    private TileEntityFancyWorkbench tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancyWorkbenchRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFancyWorkbenchRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityFancyWorkbenchRenderer;
-import jds.bibliocraft.tileentities.TileEntityFancyWorkbench;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityFancyWorkbenchRenderer;
+import jds.bibliocraft.tileentities.TileEntityFancyWorkbench;
 
 @Mixin(TileEntityFancyWorkbenchRenderer.class)
 public class MixinTileEntityFancyWorkbenchRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFurniturePanelerRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFurniturePanelerRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityFurniturePanelerRenderer;
+import jds.bibliocraft.tileentities.TileEntityFurniturePaneler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityFurniturePanelerRenderer.class)
+public class MixinTileEntityFurniturePanelerRenderer {
+
+    @Shadow
+    private TileEntityFurniturePaneler tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFurniturePanelerRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityFurniturePanelerRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityFurniturePanelerRenderer;
-import jds.bibliocraft.tileentities.TileEntityFurniturePaneler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityFurniturePanelerRenderer;
+import jds.bibliocraft.tileentities.TileEntityFurniturePaneler;
 
 @Mixin(TileEntityFurniturePanelerRenderer.class)
 public class MixinTileEntityFurniturePanelerRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLampRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLampRenderer.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+
+import jds.bibliocraft.rendering.TileEntityLampRenderer;
+import jds.bibliocraft.tileentities.TileEntityLamp;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityLampRenderer.class)
+public class MixinTileEntityLampRenderer {
+
+    @Shadow
+    private TileEntityLamp lampTile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.lampTile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLampRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLampRenderer.java
@@ -1,13 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-
-import jds.bibliocraft.rendering.TileEntityLampRenderer;
-import jds.bibliocraft.tileentities.TileEntityLamp;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityLampRenderer;
+import jds.bibliocraft.tileentities.TileEntityLamp;
 
 @Mixin(TileEntityLampRenderer.class)
 public class MixinTileEntityLampRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLanternRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLanternRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityLanternRenderer;
-import jds.bibliocraft.tileentities.TileEntityLantern;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityLanternRenderer;
+import jds.bibliocraft.tileentities.TileEntityLantern;
 
 @Mixin(TileEntityLanternRenderer.class)
 public class MixinTileEntityLanternRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLanternRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityLanternRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityLanternRenderer;
+import jds.bibliocraft.tileentities.TileEntityLantern;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityLanternRenderer.class)
+public class MixinTileEntityLanternRenderer {
+
+    @Shadow
+    private TileEntityLantern lanternTile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.lanternTile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintPressRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintPressRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityPaintPressRenderer;
-import jds.bibliocraft.tileentities.TileEntityPaintPress;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityPaintPressRenderer;
+import jds.bibliocraft.tileentities.TileEntityPaintPress;
 
 @Mixin(TileEntityPaintPressRenderer.class)
 public class MixinTileEntityPaintPressRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintPressRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintPressRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityPaintPressRenderer;
+import jds.bibliocraft.tileentities.TileEntityPaintPress;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityPaintPressRenderer.class)
+public class MixinTileEntityPaintPressRenderer {
+
+    @Shadow
+    private TileEntityPaintPress tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintingRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintingRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityPaintingRenderer;
-import jds.bibliocraft.tileentities.TileEntityPainting;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityPaintingRenderer;
+import jds.bibliocraft.tileentities.TileEntityPainting;
 
 @Mixin(TileEntityPaintingRenderer.class)
 public class MixinTileEntityPaintingRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintingRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPaintingRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityPaintingRenderer;
+import jds.bibliocraft.tileentities.TileEntityPainting;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityPaintingRenderer.class)
+public class MixinTileEntityPaintingRenderer {
+
+    @Shadow
+    private TileEntityPainting tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPotionShelfRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPotionShelfRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityPotionShelfRenderer;
+import jds.bibliocraft.tileentities.TileEntityPotionShelf;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityPotionShelfRenderer.class)
+public class MixinTileEntityPotionShelfRenderer {
+
+    @Shadow
+    TileEntityPotionShelf tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPotionShelfRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPotionShelfRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityPotionShelfRenderer;
-import jds.bibliocraft.tileentities.TileEntityPotionShelf;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityPotionShelfRenderer;
+import jds.bibliocraft.tileentities.TileEntityPotionShelf;
 
 @Mixin(TileEntityPotionShelfRenderer.class)
 public class MixinTileEntityPotionShelfRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPrintPressRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPrintPressRenderer.java
@@ -1,12 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-import jds.bibliocraft.rendering.TileEntityPrintPressRenderer;
-import jds.bibliocraft.tileentities.TileEntityPrintPress;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityPrintPressRenderer;
+import jds.bibliocraft.tileentities.TileEntityPrintPress;
 
 @Mixin(TileEntityPrintPressRenderer.class)
 public class MixinTileEntityPrintPressRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPrintPressRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityPrintPressRenderer.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+import jds.bibliocraft.rendering.TileEntityPrintPressRenderer;
+import jds.bibliocraft.tileentities.TileEntityPrintPress;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityPrintPressRenderer.class)
+public class MixinTileEntityPrintPressRenderer {
+
+    @Shadow
+    private TileEntityPrintPress printTile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.printTile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntitySwordPedestalRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntitySwordPedestalRenderer.java
@@ -1,13 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-
-import jds.bibliocraft.rendering.TileEntitySwordPedestalRenderer;
-import jds.bibliocraft.tileentities.TileEntitySwordPedestal;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntitySwordPedestalRenderer;
+import jds.bibliocraft.tileentities.TileEntitySwordPedestal;
 
 @Mixin(TileEntitySwordPedestalRenderer.class)
 public class MixinTileEntitySwordPedestalRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntitySwordPedestalRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntitySwordPedestalRenderer.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+
+import jds.bibliocraft.rendering.TileEntitySwordPedestalRenderer;
+import jds.bibliocraft.tileentities.TileEntitySwordPedestal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntitySwordPedestalRenderer.class)
+public class MixinTileEntitySwordPedestalRenderer {
+
+    @Shadow
+    private TileEntitySwordPedestal tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTableRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTableRenderer.java
@@ -1,13 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-
-import jds.bibliocraft.rendering.TileEntityTableRenderer;
-import jds.bibliocraft.tileentities.TileEntityTable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityTableRenderer;
+import jds.bibliocraft.tileentities.TileEntityTable;
 
 @Mixin(TileEntityTableRenderer.class)
 public class MixinTileEntityTableRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTableRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTableRenderer.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+
+import jds.bibliocraft.rendering.TileEntityTableRenderer;
+import jds.bibliocraft.tileentities.TileEntityTable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityTableRenderer.class)
+public class MixinTileEntityTableRenderer {
+
+    @Shadow
+    private TileEntityTable tableTile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tableTile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypeSetRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypeSetRenderer.java
@@ -1,13 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-
-import jds.bibliocraft.rendering.TileEntityTypeSetRenderer;
-import jds.bibliocraft.tileentities.TileEntityTypeMachine;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityTypeSetRenderer;
+import jds.bibliocraft.tileentities.TileEntityTypeMachine;
 
 @Mixin(TileEntityTypeSetRenderer.class)
 public class MixinTileEntityTypeSetRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypeSetRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypeSetRenderer.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+
+import jds.bibliocraft.rendering.TileEntityTypeSetRenderer;
+import jds.bibliocraft.tileentities.TileEntityTypeMachine;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityTypeSetRenderer.class)
+public class MixinTileEntityTypeSetRenderer {
+
+    @Shadow
+    private TileEntityTypeMachine typeTile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.typeTile = null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypewriterRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypewriterRenderer.java
@@ -1,13 +1,13 @@
 package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
 
-
-import jds.bibliocraft.rendering.TileEntityTypewriterRenderer;
-import jds.bibliocraft.tileentities.TileEntityTypewriter;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.rendering.TileEntityTypewriterRenderer;
+import jds.bibliocraft.tileentities.TileEntityTypewriter;
 
 @Mixin(TileEntityTypewriterRenderer.class)
 public class MixinTileEntityTypewriterRenderer {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypewriterRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/leaks/MixinTileEntityTypewriterRenderer.java
@@ -1,0 +1,22 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft.leaks;
+
+
+import jds.bibliocraft.rendering.TileEntityTypewriterRenderer;
+import jds.bibliocraft.tileentities.TileEntityTypewriter;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityTypewriterRenderer.class)
+public class MixinTileEntityTypewriterRenderer {
+
+    @Shadow
+    private TileEntityTypewriter tile;
+
+    @Inject(method = "renderTileEntityAt", at = @At("RETURN"))
+    private void clearRef(CallbackInfo ci) {
+        this.tile = null;
+    }
+}


### PR DESCRIPTION
They all keep a reference to a tile which could be a local variable and so it leaks...
I made 15 mixins that just set the field to null at the end of the render method. Except for the armor stand renderer where I set the field to null when switching dimension.