### PR TITLE
Fix crash with disableChunkTerrainGeneration and EndlessIDs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,6 +34,7 @@ dependencies {
     transformedModCompileOnly(rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612"))
     transformedModCompileOnly("curse.maven:cofh-core-69162:2388751")
     //transformedModCompileOnly('curse.maven:dragon-api-235591:3574508')
+    transformedModCompileOnly(rfg.deobf("curse.maven:endlessids-665730:7585931"))
     transformedModCompileOnly("curse.maven:minefactory-reloaded-66672:2277486")
     transformedModCompileOnly(rfg.deobf('curse.maven:damage-indicators-mod-59489:2692129'))
     transformedModCompileOnly("curse.maven:extra-utilities-225561:2264384")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1221,6 +1221,12 @@ public enum Mixins implements IMixins {
     DISABLE_CHUNK_TERRAIN_GENERATION(new MixinBuilder()
             .addCommonMixins("minecraft.MixinChunkProviderServer_DisableTerrain")
             .setApplyIf(() -> TweaksConfig.disableChunkTerrainGeneration)
+            .addExcludedMod(TargetedMod.ENDLESSIDS)
+            .setPhase(Phase.EARLY)),
+    DISABLE_CHUNK_TERRAIN_GENERATION_ENDLESS_IDS(new MixinBuilder()
+            .addCommonMixins("minecraft.MixinChunkProviderServer_DisableTerrain_EndlessIDs")
+            .setApplyIf(() -> TweaksConfig.disableChunkTerrainGeneration)
+            .addRequiredMod(TargetedMod.ENDLESSIDS)
             .setPhase(Phase.EARLY)),
     DISABLE_WORLD_TYPE_CHUNK_POPULATION(new MixinBuilder("Disable chunk population tied to chunk generation (ores/structure)")
             .addCommonMixins("minecraft.MixinChunkProviderServer_DisablePopulation")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/TargetedMod.java
@@ -31,6 +31,7 @@ public enum TargetedMod implements ITargetMod {
     // transformer that got removed and added via mixin in this mod, so we don't
     // load our mixins if an old version of the mod that contains this class is loaded
     ENDERCORE_WITH_MODLIST(null, null, "com.enderio.core.common.transform.EnderCoreTransformerClient"),
+    ENDLESSIDS("com.falsepattern.endlessids.asm.EndlessIDsCore", "endlessids"),
     ETFURUMREQUIEM("ganymedes01.etfuturum.mixinplugin.EtFuturumEarlyMixins", "etfuturum"),
     EXTRATIC("ExtraTiC"),
     EXTRA_UTILITIES("ExtraUtilities"),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderServer_DisableTerrain_EndlessIDs.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderServer_DisableTerrain_EndlessIDs.java
@@ -1,0 +1,48 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.util.Arrays;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.ChunkProviderServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import com.falsepattern.endlessids.mixin.helpers.ChunkBiomeHook;
+
+@Mixin(ChunkProviderServer.class)
+public class MixinChunkProviderServer_DisableTerrain_EndlessIDs {
+
+    @Unique
+    private static final int CHUNK_WIDTH = 16;
+
+    @Unique
+    private static final int CHUNK_LENGTH = 16;
+
+    @Unique
+    private static final int CHUNK_HEIGHT = 256;
+
+    @Unique
+    private static final int BLOCKS_TOTAL = CHUNK_LENGTH * CHUNK_WIDTH * CHUNK_HEIGHT;
+
+    @ModifyVariable(
+            at = @At(
+                    value = "INVOKE_ASSIGN",
+                    target = "Lnet/minecraft/world/chunk/IChunkProvider;provideChunk(II)Lnet/minecraft/world/chunk/Chunk;"),
+            method = "originalLoadChunk")
+    public Chunk hodgepodge$disableTerrainEndlessIds(Chunk chunk) {
+        final Block[] ids = new Block[BLOCKS_TOTAL];
+        final byte[] metadata = new byte[BLOCKS_TOTAL];
+        Arrays.fill(ids, Blocks.air);
+
+        short[] biomeArray = ((ChunkBiomeHook) chunk).getBiomeShortArray();
+        Chunk newChunk = new Chunk(chunk.worldObj, ids, metadata, chunk.xPosition, chunk.zPosition);
+        ((ChunkBiomeHook) chunk).setBiomeShortArray(biomeArray);
+
+        return newChunk;
+    }
+}


### PR DESCRIPTION
EndlessIDs disallows the suse of `getBiomeArray()` and `setBiomeArray()`. Those calls are replaced with `getBiomeShortArray()` and `.setBiomeShortArray()` From EndlessIDs' `ChunkBiomeHook`.

Fixes: #876