### PR TITLE
Fix resetRainAndThunder setting weather timers to zero

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -455,6 +455,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixFakePlayerChatCrash;
 
+    @Config.Comment("Fix resetRainAndThunder (called when sleeping) setting rain and thunder timers to 0, which can cause immediate rain on world load if saved at that moment")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixResetRainAndThunder;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -459,6 +459,7 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean fixResetRainAndThunder;
+
     @Config.Comment("Make a deep copy when sending objects from the data watcher to the client in SinglePlayer")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -331,7 +331,7 @@ public enum Mixins implements IMixins {
     CONFIGURABLE_PORTAL_RATIO(new MixinBuilder("Make Nether portal travel ratio configurable")
             .addCommonMixins("minecraft.MixinWorldProviderHell")
             .setPhase(Phase.EARLY)),
-    FIX_RESET_RAIN_AND_THUNDER(new MixinBuilder("Fix resetRainAndThunder setting timers to 0 instead of a proper random value")
+    FIX_RESET_RAIN_AND_THUNDER(new MixinBuilder()
             .addCommonMixins("minecraft.MixinWorldProvider_FixResetRainAndThunder")
             .setApplyIf(() -> FixesConfig.fixResetRainAndThunder)
             .setPhase(Phase.EARLY)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -327,6 +327,10 @@ public enum Mixins implements IMixins {
     CONFIGURABLE_PORTAL_RATIO(new MixinBuilder("Make Nether portal travel ratio configurable")
             .addCommonMixins("minecraft.MixinWorldProviderHell")
             .setPhase(Phase.EARLY)),
+    FIX_RESET_RAIN_AND_THUNDER(new MixinBuilder("Fix resetRainAndThunder setting timers to 0 instead of a proper random value")
+            .addCommonMixins("minecraft.MixinWorldProvider_FixResetRainAndThunder")
+            .setApplyIf(() -> FixesConfig.fixResetRainAndThunder)
+            .setPhase(Phase.EARLY)),
     FIX_EATING_STACKED_STEW(new MixinBuilder("Stacked Mushroom Stew Eating Fix")
             .addCommonMixins("minecraft.MixinItemSoup")
             .setApplyIf(() -> FixesConfig.fixEatingStackedStew)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldProvider_FixResetRainAndThunder.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldProvider_FixResetRainAndThunder.java
@@ -16,17 +16,15 @@ public class MixinWorldProvider_FixResetRainAndThunder {
 
     @ModifyArg(
             method = "resetRainAndThunder",
-            remap = false,
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;func_76080_a(I)V"))
-    private int hodgepodge$fixRainTime(int original) {
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;setRainTime(I)V"))
+    private int fixRainTime(int original) {
         return worldObj.rand.nextInt(168000) + 12000;
     }
 
     @ModifyArg(
             method = "resetRainAndThunder",
-            remap = false,
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;func_76090_a(I)V"))
-    private int hodgepodge$fixThunderTime(int original) {
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;setThunderTime(I)V"))
+    private int fixThunderTime(int original) {
         return worldObj.rand.nextInt(168000) + 12000;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldProvider_FixResetRainAndThunder.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldProvider_FixResetRainAndThunder.java
@@ -6,8 +6,7 @@ import net.minecraft.world.WorldProvider;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(WorldProvider.class)
 public class MixinWorldProvider_FixResetRainAndThunder {
@@ -15,12 +14,19 @@ public class MixinWorldProvider_FixResetRainAndThunder {
     @Shadow
     public World worldObj;
 
-    @Inject(method = "resetRainAndThunder", at = @At("HEAD"), cancellable = true, remap = false)
-    private void hodgepodge$fixResetRainAndThunder(CallbackInfo ci) {
-        worldObj.getWorldInfo().setRainTime(worldObj.rand.nextInt(168000) + 12000);
-        worldObj.getWorldInfo().setRaining(false);
-        worldObj.getWorldInfo().setThunderTime(worldObj.rand.nextInt(168000) + 12000);
-        worldObj.getWorldInfo().setThundering(false);
-        ci.cancel();
+    @ModifyArg(
+            method = "resetRainAndThunder",
+            remap = false,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;func_76080_a(I)V"))
+    private int hodgepodge$fixRainTime(int original) {
+        return worldObj.rand.nextInt(168000) + 12000;
+    }
+
+    @ModifyArg(
+            method = "resetRainAndThunder",
+            remap = false,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/storage/WorldInfo;func_76090_a(I)V"))
+    private int hodgepodge$fixThunderTime(int original) {
+        return worldObj.rand.nextInt(168000) + 12000;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldProvider_FixResetRainAndThunder.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinWorldProvider_FixResetRainAndThunder.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.world.World;
+import net.minecraft.world.WorldProvider;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WorldProvider.class)
+public class MixinWorldProvider_FixResetRainAndThunder {
+
+    @Shadow
+    public World worldObj;
+
+    @Inject(method = "resetRainAndThunder", at = @At("HEAD"), cancellable = true, remap = false)
+    private void hodgepodge$fixResetRainAndThunder(CallbackInfo ci) {
+        worldObj.getWorldInfo().setRainTime(worldObj.rand.nextInt(168000) + 12000);
+        worldObj.getWorldInfo().setRaining(false);
+        worldObj.getWorldInfo().setThunderTime(worldObj.rand.nextInt(168000) + 12000);
+        worldObj.getWorldInfo().setThundering(false);
+        ci.cancel();
+    }
+}


### PR DESCRIPTION
When all players sleep, WorldProvider.resetRainAndThunder() is called, which sets rainTime = 0 and thunderTime = 0. If the world is saved at that exact tick, the next load starts with both timers at zero, causing weather to toggle immediately.

Fix by initializing both timers to a proper random value (rand.nextInt(168000) + 12000) at the moment of reset, matching what updateWeatherBody() would set on the very next tick anyway.

Storm-skipping via sleeping is unaffected — isRaining and isThundering are still set to false.