### PR TITLE
Fix GL_ALPHA_TEST and potion effect HUD rendering

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/IHodgepodgePotionPanelRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/IHodgepodgePotionPanelRenderer.java
@@ -1,6 +1,0 @@
-package com.mitchej123.hodgepodge.client;
-
-public interface IHodgepodgePotionPanelRenderer {
-
-    void hodgepodge$renderPotionPanelForeground();
-}

--- a/src/main/java/com/mitchej123/hodgepodge/client/IHodgepodgePotionPanelRenderer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/IHodgepodgePotionPanelRenderer.java
@@ -1,0 +1,6 @@
+package com.mitchej123.hodgepodge.client;
+
+public interface IHodgepodgePotionPanelRenderer {
+
+    void hodgepodge$renderPotionPanelForeground();
+}

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -197,6 +197,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixPotionEffectAlphaTest;
 
+    @Config.Comment("Fix creative tab backgrounds showing black corners when alpha test is left disabled by item rendering (Forge GL state bug)")
+    @Config.DefaultBoolean(true)
+    public static boolean fixCreativeTabAlphaTest;
+
     @Config.Comment("Fix potions >= 128")
     @Config.DefaultBoolean(true)
     public static boolean fixPotionLimit;

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -193,6 +193,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixPotionIterating;
 
+    @Config.Comment("Fix potion effect panel rendering glitched when certain items are held on the cursor (Forge GL state bug)")
+    @Config.DefaultBoolean(true)
+    public static boolean fixPotionEffectAlphaTest;
+
     @Config.Comment("Fix potions >= 128")
     @Config.DefaultBoolean(true)
     public static boolean fixPotionLimit;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -186,7 +186,9 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> !TweaksConfig.showInventoryEffectIcons)
             .setPhase(Phase.EARLY)),
     FIX_POTION_EFFECT_RENDERING(new MixinBuilder()
-            .addClientMixins("minecraft.MixinInventoryEffectRenderer_PotionEffectRendering")
+            .addClientMixins(
+                    "minecraft.MixinInventoryEffectRenderer_PotionEffectRendering",
+                    "minecraft.MixinGuiContainer_PotionEffectRendering")
             .setApplyIf(() -> TweaksConfig.fixPotionEffectRender)
             .setPhase(Phase.EARLY)),
     FIX_POTION_EFFECT_ALPHA_TEST(new MixinBuilder("Fix potion effect panel visual glitch caused by Forge leaving GL_ALPHA_TEST disabled after item rendering")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -193,6 +193,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinInventoryEffectRenderer_AlphaTestFix")
             .setApplyIf(() -> FixesConfig.fixPotionEffectAlphaTest)
             .setPhase(Phase.EARLY)),
+    FIX_CREATIVE_TAB_ALPHA_TEST(new MixinBuilder("Fix creative tab background black corners caused by Forge leaving GL_ALPHA_TEST disabled after item rendering")
+            .addClientMixins("minecraft.MixinGuiContainerCreative_AlphaTestFix")
+            .setApplyIf(() -> FixesConfig.fixCreativeTabAlphaTest)
+            .setPhase(Phase.EARLY)),
     FIX_IMMOBILE_FIREBALLS(new MixinBuilder()
             .addCommonMixins("minecraft.MixinEntityFireball")
             .setApplyIf(() -> FixesConfig.fixImmobileFireballs)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -189,6 +189,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinInventoryEffectRenderer_PotionEffectRendering")
             .setApplyIf(() -> TweaksConfig.fixPotionEffectRender)
             .setPhase(Phase.EARLY)),
