### PR TITLE
Fix enchant glint being applied on every render pass

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -488,6 +488,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean deepCopyDataWatcherInSP;
 
+    @Config.Comment("Fix the enchant glint being applied multiple times for items with multiple render passes")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixMultipleEnchantGlint;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1077,6 +1077,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("fml.MixinUniqueIdentifier_Intern")
             .setApplyIf(() -> MemoryConfig.allocs.internUniqueIdentifierModid)
             .setPhase(Phase.EARLY)),
+    FIX_MULTIPLE_ENCHANT_GLINT(new MixinBuilder()
+            .addClientMixins("minecraft.MixinItem_EnchantGlint")
+            .setApplyIf(() -> FixesConfig.fixMultipleEnchantGlint)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItem_EnchantGlint.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItem_EnchantGlint.java
@@ -5,9 +5,7 @@ import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemStack;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.Overwrite;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -18,15 +16,14 @@ public abstract class MixinItem_EnchantGlint {
     /**
      * @author koolkrafter5
      * @reason Prevent enchantment glint from rendering once per render pass. Only render it on the final pass for all
-     *         items. Potions are special and have it on the first pass so only the liquid has the glint.
+     *         items. Rendering it earlier causes it to be behind later passes. Potions are special and have it on the
+     *         first pass so only the liquid has the glint (matches overwritten vanilla logic).
      */
-    @Inject(method = "hasEffect(Lnet/minecraft/item/ItemStack;I)Z", at = @At("HEAD"), cancellable = true, remap = false)
+    @Overwrite(remap = false)
     @SideOnly(Side.CLIENT)
-    private void fixGlint(ItemStack stack, int pass, CallbackInfoReturnable<Boolean> cir) {
-        Item item = (Item) (Object) this;
-        cir.setReturnValue(
-                stack != null && item.hasEffect(stack)
-                        && (item instanceof ItemPotion ? pass == 0
-                                : pass == item.getRenderPasses(stack.getItemDamage()) - 1));
+    public boolean hasEffect(ItemStack stack, int pass) {
+        final Item item = (Item) (Object) this;
+        return stack != null && item.hasEffect(stack)
+                && (item instanceof ItemPotion ? pass == 0 : pass == item.getRenderPasses(stack.getItemDamage()) - 1);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItem_EnchantGlint.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinItem_EnchantGlint.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemPotion;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@Mixin(Item.class)
+public abstract class MixinItem_EnchantGlint {
+
+    /**
+     * @author koolkrafter5
+     * @reason Prevent enchantment glint from rendering once per render pass. Only render it on the final pass for all
+     *         items. Potions are special and have it on the first pass so only the liquid has the glint.
+     */
+    @Inject(method = "hasEffect(Lnet/minecraft/item/ItemStack;I)Z", at = @At("HEAD"), cancellable = true, remap = false)
+    @SideOnly(Side.CLIENT)
+    private void fixGlint(ItemStack stack, int pass, CallbackInfoReturnable<Boolean> cir) {
+        Item item = (Item) (Object) this;
+        cir.setReturnValue(
+                stack != null && item.hasEffect(stack)
+                        && (item instanceof ItemPotion ? pass == 0
+                                : pass == item.getRenderPasses(stack.getItemDamage()) - 1));
+    }
+}


### PR DESCRIPTION
It would apply the glint on any item with multiple render passes on every pass.
Now it just does it on the last one.

Look at the leather tunic and firework star. Coal and enchanted book are the same and potion has special logic for only the liquid to get the glint, which is preserved.

Old:

https://github.com/user-attachments/assets/bf408d42-0648-437b-b975-8ea8c94a1912

New:

https://github.com/user-attachments/assets/3d0d1d25-c8e7-40e8-a58a-94fdec835dbc


