### PR TITLE
Intern Strings of the ASMDataTable

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Hodgepodge.java
@@ -6,6 +6,7 @@ import com.mitchej123.hodgepodge.client.HodgepodgeClient;
 import com.mitchej123.hodgepodge.commands.DebugCommand;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
+import com.mitchej123.hodgepodge.mixins.hooks.ASMDataStringPooler;
 import com.mitchej123.hodgepodge.mixins.hooks.ChunkGenScheduler;
 import com.mitchej123.hodgepodge.net.NetworkHandler;
 import com.mitchej123.hodgepodge.util.AnchorAlarm;
@@ -71,6 +72,7 @@ public class Hodgepodge {
 
     @EventHandler
     public void init(FMLInitializationEvent event) {
+        ASMDataStringPooler.free();
         FMLCommonHandler.instance().bus().register(ANCHOR_ALARM);
         Common.init();
         NetworkHandler.init();

--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -142,6 +142,6 @@ public class MemoryConfig {
         @Config.Comment("Reduces the RAM usage of the ASMDataTable by interning the Strings")
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart
-        public boolean internASMDataTableStrings;
+        public boolean deduplicateASMDataTableStrings;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -138,5 +138,10 @@ public class MemoryConfig {
         @Config.DefaultBoolean(true)
         @Config.RequiresMcRestart
         public boolean cacheAdvancedModels;
+
+        @Config.Comment("Reduces the RAM usage of the ASMDataTable by interning the Strings")
+        @Config.DefaultBoolean(true)
+        @Config.RequiresMcRestart
+        public boolean internASMDataTableStrings;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/HodgepodgeCore.java
@@ -82,6 +82,12 @@ public class HodgepodgeCore implements IFMLLoadingPlugin, IEarlyMixinLoader {
                 }
             }
         } catch (Exception ignored) {}
+
+        if (MemoryConfig.allocs.deduplicateASMDataTableStrings) {
+            String transformer = "com.mitchej123.hodgepodge.core.fml.transformers.early.ModCandidateTransformer";
+            FMLRelaunchLog.finer("Registering transformer %s", transformer);
+            Launch.classLoader.registerTransformer(transformer);
+        }
     }
 
     @Override

--- a/src/main/java/com/mitchej123/hodgepodge/core/fml/transformers/early/ModCandidateTransformer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/core/fml/transformers/early/ModCandidateTransformer.java
@@ -1,0 +1,150 @@
+package com.mitchej123.hodgepodge.core.fml.transformers.early;
+
+import java.util.ListIterator;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import com.gtnewhorizon.gtnhlib.asm.SafeClassWriter;
+import com.mitchej123.hodgepodge.core.shared.HodgepodgeClassDump;
+
+/**
+ * The targeted class is loaded too early by cofh/asm/LoadingPlugin$CoFHDummyContainer#call(), it's an IFMLCallHook
+ * which gets called before our ASM transformers are registered in the usual way. This is why we register this
+ * transformer manually when our IFMLLoadingPlugin is instantiated.
+ */
+public final class ModCandidateTransformer implements IClassTransformer, Opcodes {
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if (basicClass == null) return null;
+        if ("cpw.mods.fml.common.discovery.ModCandidate".equals(transformedName)) {
+            final byte[] transformedBytes = transformBytes(basicClass);
+            HodgepodgeClassDump.dumpClass(transformedName, basicClass, transformedBytes, this);
+            return transformedBytes;
+        }
+        return basicClass;
+    }
+
+    private static byte[] transformBytes(byte[] basicClass) {
+        final ClassReader cr = new ClassReader(basicClass);
+        final ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+
+        // add field
+        cn.visitField(
+                ACC_PRIVATE | ACC_FINAL,
+                "hp$packageSet",
+                "Ljava/util/Set;",
+                "Ljava/util/Set<Ljava/lang/String;>;",
+                null);
+
+        for (MethodNode method : cn.methods) {
+            if (method.name.equals("<init>") && method.desc
+                    .equals("(Ljava/io/File;Ljava/io/File;Lcpw/mods/fml/common/discovery/ContainerType;ZZ)V")) {
+                transformConstructor(method);
+            } else if (method.name.equals("addClassEntry") && method.desc.equals("(Ljava/lang/String;)V")) {
+                transformAddClassEntry(method);
+            } else if (method.name.equals("getContainedPackages") && method.desc.equals("()Ljava/util/List;")) {
+                transformGetContainedPackages(method);
+            }
+        }
+
+        final ClassWriter cw = new SafeClassWriter(cr, ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        cn.accept(cw);
+        return cw.toByteArray();
+    }
+
+    /**
+     * Injects at the end of the constructor : this.hp$packageSet = new HashSet<>();
+     */
+    private static void transformConstructor(MethodNode method) {
+        final ListIterator<AbstractInsnNode> it = method.instructions.iterator();
+        while (it.hasNext()) {
+            final AbstractInsnNode node = it.next();
+            if (node.getOpcode() == RETURN) {
+                final InsnList list = new InsnList();
+                list.add(new VarInsnNode(ALOAD, 0));
+                list.add(new TypeInsnNode(NEW, "java/util/HashSet"));
+                list.add(new InsnNode(DUP));
+                list.add(new MethodInsnNode(INVOKESPECIAL, "java/util/HashSet", "<init>", "()V", false));
+                list.add(
+                        new FieldInsnNode(
+                                PUTFIELD,
+                                "cpw/mods/fml/common/discovery/ModCandidate",
+                                "hp$packageSet",
+                                "Ljava/util/Set;"));
+                method.instructions.insertBefore(node, list);
+            }
+        }
+    }
+
+    /**
+     * Replaces the call : this.packages.add(pkg); with : this.hp$packageSet.add(pkg);
+     */
+    private static void transformAddClassEntry(MethodNode method) {
+        final ListIterator<AbstractInsnNode> it = method.instructions.iterator();
+        while (it.hasNext()) {
+            final AbstractInsnNode node = it.next();
+            if (node.getOpcode() == GETFIELD && node instanceof FieldInsnNode fn
+                    && fn.owner.equals("cpw/mods/fml/common/discovery/ModCandidate")
+                    && fn.name.equals("packages")
+                    && fn.desc.equals("Ljava/util/List;")) {
+                final AbstractInsnNode secondNode = node.getNext();
+                if (secondNode instanceof VarInsnNode) {
+                    final AbstractInsnNode thirdNode = secondNode.getNext();
+                    if (thirdNode.getOpcode() == INVOKEINTERFACE && thirdNode instanceof MethodInsnNode mn
+                            && mn.owner.equals("java/util/List")
+                            && mn.name.equals("add")
+                            && mn.desc.equals("(Ljava/lang/Object;)Z")) {
+                        fn.name = "hp$packageSet";
+                        fn.desc = "Ljava/util/Set;";
+                        mn.owner = "java/util/Set";
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Replaces the call : return packages; with : return new ArrayList<>(this.hp$packageSet);
+     */
+    private static void transformGetContainedPackages(MethodNode method) {
+        final ListIterator<AbstractInsnNode> it = method.instructions.iterator();
+        while (it.hasNext()) {
+            final AbstractInsnNode node = it.next();
+            if (node.getOpcode() == ALOAD && node instanceof VarInsnNode vn && vn.var == 0) {
+                final AbstractInsnNode nextNode = node.getNext();
+                if (nextNode.getOpcode() == GETFIELD && nextNode instanceof FieldInsnNode fn
+                        && fn.owner.equals("cpw/mods/fml/common/discovery/ModCandidate")
+                        && fn.name.equals("packages")
+                        && fn.desc.equals("Ljava/util/List;")) {
+                    fn.name = "hp$packageSet";
+                    fn.desc = "Ljava/util/Set;";
+                    method.instructions.insertBefore(node, new TypeInsnNode(NEW, "java/util/ArrayList"));
+                    method.instructions.insertBefore(node, new InsnNode(DUP));
+                    method.instructions.insert(
+                            nextNode,
+                            new MethodInsnNode(
+                                    INVOKESPECIAL,
+                                    "java/util/ArrayList",
+                                    "<init>",
+                                    "(Ljava/util/Collection;)V",
+                                    false));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1044,6 +1044,13 @@ public enum Mixins implements IMixins {
             .addCommonMixins("memory.MixinFakePlayerFactory_FixLeak")
             .setApplyIf(() -> MemoryConfig.leaks.fixForgePlayerFactoryLeak)
             .setPhase(Phase.EARLY)),
+    INTERN_ASMDATATABLE_STRINGS(new MixinBuilder()
+            .addCommonMixins(
+                    "fml.MixinEnumHolder_Intern",
+                    "fml.MixinModAnnotation_Intern",
+                    "fml.MixinASMData_Intern")
+            .setApplyIf(() -> MemoryConfig.allocs.internASMDataTableStrings)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1049,7 +1049,7 @@ public enum Mixins implements IMixins {
                     "fml.MixinEnumHolder_Intern",
                     "fml.MixinModAnnotation_Intern",
                     "fml.MixinASMData_Intern")
-            .setApplyIf(() -> MemoryConfig.allocs.internASMDataTableStrings)
+            .setApplyIf(() -> MemoryConfig.allocs.deduplicateASMDataTableStrings)
             .setPhase(Phase.EARLY)),
     // endregion
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinASMData_Intern.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinASMData_Intern.java
@@ -1,0 +1,30 @@
+package com.mitchej123.hodgepodge.mixins.early.fml;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mitchej123.hodgepodge.mixins.hooks.ASMDataStringPooler;
+
+import cpw.mods.fml.common.discovery.ASMDataTable;
+
+@Mixin(value = ASMDataTable.ASMData.class, remap = false)
+public class MixinASMData_Intern {
+
+    @Definition(
+            id = "annotationName",
+            field = "Lcpw/mods/fml/common/discovery/ASMDataTable$ASMData;annotationName:Ljava/lang/String;")
+    @Definition(
+            id = "className",
+            field = "Lcpw/mods/fml/common/discovery/ASMDataTable$ASMData;className:Ljava/lang/String;")
+    @Definition(
+            id = "objectName",
+            field = "Lcpw/mods/fml/common/discovery/ASMDataTable$ASMData;objectName:Ljava/lang/String;")
+    @Expression({ "this.annotationName = @(?)", "this.className = @(?)", "this.objectName = @(?)" })
+    @ModifyExpressionValue(method = "<init>", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private String intern(String original) {
+        return ASMDataStringPooler.intern(original);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEnumHolder_Intern.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinEnumHolder_Intern.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.fml;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mitchej123.hodgepodge.mixins.hooks.ASMDataStringPooler;
+
+import cpw.mods.fml.common.discovery.asm.ModAnnotation;
+
+@Mixin(value = ModAnnotation.EnumHolder.class, remap = false)
+public class MixinEnumHolder_Intern {
+
+    @Definition(
+            id = "desc",
+            field = "Lcpw/mods/fml/common/discovery/asm/ModAnnotation$EnumHolder;desc:Ljava/lang/String;")
+    @Definition(
+            id = "value",
+            field = "Lcpw/mods/fml/common/discovery/asm/ModAnnotation$EnumHolder;value:Ljava/lang/String;")
+    @Expression({ "this.desc = @(?)", "this.value = @(?)" })
+    @ModifyExpressionValue(method = "<init>", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private String intern(String original) {
+        return ASMDataStringPooler.intern(original);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinModAnnotation_Intern.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinModAnnotation_Intern.java
@@ -22,4 +22,13 @@ public class MixinModAnnotation_Intern {
     private String intern(String original) {
         return ASMDataStringPooler.intern(original);
     }
+
+    @Definition(id = "member", field = "Lcpw/mods/fml/common/discovery/asm/ModAnnotation;member:Ljava/lang/String;")
+    @Expression("this.member = @(?)")
+    @ModifyExpressionValue(
+            method = "<init>(Lcpw/mods/fml/common/discovery/asm/ASMModParser$AnnotationType;Lorg/objectweb/asm/Type;Ljava/lang/String;)V",
+            at = @At("MIXINEXTRAS:EXPRESSION"))
+    private String intern2(String original) {
+        return ASMDataStringPooler.intern(original);
+    }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinModAnnotation_Intern.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinModAnnotation_Intern.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.early.fml;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mitchej123.hodgepodge.mixins.hooks.ASMDataStringPooler;
+
+import cpw.mods.fml.common.discovery.asm.ModAnnotation;
+
+@Mixin(value = ModAnnotation.class, remap = false)
+public class MixinModAnnotation_Intern {
+
+    @Definition(id = "put", method = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")
+    @Definition(id = "values", field = "Lcpw/mods/fml/common/discovery/asm/ModAnnotation;values:Ljava/util/Map;")
+    @Expression("this.values.put(@(?), ?)")
+    @ModifyExpressionValue(
+            method = { "addProperty", "addEnumProperty", "endArray" },
+            at = @At("MIXINEXTRAS:EXPRESSION"))
+    private String intern(String original) {
+        return ASMDataStringPooler.intern(original);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinModAnnotation_Intern.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/fml/MixinModAnnotation_Intern.java
@@ -2,6 +2,7 @@ package com.mitchej123.hodgepodge.mixins.early.fml;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import com.llamalad7.mixinextras.expression.Definition;
 import com.llamalad7.mixinextras.expression.Expression;
@@ -30,5 +31,13 @@ public class MixinModAnnotation_Intern {
             at = @At("MIXINEXTRAS:EXPRESSION"))
     private String intern2(String original) {
         return ASMDataStringPooler.intern(original);
+    }
+
+    @ModifyVariable(method = "addProperty", at = @At("HEAD"), argsOnly = true, name = "arg2")
+    private Object intern2(Object original) {
+        if (original instanceof String s) {
+            return ASMDataStringPooler.intern(s);
+        }
+        return original;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/ASMDataStringPooler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/ASMDataStringPooler.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 
 public final class ASMDataStringPooler {
 
-    private static final ConcurrentHashMap<String, String> pool = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<String, String> pool = new ConcurrentHashMap<>();
 
     public static String intern(String s) {
         if (s == null) return null;
@@ -13,6 +13,6 @@ public final class ASMDataStringPooler {
     }
 
     public static void free() {
-        pool.clear();
+        pool = new ConcurrentHashMap<>();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/ASMDataStringPooler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/hooks/ASMDataStringPooler.java
@@ -1,0 +1,18 @@
+package com.mitchej123.hodgepodge.mixins.hooks;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public final class ASMDataStringPooler {
+
+    private static final ConcurrentHashMap<String, String> pool = new ConcurrentHashMap<>();
+
+    public static String intern(String s) {
+        if (s == null) return null;
+        return pool.computeIfAbsent(s, Function.identity());
+    }
+
+    public static void free() {
+        pool.clear();
+    }
+}

--- a/src/main/resources/mixins.hodgepodge.early.json
+++ b/src/main/resources/mixins.hodgepodge.early.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "minVersion": "0.8.3-GTNH",
+  "mixinextras": {"minVersion": "0.5.0"},
   "package": "com.mitchej123.hodgepodge.mixins.early",
   "refmap": "mixins.hodgepodge.refmap.json",
   "target": "@env(DEFAULT)",

--- a/src/main/resources/mixins.hodgepodge.json
+++ b/src/main/resources/mixins.hodgepodge.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "minVersion": "0.8.3-GTNH",
+  "mixinextras": {"minVersion": "0.5.0"},
   "refmap": "mixins.hodgepodge.refmap.json",
   "target": "@env(PREINIT)",
   "compatibilityLevel": "JAVA_8",

--- a/src/main/resources/mixins.hodgepodge.late.json
+++ b/src/main/resources/mixins.hodgepodge.late.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "minVersion": "0.8.3-GTNH",
+  "mixinextras": {"minVersion": "0.5.0"},
   "package": "com.mitchej123.hodgepodge.mixins.late",
   "refmap": "mixins.hodgepodge.refmap.json",
   "target": "@env(DEFAULT)",


### PR DESCRIPTION
Intern Strings stored in the ASMDataTable, also replaces the package List in `ModCandidate` with a Set to avoid storing the same package strings multiple times...

Saves around 40MB since a lot of the strings are duplicate.

One of the mixins is taken from archaic fix and the ASM transformer does the same thing as one of the archaicfix mixins which is disabled because the target class is loaded too early by cofh, so by turning it to an asm transformer we can fix it.

Before :
<img width="848" height="155" alt="image" src="https://github.com/user-attachments/assets/57e2a680-2fce-4fdf-a8f4-68161a625870" />

After :
<img width="845" height="158" alt="image" src="https://github.com/user-attachments/assets/df4ed0dc-62ac-4c67-a72e-dc0cb4279add" />