+    FIX_POTION_EFFECT_ALPHA_TEST(new MixinBuilder("Fix potion effect panel visual glitch caused by Forge leaving GL_ALPHA_TEST disabled after item rendering")
+            .addClientMixins("minecraft.MixinInventoryEffectRenderer_AlphaTestFix")
+            .setApplyIf(() -> FixesConfig.fixPotionEffectAlphaTest)
+            .setPhase(Phase.EARLY)),
     FIX_IMMOBILE_FIREBALLS(new MixinBuilder()
             .addCommonMixins("minecraft.MixinEntityFireball")
             .setApplyIf(() -> FixesConfig.fixImmobileFireballs)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainerCreative_AlphaTestFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainerCreative_AlphaTestFix.java
@@ -10,12 +10,11 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * func_147051_a renders one creative tab (background + icon). The icon render calls
- * RenderItem.renderItemIntoGUI which leaves GL_ALPHA_TEST disabled (Forge bug). When
- * the loop over non-selected tabs finishes, the main panel background is drawn next;
- * its transparent cut-outs where adjacent tabs protrude render as black because alpha
- * test is still off. Re-enabling alpha test on every exit of func_147051_a restores the
- * expected state before the main background drawTexturedModalRect.
+ * func_147051_a renders one creative tab (background + icon). The icon render calls RenderItem.renderItemIntoGUI which
+ * leaves GL_ALPHA_TEST disabled (Forge bug). When the loop over non-selected tabs finishes, the main panel background
+ * is drawn next; its transparent cut-outs where adjacent tabs protrude render as black because alpha test is still off.
+ * Re-enabling alpha test on every exit of func_147051_a restores the expected state before the main background
+ * drawTexturedModalRect.
  */
 @Mixin(GuiContainerCreative.class)
 public abstract class MixinGuiContainerCreative_AlphaTestFix {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainerCreative_AlphaTestFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainerCreative_AlphaTestFix.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
+import net.minecraft.creativetab.CreativeTabs;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * func_147051_a renders one creative tab (background + icon). The icon render calls
+ * RenderItem.renderItemIntoGUI which leaves GL_ALPHA_TEST disabled (Forge bug). When
+ * the loop over non-selected tabs finishes, the main panel background is drawn next;
+ * its transparent cut-outs where adjacent tabs protrude render as black because alpha
+ * test is still off. Re-enabling alpha test on every exit of func_147051_a restores the
+ * expected state before the main background drawTexturedModalRect.
+ */
+@Mixin(GuiContainerCreative.class)
+public abstract class MixinGuiContainerCreative_AlphaTestFix {
+
+    @Inject(method = "func_147051_a", at = @At("RETURN"))
+    private void hodgepodge$restoreAlphaTestAfterTabRender(CreativeTabs tab, CallbackInfo ci) {
+        GL11.glEnable(GL11.GL_ALPHA_TEST);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainer_PotionEffectRendering.java
@@ -1,7 +1,5 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -9,18 +7,22 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
+
 /**
- * Injects the potion panel render into GuiContainer.drawScreen immediately after the
- * drawGuiContainerForegroundLayer call. This fires for every InventoryEffectRenderer subclass
- * regardless of what it overrides, and places the panel correctly before the cursor item and tooltips.
+ * Injects the potion panel render into GuiContainer.drawScreen immediately after the drawGuiContainerForegroundLayer
+ * call. This fires for every InventoryEffectRenderer subclass regardless of what it overrides, and places the panel
+ * correctly before the cursor item and tooltips.
  */
 @Mixin(GuiContainer.class)
 public abstract class MixinGuiContainer_PotionEffectRendering {
 
-    @Inject(method = "drawScreen",
-            at = @At(value = "INVOKE",
-                     target = "Lnet/minecraft/client/gui/inventory/GuiContainer;drawGuiContainerForegroundLayer(II)V",
-                     shift = At.Shift.AFTER))
+    @Inject(
+            method = "drawScreen",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/inventory/GuiContainer;drawGuiContainerForegroundLayer(II)V",
+                    shift = At.Shift.AFTER))
     private void hodgepodge$renderPotionPanelAfterForeground(int mouseX, int mouseY, float partialTicks,
             CallbackInfo ci) {
         if (this instanceof IHodgepodgePotionPanelRenderer) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainer_PotionEffectRendering.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
+import com.mitchej123.hodgepodge.mixins.interfaces.InventoryEffectRendererExt;
 
 /**
  * Injects the potion panel render into GuiContainer.drawScreen immediately after the drawGuiContainerForegroundLayer
@@ -25,8 +25,8 @@ public abstract class MixinGuiContainer_PotionEffectRendering {
                     shift = At.Shift.AFTER))
     private void hodgepodge$renderPotionPanelAfterForeground(int mouseX, int mouseY, float partialTicks,
             CallbackInfo ci) {
-        if (this instanceof IHodgepodgePotionPanelRenderer) {
-            ((IHodgepodgePotionPanelRenderer) this).hodgepodge$renderPotionPanelForeground();
+        if (this instanceof InventoryEffectRendererExt) {
+            ((InventoryEffectRendererExt) this).hp$renderPotionPanelForeground();
         }
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiContainer_PotionEffectRendering.java
@@ -1,0 +1,30 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Injects the potion panel render into GuiContainer.drawScreen immediately after the
+ * drawGuiContainerForegroundLayer call. This fires for every InventoryEffectRenderer subclass
+ * regardless of what it overrides, and places the panel correctly before the cursor item and tooltips.
+ */
+@Mixin(GuiContainer.class)
+public abstract class MixinGuiContainer_PotionEffectRendering {
+
+    @Inject(method = "drawScreen",
+            at = @At(value = "INVOKE",
+                     target = "Lnet/minecraft/client/gui/inventory/GuiContainer;drawGuiContainerForegroundLayer(II)V",
+                     shift = At.Shift.AFTER))
+    private void hodgepodge$renderPotionPanelAfterForeground(int mouseX, int mouseY, float partialTicks,
+            CallbackInfo ci) {
+        if (this instanceof IHodgepodgePotionPanelRenderer) {
+            ((IHodgepodgePotionPanelRenderer) this).hodgepodge$renderPotionPanelForeground();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_AlphaTestFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_AlphaTestFix.java
@@ -9,9 +9,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * Forge's RenderItem.renderItemIntoGUI disables GL_ALPHA_TEST after rendering flat 2D items but
- * InventoryEffectRenderer never re-enables it, so the transparent corners of the potion-effect
- * background panel render as opaque rectangles.
+ * Forge's RenderItem.renderItemIntoGUI disables GL_ALPHA_TEST after rendering flat 2D items but InventoryEffectRenderer
+ * never re-enables it, so the transparent corners of the potion-effect background panel render as opaque rectangles.
  */
 @Mixin(InventoryEffectRenderer.class)
 public abstract class MixinInventoryEffectRenderer_AlphaTestFix {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_AlphaTestFix.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_AlphaTestFix.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.renderer.InventoryEffectRenderer;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Forge's RenderItem.renderItemIntoGUI disables GL_ALPHA_TEST after rendering flat 2D items but
+ * InventoryEffectRenderer never re-enables it, so the transparent corners of the potion-effect
+ * background panel render as opaque rectangles.
+ */
+@Mixin(InventoryEffectRenderer.class)
+public abstract class MixinInventoryEffectRenderer_AlphaTestFix {
+
+    @Inject(method = "func_147044_g", at = @At("HEAD"))
+    private void hodgepodge$enableAlphaTestForPotionPanel(CallbackInfo ci) {
+        GL11.glEnable(GL11.GL_ALPHA_TEST);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -1,48 +1,43 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import net.minecraft.client.gui.FontRenderer;
+import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 import net.minecraft.inventory.Container;
-import net.minecraft.item.ItemStack;
 
+import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
-import com.mitchej123.hodgepodge.Compat;
-
 @Mixin(InventoryEffectRenderer.class)
-public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends GuiContainer {
+public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends GuiContainer
+        implements IHodgepodgePotionPanelRenderer {
 
     @Shadow
     private void func_147044_g() {}
 
     /**
      * @author Alexdoru
-     * @reason Fix the bug that renders the potion effects above the tooltips from items in NEI. Fix the vanilla bug that
-     *         doesn't render the potion effects that you get while your inventory is opened.
+     * @reason Suppress vanilla's post-drawScreen call to func_147044_g (gated on field_147045_u which is only set at
+     *         initGui, missing effects gained while the GUI is open). The panel is rendered via
+     *         MixinGuiContainer_PotionEffectRendering which injects into GuiContainer.drawScreen after
+     *         drawGuiContainerForegroundLayer, giving correct z-ordering before the cursor item and tooltips.
      */
     @Overwrite
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
-        boolean leftPanelHidden = !Compat.isNeiLeftPanelVisible();
-        if (leftPanelHidden) {
-            super.drawScreen(mouseX, mouseY, partialTicks);
-        }
-        if (!this.mc.thePlayer.getActivePotionEffects().isEmpty()) {
-            this.func_147044_g();
-        }
-        if (leftPanelHidden) {
-            // renderItemOverlayIntoGUI skips depth writes, so the panel covers the count; re-render it after.
-            ItemStack cursorItem = this.mc.thePlayer.inventory.getItemStack();
-            if (cursorItem != null) {
-                FontRenderer font = cursorItem.getItem().getFontRenderer(cursorItem);
-                if (font == null) font = this.fontRendererObj;
-                itemRender.renderItemOverlayIntoGUI(font, this.mc.getTextureManager(), cursorItem, mouseX - 8, mouseY - 8, null);
-            }
-            return;
-        }
         super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public void hodgepodge$renderPotionPanelForeground() {
+        if (!this.mc.thePlayer.getActivePotionEffects().isEmpty()) {
+            GL11.glPushMatrix();
+            GL11.glTranslatef(-this.guiLeft, -this.guiTop, 0.0F);
+            this.func_147044_g();
+            GL11.glPopMatrix();
+        }
     }
 
     /* Forced to have constructor matching super */

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -1,8 +1,5 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import com.mitchej123.hodgepodge.Compat;
-import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 import net.minecraft.inventory.Container;
@@ -11,6 +8,9 @@ import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+
+import com.mitchej123.hodgepodge.Compat;
+import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
 
 @Mixin(InventoryEffectRenderer.class)
 public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends GuiContainer

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -10,11 +10,11 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
 import com.mitchej123.hodgepodge.Compat;
-import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
+import com.mitchej123.hodgepodge.mixins.interfaces.InventoryEffectRendererExt;
 
 @Mixin(InventoryEffectRenderer.class)
 public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends GuiContainer
-        implements IHodgepodgePotionPanelRenderer {
+        implements InventoryEffectRendererExt {
 
     @Shadow
     private void func_147044_g() {}
@@ -36,7 +36,7 @@ public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends
     }
 
     @Override
-    public void hodgepodge$renderPotionPanelForeground() {
+    public void hp$renderPotionPanelForeground() {
         if (Compat.isNeiLeftPanelVisible()) return;
         if (!this.mc.thePlayer.getActivePotionEffects().isEmpty()) {
             GL11.glPushMatrix();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -1,5 +1,6 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import com.mitchej123.hodgepodge.Compat;
 import com.mitchej123.hodgepodge.client.IHodgepodgePotionPanelRenderer;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -21,17 +22,22 @@ public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends
     /**
      * @author Alexdoru
      * @reason Suppress vanilla's post-drawScreen call to func_147044_g (gated on field_147045_u which is only set at
-     *         initGui, missing effects gained while the GUI is open). The panel is rendered via
-     *         MixinGuiContainer_PotionEffectRendering which injects into GuiContainer.drawScreen after
-     *         drawGuiContainerForegroundLayer, giving correct z-ordering before the cursor item and tooltips.
+     *         initGui, missing effects gained while the GUI is open). When the NEI panel is visible the panel is
+     *         pre-rendered here before super.drawScreen so drawDefaultBackground's dark overlay naturally covers it,
+     *         matching the original "background" appearance. Otherwise rendering is deferred to
+     *         MixinGuiContainer_PotionEffectRendering for correct z-ordering before the cursor item and tooltips.
      */
     @Overwrite
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        if (Compat.isNeiLeftPanelVisible() && !this.mc.thePlayer.getActivePotionEffects().isEmpty()) {
+            this.func_147044_g();
+        }
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
 
     @Override
     public void hodgepodge$renderPotionPanelForeground() {
+        if (Compat.isNeiLeftPanelVisible()) return;
         if (!this.mc.thePlayer.getActivePotionEffects().isEmpty()) {
             GL11.glPushMatrix();
             GL11.glTranslatef(-this.guiLeft, -this.guiTop, 0.0F);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinInventoryEffectRenderer_PotionEffectRendering.java
@@ -1,8 +1,10 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.InventoryEffectRenderer;
 import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -18,8 +20,8 @@ public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends
 
     /**
      * @author Alexdoru
-     * @reason Fix the bug that renders the potion effects above the tooltips from items in NEI Fix the vanilla bug that
-     *         doesn't render the potion effects that you get while your inventory is opened
+     * @reason Fix the bug that renders the potion effects above the tooltips from items in NEI. Fix the vanilla bug that
+     *         doesn't render the potion effects that you get while your inventory is opened.
      */
     @Overwrite
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
@@ -31,6 +33,13 @@ public abstract class MixinInventoryEffectRenderer_PotionEffectRendering extends
             this.func_147044_g();
         }
         if (leftPanelHidden) {
+            // renderItemOverlayIntoGUI skips depth writes, so the panel covers the count; re-render it after.
+            ItemStack cursorItem = this.mc.thePlayer.inventory.getItemStack();
+            if (cursorItem != null) {
+                FontRenderer font = cursorItem.getItem().getFontRenderer(cursorItem);
+                if (font == null) font = this.fontRendererObj;
+                itemRender.renderItemOverlayIntoGUI(font, this.mc.getTextureManager(), cursorItem, mouseX - 8, mouseY - 8, null);
+            }
             return;
         }
         super.drawScreen(mouseX, mouseY, partialTicks);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/InventoryEffectRendererExt.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/InventoryEffectRendererExt.java
@@ -1,0 +1,6 @@
+package com.mitchej123.hodgepodge.mixins.interfaces;
+
+public interface InventoryEffectRendererExt {
+
+    void hp$renderPotionPanelForeground();
+}


### PR DESCRIPTION
## Problem

Forge's `RenderItem.renderItemIntoGUI` leaves `GL_ALPHA_TEST` disabled after rendering certain flat 2D items. This caused two separate visual bugs:

1. **Potion effect panel glitch** — when flat 2D items (e.g. vanilla saplings) were held on the cursor, the transparent areas of the potion effect panel background rendered as opaque rectangles, corrupting the panel's appearance.

2. **Creative inventory tab black corners** — when the Survival Inventory tab was selected in the creative menu, the main panel background had black pixels where adjacent tabs protrude, because alpha test was still disabled from the previous tab icon render.

Additionally, the existing potion panel rendering had two z-ordering issues:

3. **Cursor stack count hidden below panel** — `renderItemOverlayIntoGUI` renders the stack count with depth test disabled, leaving no depth write. The panel rendered afterward passed the depth test in that area and drew over the count.

4. **Delete tooltip overlay hidden below panel** — the panel rendered after `GuiContainer.drawScreen` completed, covering tooltips (including NEI's "Delete Item" label) that should appear above it.

## Fix

- **`MixinInventoryEffectRenderer_AlphaTestFix`** — `@Inject` at HEAD of `InventoryEffectRenderer.func_147044_g` to re-enable `GL_ALPHA_TEST` before the panel renders.

- **`MixinGuiContainerCreative_AlphaTestFix`** — `@Inject` at RETURN of `GuiContainerCreative.func_147051_a` to re-enable `GL_ALPHA_TEST` after each tab icon render.

- **`MixinInventoryEffectRenderer_PotionEffectRendering`** + **`MixinGuiContainer_PotionEffectRendering`** — reworks the panel rendering timing:
  - When the NEI item panel is **visible**: `func_147044_g` is called *before* `super.drawScreen()` so `drawDefaultBackground`'s dark world overlay naturally covers it, preserving the original "background" appearance.
  - When the NEI item panel is **hidden**: the panel is rendered via a hook in `GuiContainer.drawScreen` immediately after `drawGuiContainerForegroundLayer`, placing it correctly before the cursor item and all tooltips. This also naturally fixes the stack count z-ordering since the panel now renders before the cursor item draws anything to the depth buffer.

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11259

## Preview
### 1. Before
<img width="561" height="188" alt="image" src="https://github.com/user-attachments/assets/c1726be5-fc16-4271-808b-941dcf9a79b6" />

### 1. After
<img width="561" height="188" alt="image" src="https://github.com/user-attachments/assets/8c387a39-5785-4b65-97e0-4d4a43723508" />

### 2. Before
<img width="666" height="698" alt="image" src="https://github.com/user-attachments/assets/c7ef6dcf-fb65-476f-92b4-c6c5fa648089" />

### 2. After
<img width="666" height="698" alt="image" src="https://github.com/user-attachments/assets/e435126f-4398-44fe-b207-7d0387d0bf66" />

### 3. and 4. Before
<img width="453" height="166" alt="image" src="https://github.com/user-attachments/assets/f6ed402e-4a36-4310-890a-01dfe6fc1709" />

### 3. and 4. After
<img width="453" height="166" alt="image" src="https://github.com/user-attachments/assets/a4de3fdb-f5fa-4a75-920a-70b8cd137bd1" />

