### PR TITLE
Add a config to disable potion effect icons from the inventory screen

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -119,6 +119,10 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixPotionRenderOffset;
 
+    @Config.Comment("Show potion effect icons in inventory screens")
+    @Config.DefaultBoolean(true)
+    public static boolean showInventoryEffectIcons;
+
     @Config.Comment("Stops rendering the crosshair when you are playing in third person")
     @Config.DefaultBoolean(true)
     public static boolean hideCrosshairInThirdPerson;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -173,7 +173,7 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     TOGGLE_INVENTORY_EFFECT_ICONS(new MixinBuilder()
             .addClientMixins("minecraft.MixinInventoryEffectRenderer_TogglePotionIcons")
-            .setApplyIf(() -> TweaksConfig.fixPotionRenderOffset)
+            .setApplyIf(() -> !TweaksConfig.showInventoryEffectIcons)  
             .setPhase(Phase.EARLY)),
     FIX_POTION_EFFECT_RENDERING(new MixinBuilder()
             .addClientMixins("minecraft.MixinInventoryEffectRenderer_PotionEffectRendering")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -171,6 +171,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinInventoryEffectRenderer_PotionOffset")
             .setApplyIf(() -> TweaksConfig.fixPotionRenderOffset)
             .setPhase(Phase.EARLY)),
+    TOGGLE_INVENTORY_EFFECT_ICONS(new MixinBuilder()
+            .addClientMixins("minecraft.MixinInventoryEffectRenderer_TogglePotionIcons")
+            .setApplyIf(() -> TweaksConfig.fixPotionRenderOffset)
+            .setPhase(Phase.EARLY)),
     FIX_POTION_EFFECT_RENDERING(new MixinBuilder()
             .addClientMixins("minecraft.MixinInventoryEffectRenderer_PotionEffectRendering")
             .setApplyIf(() -> TweaksConfig.fixPotionEffectRender)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_TogglePotionIcons.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_TogglePotionIcons.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.renderer.InventoryEffectRenderer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+
+@Mixin(InventoryEffectRenderer.class)
+public class MixinInventoryEffectRenderer_TogglePotionIcons {
+
+    @Inject(method = "func_147044_g", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$togglePotionEffectIcons(CallbackInfo ci) {
+        if (!TweaksConfig.showInventoryEffectIcons) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_TogglePotionIcons.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_TogglePotionIcons.java
@@ -3,19 +3,14 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mitchej123.hodgepodge.config.TweaksConfig;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
 @Mixin(InventoryEffectRenderer.class)
 public class MixinInventoryEffectRenderer_TogglePotionIcons {
 
-    @Inject(method = "func_147044_g", at = @At("HEAD"), cancellable = true)
-    private void hodgepodge$togglePotionEffectIcons(CallbackInfo ci) {
-        if (!TweaksConfig.showInventoryEffectIcons) {
-            ci.cancel();
-        }
+    @WrapMethod(method = "func_147044_g")
+    private void hodgepodge$togglePotionEffectIcons(Operation<Void> original) {
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_TogglePotionIcons.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_TogglePotionIcons.java
@@ -11,6 +11,5 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 public class MixinInventoryEffectRenderer_TogglePotionIcons {
 
     @WrapMethod(method = "func_147044_g")
-    private void hodgepodge$togglePotionEffectIcons(Operation<Void> original) {
-    }
+    private void hodgepodge$togglePotionEffectIcons(Operation<Void> original) {}
 }


### PR DESCRIPTION
This toggle works just for the inventory icons. The icons from Adventure backpack, IGI or additional mods like StatusEfectHud are untouched :>


| Before | After |
| - | - |
| <img width="2393" height="776" alt="image" src="https://github.com/user-attachments/assets/c61fd2c2-2c71-45b1-9f87-8dd858b032f5" /> | <img width="555" height="596" alt="image" src="https://github.com/user-attachments/assets/ae13f575-5a63-4504-9127-2a3aa34f9e99" /> |  
|  <img width="2393" height="776" alt="image" src="https://github.com/user-attachments/assets/c0f0db4e-3ede-4547-864d-876f70633480" /> | <img width="573" height="687" alt="image" src="https://github.com/user-attachments/assets/1893739c-5bf0-4f60-b101-7e6bf9aa51d6" /> | 