### PR TITLE
Fix BiblioCraft error during pack launch for some instance path with special characters

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -518,6 +518,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean noPauseGuiClipboard;
 
+    @Config.Comment("Fix Bibliocraft PaintingUtil getting it's own jar path")
+    @Config.DefaultBoolean(true)
+    public static boolean fixBibliocraftPaintingUtilPath;
+
     // Bibliowoods Forestry
 
     @Config.Comment("Fix Bibliowoods Forestry recipes")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1800,6 +1800,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.noPauseGuiClipboard)
             .addRequiredMod(TargetedMod.BIBLIOCRAFT)
             .setPhase(Phase.LATE)),
+    BIBLIOCRAFT_PAINTING_UTIL_FIX(new MixinBuilder("PaintingUtil jar Path Fix")
+            .addCommonMixins("bibliocraft.MixinPaintingUtil")
+            .setApplyIf(() -> FixesConfig.fixBibliocraftPaintingUtilPath)
+            .addRequiredMod(TargetedMod.BIBLIOCRAFT)
+            .setPhase(Phase.LATE)),
     BIBLIOCRAFT_FIX_TESR_WORLD_LEAK(new MixinBuilder()
             .addClientMixins(
                     "bibliocraft.leaks.MixinTileEntityArmorStandRenderer",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinPaintingUtil.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinPaintingUtil.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import java.net.URI;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import jds.bibliocraft.PaintingUtil;
+
+@Mixin(value = PaintingUtil.class)
+public class MixinPaintingUtil {
+
+    @Redirect(
+            method = "getJarPaintings",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/net/URLDecoder;decode(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"),
+            remap = false)
+    private static String hodgepodge$fixJarPath(String path, String encoding) throws Exception {
+        return URI.create("file://" + path).getPath();
+    }
+}


### PR DESCRIPTION
If you drag & drop the dailies into Prism and don't touch anything you end up with a '+' in the instance directory name.

This cause BC to throw some errors during pack startup because it remove this character for a path due to how encode it:
```
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: java.nio.file.NoSuchFileException: C:\Users\Censored\AppData\Roaming\PrismLauncher\instances\GTNH-daily-2026-05-17 519-mmcprism-java17-25\.minecraft\mods\BiblioCraft[v1.11.7][MC1.7.10].jar
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:85)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(WindowsFileAttributeViews.java:52)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(WindowsFileAttributeViews.java:38)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/sun.nio.fs.WindowsFileSystemProvider.readAttributes(WindowsFileSystemProvider.java:195)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.nio.file.Files.readAttributes(Files.java:1702)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1493)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:704)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:204)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:150)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.jar.JarFile.<init>(JarFile.java:333)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.jar.JarFile.<init>(JarFile.java:306)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at java.base/java.util.jar.JarFile.<init>(JarFile.java:253)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at Launch//jds.bibliocraft.PaintingUtil.getJarPaintings(PaintingUtil.java:212)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at Launch//jds.bibliocraft.PaintingUtil.getListOfPaintings(PaintingUtil.java:142)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at Launch//jds.bibliocraft.PaintingUtil.updateCustomArtDatas(PaintingUtil.java:65)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at Launch//jds.bibliocraft.EventResourcePackReload.ReloadResourcePackEvent(EventResourcePackReload.java:11)
[14:14:12] [Client thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:790]: 	at cpw.mods.fml.common.eventhandler.ASMEventHandler_665_EventResourcePackReload_ReloadResourcePackEvent_Post.invoke(.dynamic)
....
```

This change
`JarFile jar = new JarFile(URLDecoder.decode(jarPath, "UTF-8"));`
into
`JarFile jar = new JarFile(URI.create("file://" + jarPath).getPath());`


This is probably not super useful outside of dailies but this is annoying.