### PR TITLE
Update MixinChunkProviderServer_DisableTerrain_EndlessIDs.java

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderServer_DisableTerrain_EndlessIDs.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinChunkProviderServer_DisableTerrain_EndlessIDs.java
@@ -41,7 +41,7 @@ public class MixinChunkProviderServer_DisableTerrain_EndlessIDs {
 
         short[] biomeArray = ((ChunkBiomeHook) chunk).getBiomeShortArray();
         Chunk newChunk = new Chunk(chunk.worldObj, ids, metadata, chunk.xPosition, chunk.zPosition);
-        ((ChunkBiomeHook) chunk).setBiomeShortArray(biomeArray);
+        ((ChunkBiomeHook) newChunk).setBiomeShortArray(biomeArray);
 
         return newChunk;
     }


### PR DESCRIPTION
thanks tiffit for the help

this fixes GOG worlds having no biomes. (ocean only)

this was presumably a typo from someone