### PR TITLE
Fix BOP colorized sapling icon when growth stage bit is set in meta

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -569,6 +569,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixBoPEid;
 
+    @Config.Comment("Fix BOP sapling icon showing the wrong type when the growth stage bit is set in meta")
+    @Config.DefaultBoolean(true)
+    public static boolean fixBOPSaplingIcon;
+
     // Candycraft
 
     @Config.Comment("Fix NPE when interacting with sugar block")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1453,6 +1453,11 @@ public enum Mixins implements IMixins {
             .addRequiredMod(TargetedMod.BOP)
             .addRequiredMod(TargetedMod.ENDLESSIDS)
             .setPhase(Phase.LATE)),
+    FIX_BOP_SAPLING_ICON(new MixinBuilder("Fix BOP sapling icon when growth stage bit is set in meta")
+            .addCommonMixins("biomesoplenty.MixinBlockBOPColorizedSapling_FixIcon")
+            .setApplyIf(() -> FixesConfig.fixBOPSaplingIcon)
+            .addRequiredMod(TargetedMod.BOP)
+            .setPhase(Phase.LATE)),
 
     // Bibliowood Recipe Fix
     BIBLIOWOODS_RECIPE_FIX(new MixinBuilder("Fixes Bibliowoods Forestry recipes")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/biomesoplenty/MixinBlockBOPColorizedSapling_FixIcon.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/biomesoplenty/MixinBlockBOPColorizedSapling_FixIcon.java
@@ -1,0 +1,16 @@
+package com.mitchej123.hodgepodge.mixins.late.biomesoplenty;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import biomesoplenty.common.blocks.BlockBOPColorizedSapling;
+
+@Mixin(BlockBOPColorizedSapling.class)
+public class MixinBlockBOPColorizedSapling_FixIcon {
+
+    @ModifyVariable(method = "func_149691_a", at = @At("HEAD"), argsOnly = true, index = 2)
+    private int hodgepodge$maskMetaGrowthBit(int meta) {
+        return meta & 7;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/biomesoplenty/MixinBlockBOPColorizedSapling_FixIcon.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/biomesoplenty/MixinBlockBOPColorizedSapling_FixIcon.java
@@ -9,7 +9,7 @@ import biomesoplenty.common.blocks.BlockBOPColorizedSapling;
 @Mixin(BlockBOPColorizedSapling.class)
 public class MixinBlockBOPColorizedSapling_FixIcon {
 
-    @ModifyVariable(method = "func_149691_a", at = @At("HEAD"), argsOnly = true, index = 2)
+    @ModifyVariable(method = "getIcon", at = @At("HEAD"), argsOnly = true, index = 2)
     private int hodgepodge$maskMetaGrowthBit(int meta) {
         return meta & 7;
     }


### PR DESCRIPTION
## Summary

BOP's `BlockBOPColorizedSapling` uses block metadata to determine which sapling icon to render. The metadata stores both the sapling type (bits 0–2) and the growth stage flag (bit 3). However, the icon lookup uses the raw metadata value directly:

```java
public IIcon func_149691_a(int side, int meta) {
   if (meta < 0 || meta >= saplings.length) {
      meta = 0;
   }

   return this.textures[meta];
}
```

Once a sapling receives a growth tick, bit 3 becomes set. This increases the metadata value beyond the valid sapling index range, causing the lookup to fail the bounds check and fall back to index `0` (Sacred Oak). As a result, every sapling from this block class starts rendering as Sacred Oak after its first growth tick, regardless of its actual type.

This fix adds a mixin that masks out the growth-stage bit before the texture lookup, ensuring the icon selection only uses the sapling type bits and remains correct across all growth stages.

Closes GTNewHorizons/GT-New-Horizons-Modpack#15244

> #15244 was previously closed as a duplicate of GTNewHorizons/GT-New-Horizons-Modpack#23500. These appear to be separate issues, so #15244 was reopened — this PR fixes the visual rendering issue tracked there.
