### PR TITLE
disable interning by default

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/MemoryConfig.java
@@ -140,17 +140,17 @@ public class MemoryConfig {
         public boolean cacheAdvancedModels;
 
         @Config.Comment("Reduces the RAM usage of the ASMDataTable by interning the Strings")
-        @Config.DefaultBoolean(true)
+        @Config.DefaultBoolean(false)
         @Config.RequiresMcRestart
         public boolean deduplicateASMDataTableStrings;
 
         @Config.Comment("Reduce the memory usage from resource location domain strings")
-        @Config.DefaultBoolean(true)
+        @Config.DefaultBoolean(false)
         @Config.RequiresMcRestart
         public boolean internResourceLocationDomain;
 
         @Config.Comment("Reduce the memory usage from unique identifier modid strings")
-        @Config.DefaultBoolean(true)
+        @Config.DefaultBoolean(false)
         @Config.RequiresMcRestart
         public boolean internUniqueIdentifierModid;
     }


### PR DESCRIPTION
Disabling the interning makes 45MBs back in memory, but it saves like 8s on my boot time with dailies. So let's make it optional in, so people in need for memory reduction can chose to trade boot time for memory reduction.