### PR TITLE
[Memory-opti:fix leak] fix world leak in TeleporterThaumcraft caused by LongHashMap transformer

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/core/fml/transformers/mc/SpeedupLongIntHashMapTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/fml/transformers/mc/SpeedupLongIntHashMapTransformer.java
@@ -30,6 +30,8 @@ public class SpeedupLongIntHashMapTransformer implements IClassTransformer, Opco
     private static final String FAST_UTIL_INT_HASH_MAP = "com/mitchej123/hodgepodge/util/FastUtilIntHashMap";
     private static final String CHUNK_PROVIDER_CLIENT = "net.minecraft.client.multiplayer.ChunkProviderClient";
     private static final String CHUNK_PROVIDER_SERVER = "net.minecraft.world.gen.ChunkProviderServer";
+    // if more classes need to be added change this to an array
+    private static final String EXCLUDED_CLASS = "thaumcraft.common.lib.world.dim.TeleporterThaumcraft";
 
     private static final ClassConstantPoolParser cstPoolParser = new ClassConstantPoolParser(
             INT_HASH_MAP,
@@ -44,8 +46,11 @@ public class SpeedupLongIntHashMapTransformer implements IClassTransformer, Opco
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
         if (basicClass == null) return null;
-        if (cstPoolParser.find(basicClass) && !transformedName.startsWith("com.mitchej123.hodgepodge.util")) {
-            return transformBytes(transformedName, basicClass);
+        if (cstPoolParser.find(basicClass)) {
+            if (!transformedName.startsWith("com.mitchej123.hodgepodge.util")
+                    && !EXCLUDED_CLASS.equals(transformedName)) {
+                return transformBytes(transformedName, basicClass);
+            }
         }
         return basicClass;
     }


### PR DESCRIPTION
This class has a `private static final LongHashMap destinationCoordinateCache = new LongHashMap();` that is used to store teleport destination, if we let our transformer change this field it will leak the server thread and thus the whole server.
<img width="711" height="188" alt="image" src="https://github.com/user-attachments/assets/67dbd358-a330-4f59-a1e0-9e0a93cabd3d" />
