### PR TITLE
fix /say, /tell, /me losing formatting after the first word

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -36,6 +36,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixChatWrappedColors;
 
+    @Config.Comment("Fix /say, /tell, /me losing formatting after the first word")
+    @Config.DefaultBoolean(true)
+    public static boolean fixCommandFormattingLoss;
+
     @Config.Comment("Prevents crash if server sends container with wrong itemStack size")
     @Config.DefaultBoolean(true)
     public static boolean fixContainerPutStacksInSlots;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -647,6 +647,10 @@ public enum Mixins implements IMixins {
                     "minecraft.MixinGuiTextField_FixColorScroll")
             .setApplyIf(() -> FixesConfig.fixChatWrappedColors)
             .setPhase(Phase.EARLY)),
+    FIX_COMMAND_FORMATTING_LOSS(new MixinBuilder("Fix /say, /tell, /me losing formatting after first word")
+            .addCommonMixins("minecraft.MixinCommandBase_JoinArgs")
+            .setApplyIf(() -> FixesConfig.fixCommandFormattingLoss)
+            .setPhase(Phase.EARLY)),
     COMPACT_CHAT(new MixinBuilder()
             .addClientMixins("minecraft.MixinGuiNewChat_CompactChat")
             .setApplyIf(() -> TweaksConfig.compactChat)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCommandBase_JoinArgs.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCommandBase_JoinArgs.java
@@ -1,0 +1,53 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.PlayerNotFoundException;
+import net.minecraft.command.PlayerSelector;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CommandBase.class)
+public class MixinCommandBase_JoinArgs {
+
+    @Inject(
+            method = "func_147176_a(Lnet/minecraft/command/ICommandSender;[Ljava/lang/String;IZ)Lnet/minecraft/util/IChatComponent;",
+            at = @At("HEAD"),
+            cancellable = true)
+    private static void hodgepodge$joinNonSelectorArgs(ICommandSender sender, String[] args, int index,
+            boolean checkSelectors, CallbackInfoReturnable<IChatComponent> cir) {
+        ChatComponentText root = new ChatComponentText("");
+        StringBuilder textRun = new StringBuilder();
+        boolean firstArg = true;
+
+        for (int j = index; j < args.length; j++) {
+            IChatComponent selectorResult = checkSelectors ? PlayerSelector.func_150869_b(sender, args[j]) : null;
+
+            if (selectorResult != null) {
+                if (textRun.length() > 0) {
+                    root.appendSibling(new ChatComponentText(textRun.toString()));
+                    textRun.setLength(0);
+                }
+                if (!firstArg) root.appendText(" ");
+                root.appendSibling(selectorResult);
+            } else if (checkSelectors && PlayerSelector.hasArguments(args[j])) {
+                throw new PlayerNotFoundException();
+            } else {
+                if (!firstArg) textRun.append(' ');
+                textRun.append(args[j]);
+            }
+            firstArg = false;
+        }
+
+        if (textRun.length() > 0) {
+            root.appendSibling(new ChatComponentText(textRun.toString()));
+        }
+
+        cir.setReturnValue(root);
+    }
+}


### PR DESCRIPTION
Thanks mitchej for spotting this issue : 
pre : 
<img width="338" height="42" alt="image" src="https://github.com/user-attachments/assets/8924d32c-2856-4f03-869e-e27d00fb3f47" />
after fix : 
<img width="1084" height="238" alt="image" src="https://github.com/user-attachments/assets/a442a0e1-b0b1-491b-8d0d-8d5d8c687d6f" />
