### PR TITLE
Fix fast block lookup

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
@@ -21,40 +21,74 @@ public final class BlockLookupHooks {
 
     public static Block getBlockById(final int id) {
         final Block[] arr = blockById;
+
         if (arr == null) return (Block) Block.blockRegistry.getObjectById(id);
+
         // arr[0] is air — match FML's default-object behavior for unknown/unregistered IDs
         final Block b = (id >= 0 && id < arr.length) ? arr[id] : null;
+
         return b != null ? b : arr[0];
     }
 
     public static int getIdFromBlock(final Block block) {
         if (block == null) return -1;
+
         final Block[] arr = blockById;
+
         if (arr == null) return Block.blockRegistry.getIDForObject(block);
+
         final int id = ((BlockExt_FastLookup) block).hodgepodge$getBlockId();
-        if (id == -1) return getIdFromBlockFallback(block);
+
+        if (id < 0 || id >= arr.length || arr[id] != block) {
+            return getIdFromBlockFallback(block);
+        }
+
         return id;
     }
 
     private static int getIdFromBlockFallback(final Block block) {
         final int registryId = Block.blockRegistry.getIDForObject(block);
+
         if (registryId >= 0) {
-            ((BlockExt_FastLookup) block).hodgepodge$setBlockId(registryId);
+            final Block[] arr = blockById;
+
+            if (arr != null && registryId < arr.length && arr[registryId] == block) {
+                ((BlockExt_FastLookup) block).hodgepodge$setBlockId(registryId);
+            } else {
+                ((BlockExt_FastLookup) block).hodgepodge$setBlockId(-1);
+            }
+
             if (loggedUncachedBlocks.add(block)) {
                 LOGGER.warn(
-                        "Block {} ({}) has no cached ID but is in the registry with ID {}. ",
+                        "Block {} ({}) has invalid or missing cached ID, registry ID is {}. ",
                         Block.blockRegistry.getNameForObject(block),
                         block.getClass().getName(),
                         registryId);
             }
+        } else {
+            ((BlockExt_FastLookup) block).hodgepodge$setBlockId(-1);
         }
+
         return registryId;
     }
 
     public static void rebuild() {
+        final Block[] old = blockById;
+        blockById = null;
+
+        if (old != null) {
+            for (final Block b : old) {
+                if (b instanceof BlockExt_FastLookup ext) {
+                    ext.hodgepodge$setBlockId(-1);
+                }
+            }
+        }
+
         Block[] arr = new Block[4096];
+
         for (final Object obj : Block.blockRegistry) {
             final int id = Block.blockRegistry.getIDForObject(obj);
+
             if (id >= 0) {
                 if (id >= arr.length) arr = Arrays.copyOf(arr, Math.max(arr.length * 2, id + 1));
                 arr[id] = (Block) obj;
@@ -62,22 +96,27 @@ public final class BlockLookupHooks {
         }
 
         for (int i = 0; i < arr.length; i++) {
-            if (arr[i] instanceof BlockExt_FastLookup ext) ext.hodgepodge$setBlockId(i);
+            if (arr[i] instanceof BlockExt_FastLookup ext) {
+                ext.hodgepodge$setBlockId(i);
+            }
         }
 
-        final Block[] old = blockById;
         blockById = arr;
+        loggedUncachedBlocks.clear();
+    }
 
-        // Clear embedded IDs for blocks no longer in the registry to avoid stale ID->block mismatches
+    public static void invalidate() {
+        final Block[] old = blockById;
+        blockById = null;
+
         if (old != null) {
             for (final Block b : old) {
                 if (b instanceof BlockExt_FastLookup ext) {
-                    final int id = ext.hodgepodge$getBlockId();
-                    if (id < 0 || id >= arr.length || arr[id] != b) {
-                        ext.hodgepodge$setBlockId(-1);
-                    }
+                    ext.hodgepodge$setBlockId(-1);
                 }
             }
         }
+
+        loggedUncachedBlocks.clear();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
@@ -14,8 +14,12 @@ import com.mitchej123.hodgepodge.mixins.interfaces.BlockExt_FastLookup;
 public final class BlockLookupHooks {
 
     private static final Logger LOGGER = LogManager.getLogger("BlockLookupHooks");
+
+    // Track by identity: different Block instances must not be collapsed by equals().
     private static final Set<Block> loggedUncachedBlocks = Collections.newSetFromMap(new IdentityHashMap<>());
 
+    // Published as a whole snapshot. Readers either use the previous complete cache,
+    // the next complete cache, or fall back to the registry while it is null.
     private static volatile Block[] blockById = null;
 
     public static Block getBlockById(final int id) {
@@ -23,7 +27,8 @@ public final class BlockLookupHooks {
 
         if (arr == null) return (Block) Block.blockRegistry.getObjectById(id);
 
-        // arr[0] is air — match FML's default-object behavior for unknown/unregistered IDs
+        // arr[0] is air. This preserves the vanilla/FML behavior where invalid
+        // or missing IDs resolve to the default block instead of null.
         final Block b = (id >= 0 && id < arr.length) ? arr[id] : null;
 
         return b != null ? b : arr[0];
@@ -34,10 +39,15 @@ public final class BlockLookupHooks {
 
         final Block[] arr = blockById;
 
+        // During registry rebuild/remap the fast cache is deliberately disabled.
+        // In that window, the live registry is the source of truth.
         if (arr == null) return Block.blockRegistry.getIDForObject(block);
 
         final int id = ((BlockExt_FastLookup) block).hodgepodge$getBlockId();
 
+        // Do not trust a cached positive ID blindly.
+        // Old-world ID remapping can temporarily leave a Block instance with a stale hodgepodge$blockId.
+        // The cache entry must map back to the same Block instance.
         if (id < 0 || id >= arr.length || arr[id] != block) {
             return getIdFromBlockFallback(block);
         }
@@ -51,6 +61,9 @@ public final class BlockLookupHooks {
         if (registryId >= 0) {
             final Block[] arr = blockById;
 
+            // Only refresh the per-block cached ID if the current array confirms
+            // that this registry ID maps back to the same Block instance.
+            // Otherwise, keep the per-block cache invalid and let future calls consult the registry again.
             if (arr != null && registryId < arr.length && arr[registryId] == block) {
                 ((BlockExt_FastLookup) block).hodgepodge$setBlockId(registryId);
             } else {
@@ -65,6 +78,8 @@ public final class BlockLookupHooks {
                         registryId);
             }
         } else {
+            // The block is not present in the active registry.
+            // Keep its cached ID invalid instead of preserving a stale value.
             ((BlockExt_FastLookup) block).hodgepodge$setBlockId(-1);
         }
 
@@ -72,22 +87,29 @@ public final class BlockLookupHooks {
     }
 
     public static void rebuild() {
+        // Drop old per-block IDs before constructing the new array.
+        // This prevents lookups from observing stale IDs while the active registry is changing.
         invalidate();
 
         final Block[] arr = buildBlockByIdArray();
 
+        // Populate the embedded ID only after the full array has been built from the active registry.
         for (int i = 0; i < arr.length; i++) {
             if (arr[i] instanceof BlockExt_FastLookup ext) {
                 ext.hodgepodge$setBlockId(i);
             }
         }
 
+        // Publish the complete snapshot atomically.
         blockById = arr;
         loggedUncachedBlocks.clear();
     }
 
     public static void invalidate() {
         final Block[] old = blockById;
+
+        // Disable fast lookups first. Any concurrent lookup will fall back to the
+        // registry instead of using a partially invalidated cache.
         blockById = null;
 
         if (old != null) {
@@ -104,6 +126,8 @@ public final class BlockLookupHooks {
     private static Block[] buildBlockByIdArray() {
         int maxId = -1;
 
+        // Do not assume the registry fits in the vanilla 4096 block ID range (EndlessIDs mod).
+        // Build the array size from the actual highest active registry ID.
         for (final Object obj : Block.blockRegistry) {
             if (!(obj instanceof Block)) continue;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
@@ -1,6 +1,5 @@
 package com.mitchej123.hodgepodge.mixins.hooks;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
@@ -73,27 +72,9 @@ public final class BlockLookupHooks {
     }
 
     public static void rebuild() {
-        final Block[] old = blockById;
-        blockById = null;
+        invalidate();
 
-        if (old != null) {
-            for (final Block b : old) {
-                if (b instanceof BlockExt_FastLookup ext) {
-                    ext.hodgepodge$setBlockId(-1);
-                }
-            }
-        }
-
-        Block[] arr = new Block[4096];
-
-        for (final Object obj : Block.blockRegistry) {
-            final int id = Block.blockRegistry.getIDForObject(obj);
-
-            if (id >= 0) {
-                if (id >= arr.length) arr = Arrays.copyOf(arr, Math.max(arr.length * 2, id + 1));
-                arr[id] = (Block) obj;
-            }
-        }
+        final Block[] arr = buildBlockByIdArray();
 
         for (int i = 0; i < arr.length; i++) {
             if (arr[i] instanceof BlockExt_FastLookup ext) {
@@ -118,5 +99,33 @@ public final class BlockLookupHooks {
         }
 
         loggedUncachedBlocks.clear();
+    }
+
+    private static Block[] buildBlockByIdArray() {
+        int maxId = -1;
+
+        for (final Object obj : Block.blockRegistry) {
+            if (!(obj instanceof Block)) continue;
+
+            final int id = Block.blockRegistry.getIDForObject(obj);
+
+            if (id > maxId) {
+                maxId = id;
+            }
+        }
+
+        final Block[] arr = maxId >= 0 ? new Block[maxId + 1] : new Block[0];
+
+        for (final Object obj : Block.blockRegistry) {
+            if (!(obj instanceof Block block)) continue;
+
+            final int id = Block.blockRegistry.getIDForObject(block);
+
+            if (id >= 0) {
+                arr[id] = block;
+            }
+        }
+
+        return arr;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/BlockLookupHooks.java
@@ -138,7 +138,9 @@ public final class BlockLookupHooks {
             }
         }
 
-        final Block[] arr = maxId >= 0 ? new Block[maxId + 1] : new Block[0];
+        // Keep at least one slot because getBlockById falls back to arr[0],
+        // which is expected to be air in a valid block registry.
+        final Block[] arr = new Block[Math.max(maxId + 1, 1)];
 
         for (final Object obj : Block.blockRegistry) {
             if (!(obj instanceof Block block)) continue;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinGameData_BlockArraySync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinGameData_BlockArraySync.java
@@ -19,6 +19,8 @@ public class MixinGameData_BlockArraySync {
 
     @Inject(method = "freezeData", at = @At("RETURN"))
     private static void hodgepodge$rebuildBlockArrayOnFreeze(CallbackInfo ci) {
+        // Once Forge has frozen the registries, rebuild the fast lookup cache
+        // from the final active block registry.
         BlockLookupHooks.rebuild();
     }
 
@@ -30,6 +32,9 @@ public class MixinGameData_BlockArraySync {
             Set<String> blockSubstitutions, Set<String> itemSubstitutions, boolean injectFrozenData,
             boolean isLocalWorld, CallbackInfoReturnable<List<String>> cir) {
 
+        // Old-world loading may remap numeric block IDs.
+        // Disable the fast cache before Forge starts injecting the world ID map
+        // so stale embedded IDs cannot be returned during the remap.
         BlockLookupHooks.invalidate();
     }
 
@@ -41,6 +46,8 @@ public class MixinGameData_BlockArraySync {
             Set<String> itemSubstitutions, boolean injectFrozenData, boolean isLocalWorld,
             CallbackInfoReturnable<List<String>> cir) {
 
+        // The active registry is stable again after the world ID map has been injected.
+        // Rebuild the fast lookup cache from that remapped registry.
         BlockLookupHooks.rebuild();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinGameData_BlockArraySync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinGameData_BlockArraySync.java
@@ -24,11 +24,23 @@ public class MixinGameData_BlockArraySync {
 
     @Inject(
             method = "injectWorldIDMap(Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;ZZ)Ljava/util/List;",
+            at = @At("HEAD"))
+    private static void hodgepodge$invalidateBlockArrayBeforeInject(Map<String, Integer> dataList,
+            Set<Integer> blockedIds, Map<String, String> blockAliases, Map<String, String> itemAliases,
+            Set<String> blockSubstitutions, Set<String> itemSubstitutions, boolean injectFrozenData,
+            boolean isLocalWorld, CallbackInfoReturnable<List<String>> cir) {
+
+        BlockLookupHooks.invalidate();
+    }
+
+    @Inject(
+            method = "injectWorldIDMap(Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;ZZ)Ljava/util/List;",
             at = @At("RETURN"))
     private static void hodgepodge$rebuildBlockArrayOnInject(Map<String, Integer> dataList, Set<Integer> blockedIds,
             Map<String, String> blockAliases, Map<String, String> itemAliases, Set<String> blockSubstitutions,
             Set<String> itemSubstitutions, boolean injectFrozenData, boolean isLocalWorld,
             CallbackInfoReturnable<List<String>> cir) {
+
         BlockLookupHooks.rebuild();
     }
 }


### PR DESCRIPTION
- The issue is most likely introduced by PR #744 
- Should fixes GTNewHorizons/GT-New-Horizons-Modpack#23811

### Testing

Tested with an old 2.8.4 save opened in 2.9.x.

Before this fix:
- Several Chisel cobblestone blocks became flammable and could burn.
- Setting `B:fastBlockLookup=false` prevented the issue.
- Re-enabling `fastBlockLookup` made the issue happen again after every fresh pack start.
- Leaving the world and reopening it without restarting the game temporarily fixed the issue.
- Fully restarting the game made the issue come back on the next world load.

After this fix:
- The affected blocks no longer become flammable.
- I can no longer reproduce the issue with the same save and `fastBlockLookup` enabled.

This suggests the problem was caused by stale cached block IDs during old-world ID remapping. This patch invalidates the fast block lookup cache before `GameData.injectWorldIDMap`, rebuilds it afterwards, and validates cached block IDs before returning them.

| Before | After |
|---|---|
|<img width="349" height="308" alt="Bugged" src="https://github.com/user-attachments/assets/495845db-0b0b-4a7d-b48e-70048fdc5c98" />|<img width="349" height="308" alt="Fixed" src="https://github.com/user-attachments/assets/84714e6b-7ab6-44c8-9656-0d7570624435" />|
