### PR TITLE
Improve save deletion to cleanup mod data

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -88,6 +88,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixForgeOpenGuiHandlerWindowId;
 
+    @Config.Comment("Fix windowId being set on openContainer even if openGui failed")
+    @Config.DefaultBoolean(true)
+    public static boolean fixDeletingWorldExtraFiles;
+
     @Config.Comment("Fix the Forge update checker")
     @Config.DefaultBoolean(true)
     public static boolean fixForgeUpdateChecker;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -559,6 +559,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("fml.MixinOpenGuiHandler")
             .setApplyIf(() -> FixesConfig.fixForgeOpenGuiHandlerWindowId)
             .setPhase(Phase.EARLY)),
+    FIX_DELETING_WORLD_EXTRA_FILES(new MixinBuilder("Fix GuiSelectWorld world deletion to handle mods files")
+            .addCommonMixins("minecraft.MixinGuiSelectWorld")
+            .setApplyIf(() -> FixesConfig.fixDeletingWorldExtraFiles)
+            .setPhase(Phase.EARLY)),
     FIX_KEYBIND_CONFLICTS(new MixinBuilder("Trigger all conflicting keybinds")
             .addClientMixins(
                     "minecraft.MixinKeyBinding",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -555,6 +555,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("fml.MixinOpenGuiHandler")
             .setApplyIf(() -> FixesConfig.fixForgeOpenGuiHandlerWindowId)
             .setPhase(Phase.EARLY)),
+    FIX_DELETING_WORLD_EXTRA_FILES(new MixinBuilder("Fix GuiSelectWorld world deletion to handle mods files")
+            .addCommonMixins("minecraft.MixinGuiSelectWorld")
+            .setApplyIf(() -> FixesConfig.fixDeletingWorldExtraFiles)
+            .setPhase(Phase.EARLY)),
     FIX_KEYBIND_CONFLICTS(new MixinBuilder("Trigger all conflicting keybinds")
             .addClientMixins(
                     "minecraft.MixinKeyBinding",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
@@ -1,0 +1,66 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiSelectWorld;
+import net.minecraft.world.storage.ISaveFormat;
+import net.minecraft.world.storage.SaveFormatComparator;
+
+import org.apache.commons.io.FileUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.Common;
+
+import cpw.mods.fml.common.Loader;
+
+@Mixin(value = GuiSelectWorld.class)
+public abstract class MixinGuiSelectWorld extends GuiScreen {
+
+    @Shadow
+    private boolean field_146643_x;
+
+    @Shadow (remap = false)
+    private List field_146639_s;
+
+    @Inject(method = "confirmClicked", at = @At("HEAD"), cancellable = true)
+    public void onConfirmClicked(boolean result, int id, CallbackInfo ci) {
+
+        if (this.field_146643_x) {
+            this.field_146643_x = false;
+
+            if (result && !ci.isCancelled()) {
+                String McDataDir = Minecraft.getMinecraft().mcDataDir.getPath();
+                String fileName = ((SaveFormatComparator) this.field_146639_s.get(id)).getFileName();
+
+                ISaveFormat iSaveFormat = this.mc.getSaveLoader();
+                iSaveFormat.flushCache();
+                iSaveFormat.deleteWorldDirectory(fileName);
+
+                if (Loader.isModLoaded("journeymap")) {
+                    Path jmPath = Paths.get(McDataDir + "/journeymap/data/sp/" + fileName);
+                    if (Files.isDirectory(jmPath)) {
+                        Common.log.info("Removing JourneyMap world data found at {}", jmPath);
+                        try {
+                            FileUtils.deleteDirectory(jmPath.toFile());
+                        } catch (IOException e) {
+                            Common.log.warn("Failed to delete JourneyMap world data");
+                        }
+                    }
+                }
+
+                ci.cancel();
+            }
+            this.mc.displayGuiScreen(this);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
@@ -29,7 +29,7 @@ public abstract class MixinGuiSelectWorld extends GuiScreen {
     @Shadow
     private boolean field_146643_x;
 
-    @Shadow (remap = false)
+    @Shadow(remap = false)
     private List field_146639_s;
 
     @Inject(method = "confirmClicked", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -20,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.util.SaveCleanupUtils;
 
 import cpw.mods.fml.common.Loader;
 
@@ -44,12 +46,10 @@ public abstract class MixinGuiSelectWorld extends GuiScreen {
 
                 ISaveFormat iSaveFormat = this.mc.getSaveLoader();
                 iSaveFormat.flushCache();
-                iSaveFormat.deleteWorldDirectory(fileName);
 
                 if (Loader.isModLoaded("journeymap")) {
-                    Path jmPath = Paths.get(McDataDir + "/journeymap/data/sp/" + fileName);
+                    Path jmPath = Paths.get(McDataDir, "journeymap", "data", "sp", fileName);
                     if (Files.isDirectory(jmPath)) {
-                        Common.log.debug("Removing associated JourneyMap data");
                         try {
                             FileUtils.deleteDirectory(jmPath.toFile());
                         } catch (IOException e) {
@@ -59,9 +59,8 @@ public abstract class MixinGuiSelectWorld extends GuiScreen {
                 }
 
                 if (Loader.isModLoaded("tcnodetracker")) {
-                    Path tcPath = Paths.get(McDataDir + "/TCNodeTracker/" + fileName);
+                    Path tcPath = Paths.get(McDataDir, "TCNodeTracker", fileName);
                     if (Files.isDirectory(tcPath)) {
-                        Common.log.debug("Removing associated TCNodeTracker data");
                         try {
                             FileUtils.deleteDirectory(tcPath.toFile());
                         } catch (IOException e) {
@@ -70,6 +69,41 @@ public abstract class MixinGuiSelectWorld extends GuiScreen {
                     }
                 }
 
+                if (Loader.isModLoaded("visualprospecting")) {
+                    UUID userUUID = SaveCleanupUtils.getUUIDForCurrentUser();
+                    if (userUUID == null) {
+                        userUUID = SaveCleanupUtils.getUUIDFromBytes();
+                    }
+                    Path vpClientPath = Paths.get(McDataDir, "visualprospecting", "client", userUUID.toString());
+                    String wpWId = SaveCleanupUtils.getVisualProspectingWorldId(McDataDir, fileName);
+
+                    if (wpWId != null) {
+                        Path vpClientPathFull = Paths.get(vpClientPath.toString(), wpWId);
+                        if (Files.isDirectory(vpClientPathFull)) {
+                            try {
+                                FileUtils.deleteDirectory(vpClientPathFull.toFile());
+                            } catch (IOException e) {
+                                Common.log.warn(
+                                        "Failed to delete Visual Prospecting client data found at {}",
+                                        vpClientPathFull);
+                            }
+                        }
+
+                        Path vpServerPathFull = Paths.get(McDataDir, "visualprospecting", "server", wpWId);
+                        if (Files.isDirectory(vpServerPathFull)) {
+                            try {
+                                FileUtils.deleteDirectory(vpServerPathFull.toFile());
+                            } catch (IOException e) {
+                                Common.log.warn(
+                                        "Failed to delete Visual Prospecting server data found at {}",
+                                        vpServerPathFull);
+                            }
+                        }
+                    }
+
+                }
+
+                iSaveFormat.deleteWorldDirectory(fileName);
                 ci.cancel();
             }
             this.mc.displayGuiScreen(this);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
@@ -49,11 +49,23 @@ public abstract class MixinGuiSelectWorld extends GuiScreen {
                 if (Loader.isModLoaded("journeymap")) {
                     Path jmPath = Paths.get(McDataDir + "/journeymap/data/sp/" + fileName);
                     if (Files.isDirectory(jmPath)) {
-                        Common.log.info("Removing JourneyMap world data found at {}", jmPath);
+                        Common.log.debug("Removing associated JourneyMap data");
                         try {
                             FileUtils.deleteDirectory(jmPath.toFile());
                         } catch (IOException e) {
-                            Common.log.warn("Failed to delete JourneyMap world data");
+                            Common.log.warn("Failed to delete JourneyMap world data found at {}", jmPath);
+                        }
+                    }
+                }
+
+                if (Loader.isModLoaded("tcnodetracker")) {
+                    Path tcPath = Paths.get(McDataDir + "/TCNodeTracker/" + fileName);
+                    if (Files.isDirectory(tcPath)) {
+                        Common.log.debug("Removing associated TCNodeTracker data");
+                        try {
+                            FileUtils.deleteDirectory(tcPath.toFile());
+                        } catch (IOException e) {
+                            Common.log.warn("Failed to delete TCNodeTracker data found at {}", tcPath);
                         }
                     }
                 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiSelectWorld.java
@@ -29,7 +29,7 @@ public abstract class MixinGuiSelectWorld extends GuiScreen {
     @Shadow
     private boolean field_146643_x;
 
-    @Shadow(remap = false)
+    @Shadow
     private List field_146639_s;
 
     @Inject(method = "confirmClicked", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/com/mitchej123/hodgepodge/util/SaveCleanupUtils.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/SaveCleanupUtils.java
@@ -1,0 +1,77 @@
+package com.mitchej123.hodgepodge.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+public final class SaveCleanupUtils {
+
+    private SaveCleanupUtils() {}
+
+    public static UUID getUUIDForCurrentUser() {
+
+        String username = Minecraft.getMinecraft().getSession().getUsername();
+
+        File usernameFile = new File(Minecraft.getMinecraft().mcDataDir, "usernamecache.json");
+        if (!usernameFile.exists()) {
+            return null;
+        }
+
+        try (FileReader reader = new FileReader(usernameFile)) {
+            JsonObject usernameObj = new JsonParser().parse(reader).getAsJsonObject();
+            for (Map.Entry<String, JsonElement> entry : usernameObj.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (value != null && username.equalsIgnoreCase(value.getAsString())) {
+                    try {
+                        return UUID.fromString(entry.getKey());
+                    } catch (IllegalArgumentException ignored) {
+                        return null;
+                    }
+                }
+
+            }
+        } catch (IOException e) {
+            return null;
+        }
+        return null;
+    }
+
+    public static UUID getUUIDFromBytes() {
+        String username = Minecraft.getMinecraft().getSession().getUsername();
+        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + username).getBytes(UTF_8));
+    }
+
+    public static String getVisualProspectingWorldId(String McDataDir, String worldFolder) {
+        File vpDat = (Paths.get(McDataDir, "saves", worldFolder, "data", "visualprospecting.dat")).toFile();
+        if (!vpDat.exists()) {
+            return null;
+        }
+
+        try (FileInputStream vpFIS = new FileInputStream(vpDat)) {
+            NBTTagCompound vpNBT = CompressedStreamTools.readCompressed(vpFIS);
+            if (vpNBT.hasKey("data")) {
+                NBTTagCompound data = vpNBT.getCompoundTag("data");
+                if (data.hasKey("wId")) {
+                    return data.getString("wId");
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
With theses changes deleting a world from the menu should now cleanup most of the mod data that are not placed in the world save folder.

Added deletion of the following:
- JourneyMap in `journeymap/data/sp/<World Name>`
- TCNodeTracker in `TCNodeTracker/<World Name>`
- VisualProspecting in `visualprospecting/<PlayerUUID>/<WorldUUID>` & `visualprospecting/server/<UUID>` &larr; This one ended up extremely complicated due to the naming system and some values not being easy to obtain from outside a loaded world

For peace of mind the backups folder of ServerUtilities is out of scope. I didn't even look into it.

It is my first dive into mixins so I hope I did approach this in  a proper way.