### PR TITLE
[Memory-opti:fix leak] fix forge's FakePlayerFactory leaking the world server

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -110,6 +110,11 @@ public class MemoryConfig {
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart
         public boolean fixBibliocraftTESRWorldLeak;
+
+        @Config.Comment("Fix forge's FakePlayerFactory leaking the world instance")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean fixForgePlayerFactoryLeak;
     }
 
     public static class AllocationFixes {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1027,6 +1027,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("forge.MixinAdvancedModelLoader_CacheModels")
             .setApplyIf(() -> MemoryConfig.allocs.cacheAdvancedModels)
             .setPhase(Phase.EARLY)),
+    FIX_FORGE_PLAYER_LEAK(new MixinBuilder()
+            .addCommonMixins("memory.MixinFakePlayerFactory_FixLeak")
+            .setApplyIf(() -> MemoryConfig.leaks.fixForgePlayerFactoryLeak)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinFakePlayerFactory_FixLeak.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/memory/MixinFakePlayerFactory_FixLeak.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.early.memory;
+
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.common.util.FakePlayerFactory;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = FakePlayerFactory.class, remap = false)
+public class MixinFakePlayerFactory_FixLeak {
+
+    @Shadow
+    private static FakePlayer MINECRAFT_PLAYER;
+
+    @Inject(method = "unloadWorld", at = @At("HEAD"))
+    private static void clearMinecraftPlayer(WorldServer world, CallbackInfo ci) {
+        if (MINECRAFT_PLAYER != null && MINECRAFT_PLAYER.worldObj == world) {
+            MINECRAFT_PLAYER = null;
+        }
+    }
+}


### PR DESCRIPTION
When unloading world it was removing entries from the fake player map but it never cleared the static minecraft player field

<img width="514" height="72" alt="image" src="https://github.com/user-attachments/assets/01338246-8b9a-4982-986f-386ed50b0ecb" />
