### PR TITLE
Fix nbt string pooling mixin

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -517,12 +517,12 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> ASMConfig.speedupNBTTagCompoundCopy)
             .addExcludedMod(TargetedMod.BUKKIT)
             .setPhase(Phase.EARLY)),
-    STRING_POOLER_NBT_TAG(new MixinBuilder("Pool NBT Strings")
+    STRING_POOLER_NBT_TAG(new MixinBuilder()
             .addCommonMixins("minecraft.nbt.MixinNBTTagCompound_StringPooler")
             .setApplyIf(() -> TweaksConfig.enableTagCompoundStringPooling)
             .addExcludedMod(TargetedMod.DRAGONAPI)
             .setPhase(Phase.EARLY)),
-    STRING_POOLER_NBT_STRING(new MixinBuilder("Pool NBT Strings")
+    STRING_POOLER_NBT_STRING(new MixinBuilder()
             .addCommonMixins("minecraft.nbt.MixinNBTTagString_StringPooler")
             .setApplyIf(() -> TweaksConfig.enableNBTStringPooling)
             .setPhase(Phase.EARLY)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/nbt/MixinNBTTagCompound_StringPooler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/nbt/MixinNBTTagCompound_StringPooler.java
@@ -5,16 +5,22 @@ import net.minecraft.nbt.NBTTagCompound;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.mitchej123.hodgepodge.util.StringPooler;
 
 @Mixin(NBTTagCompound.class)
 public class MixinNBTTagCompound_StringPooler {
 
+    @Definition(id = "tagMap", field = "Lnet/minecraft/nbt/NBTTagCompound;tagMap:Ljava/util/Map;")
+    @Definition(id = "put", method = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")
+    @Expression("this.tagMap.put(@(?), ?)")
     @ModifyExpressionValue(
-            method = "func_152448_b",
-            at = @At(value = "INVOKE", target = "Ljava/io/DataInput;readUTF()Ljava/lang/String;"))
-    private static String poolString(String s) {
+            method = { "func_152446_a", "setTag", "setByte", "setShort", "setInteger", "setLong", "setFloat",
+                    "setDouble", "setString", "setByteArray", "setIntArray" },
+            at = @At("MIXINEXTRAS:EXPRESSION"))
+    private String poolString(String s) {
         // Pool the keys, they're likely to be reused a lot
         return StringPooler.INSTANCE.getString(s);
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/nbt/MixinNBTTagString_StringPooler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/nbt/MixinNBTTagString_StringPooler.java
@@ -3,29 +3,22 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft.nbt;
 import net.minecraft.nbt.NBTTagString;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.mitchej123.hodgepodge.util.StringPooler;
 
 @Mixin(NBTTagString.class)
 public class MixinNBTTagString_StringPooler {
 
-    @Shadow
-    private String data;
-
-    @Inject(method = "Lnet/minecraft/nbt/NBTTagString;<init>(Ljava/lang/String;)V", at = @At("RETURN"))
-    private void poolStringInit(CallbackInfo ci) {
-        this.data = StringPooler.INSTANCE.getString(this.data);
-    }
-
+    @Definition(id = "data", field = "Lnet/minecraft/nbt/NBTTagString;data:Ljava/lang/String;")
+    @Expression("this.data = @(?)")
     @ModifyExpressionValue(
-            method = "func_152446_a",
-            at = @At(value = "INVOKE", target = "Ljava/io/DataInput;readUTF()Ljava/lang/String;"))
-    private String poolStringLoad(String s) {
-        return StringPooler.INSTANCE.getString(s);
+            method = { "<init>(Ljava/lang/String;)V", "func_152446_a" },
+            at = @At("MIXINEXTRAS:EXPRESSION"))
+    private String poolString(String original) {
+        return StringPooler.INSTANCE.getString(original);
     }
 }


### PR DESCRIPTION
The mixin to pool the keys of NBTTags was injecting in the deserializing code which means it only had effect on NBTTags that were created from deserialization.
I changed the mixins to take effect on all hashmap insertion `this.tagMap.put(@(?), ?)`.

Also changed the mixin for NBTString to use mixin expression

Tested in full pack