### PR TITLE
lower frequency of thaum arcane bore cvis checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Hodgepodge is LGPL-3.
 - Thaumcraft: Aspects are sorted by localized name instead of internal tag.
 - Thaumcraft: Golems function in dimensions higher than 255.
 - Thaumcraft: Wand Recharge Pedestals accept Centivis.
+- Thaumcraft: Arcane Bore cvis source lookup choked. 
 - Traveller's Gear: Return items that were placed in TG slots after the mod is removed.
 - VoxelMap: The file extension is changed from .zip to .data to stop an adverse reaction with the Technic launcher.
 - VoxelMap: The Y coordinate is no longer off by one.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -79,6 +79,24 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.mockito:mockito-core:5.+")
+
+
+    // For /nbtEdit command
+    //devOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.2.36") { transitive = false }
+
+
+    //devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") {transitive = false}
+    //devOnlyNonPublishable('com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev') {transitive = false} // For testing Thaumcraft
+
+    // Replace Baubles with Baubles-Expanded for testing Thaumcraft and other that dep on it
+    project.getConfigurations().configureEach(c -> {
+        final DependencySubstitutions ds = c.getResolutionStrategy()
+                .getDependencySubstitution()
+        ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
+                .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH"))
+                .withClassifier("dev")
+                .because("Baubles-Expanded replaces Baubles")
+    })
 }
 
 // Replace when RFG support deobfuscation from notch mappings

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -854,6 +854,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixThaumcraftEE3Check;
 
+    @Config.Comment("Lower frequency of Thaumcraft's Arcane Bore calls to drain vis, and therefore calls to find vis nets.")
+    @Config.DefaultBoolean(true)
+    public static boolean fixArcaneBoreCVisSourceLookup;
+
     // Thermal Dynamics
 
     @Config.Comment("Prevent crash with Thermal Dynamics from Negative Array Exceptions from item duct transfers")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1390,7 +1390,7 @@ public enum Mixins implements IMixins {
             .addRequiredMod(TargetedMod.THAUMCRAFT)
             .setPhase(Phase.LATE)),
     THAUM_BORE_VIS_DRAIN_FREQUENCY(new MixinBuilder()
-            .addCommonMixins("MixinBoreVisFrequencyReduction")
+            .addCommonMixins("thaumcraft.MixinBoreVisFrequencyReduction")
             .setApplyIf(() -> FixesConfig.fixArcaneBoreCVisSourceLookup)
             .addRequiredMod(TargetedMod.THAUMCRAFT)
             .setPhase(Phase.LATE)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1389,6 +1389,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixThaumcraftEE3Check)
             .addRequiredMod(TargetedMod.THAUMCRAFT)
             .setPhase(Phase.LATE)),
+    THAUM_BORE_VIS_DRAIN_FREQUENCY(new MixinBuilder()
+            .addCommonMixins("MixinBoreVisFrequencyReduction")
+            .setApplyIf(() -> FixesConfig.fixArcaneBoreCVisSourceLookup)
+            .addRequiredMod(TargetedMod.THAUMCRAFT)
+            .setPhase(Phase.LATE)),
 
     // BOP
     FIX_QUICKSAND_XRAY(new MixinBuilder()

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinBoreVisFrequencyReduction.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinBoreVisFrequencyReduction.java
@@ -43,10 +43,15 @@ public abstract class MixinBoreVisFrequencyReduction {
             if (this.gettingPower()) {
                 // Do a cvis check, sleep 10s
                 gTNHLib$cooldown = 10 * 20;
+                // double cooldown if it never had cvis
+                // imprecision means it will never be 0 again. I think.
+                gTNHLib$cooldown *= this.speedyTime == 0 ? 2 : 1;
                 return false;
             } else {
                 // Block isn't powered, so do cvis thing but choke to 30s instead
                 gTNHLib$cooldown = 30 * 20;
+                // double cooldown if it never had cvis
+                gTNHLib$cooldown *= this.speedyTime == 0 ? 2 : 1;
                 return false;
             }
         }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinBoreVisFrequencyReduction.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinBoreVisFrequencyReduction.java
@@ -1,0 +1,68 @@
+package com.mitchej123.hodgepodge.mixins.late.thaumcraft;
+
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import thaumcraft.common.tiles.TileArcaneBore;
+
+@Mixin(value = TileArcaneBore.class, remap = true)
+public abstract class MixinBoreVisFrequencyReduction {
+
+    @Shadow
+    public abstract boolean gettingPower();
+
+    @Shadow
+    private float speedyTime;
+
+    @Unique
+    private int gTNHLib$cooldown = 0;
+    @Unique
+    private float gTNHLib$cachedTime = 0;
+
+    // Add a cooldown to the if statement.
+    @ModifyExpressionValue(
+            method = "updateEntity",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/world/World;isRemote:Z",
+                    ordinal = 0,
+                    opcode = Opcodes.GETFIELD))
+    public boolean powerAndSleep(boolean isRemote) {
+        // The returned value is inverted.
+
+        // Client thread, return
+        if (isRemote) return true;
+
+        // Cooldown expired, do checks
+        if (gTNHLib$cooldown-- <= 0) {
+            if (this.gettingPower()) {
+                // Do a cvis check, sleep 10s
+                gTNHLib$cooldown = 10 * 20;
+                return false;
+            } else {
+                // Block isn't powered, so do cvis thing but choke to 30s instead
+                gTNHLib$cooldown = 30 * 20;
+                return false;
+            }
+        }
+
+        // if it has any cached speedyTime, but less than the max, skip cooldown
+        // Speedy time can be exhausted in 1 second by a constantly-digging bore.
+        // if the speedyTime doesn't change since last lookup, increase cooldown to 1/2s
+        if (this.speedyTime > 1 && this.speedyTime < 20) {
+            if (this.speedyTime == gTNHLib$cachedTime) {
+                gTNHLib$cooldown = Math.min(gTNHLib$cooldown, 10);
+            } else gTNHLib$cooldown = 0;
+            gTNHLib$cachedTime = this.speedyTime;
+        }
+
+        // Cooldown's not up, don't do cvis thing.
+        return true;
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinBoreVisFrequencyReduction.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinBoreVisFrequencyReduction.java
@@ -20,9 +20,9 @@ public abstract class MixinBoreVisFrequencyReduction {
     private float speedyTime;
 
     @Unique
-    private int gTNHLib$cooldown = 0;
+    private int hodgepodge$cooldown = 0;
     @Unique
-    private float gTNHLib$cachedTime = 0;
+    private float hodgepodge$cachedTime = 0;
 
     // Add a cooldown to the if statement.
     @ModifyExpressionValue(
@@ -39,19 +39,19 @@ public abstract class MixinBoreVisFrequencyReduction {
         if (isRemote) return true;
 
         // Cooldown expired, do checks
-        if (gTNHLib$cooldown-- <= 0) {
+        if (hodgepodge$cooldown-- <= 0) {
             if (this.gettingPower()) {
                 // Do a cvis check, sleep 10s
-                gTNHLib$cooldown = 10 * 20;
+                hodgepodge$cooldown = 10 * 20;
                 // double cooldown if it never had cvis
                 // imprecision means it will never be 0 again. I think.
-                gTNHLib$cooldown *= this.speedyTime == 0 ? 2 : 1;
+                hodgepodge$cooldown *= this.speedyTime == 0 ? 2 : 1;
                 return false;
             } else {
                 // Block isn't powered, so do cvis thing but choke to 30s instead
-                gTNHLib$cooldown = 30 * 20;
+                hodgepodge$cooldown = 30 * 20;
                 // double cooldown if it never had cvis
-                gTNHLib$cooldown *= this.speedyTime == 0 ? 2 : 1;
+                hodgepodge$cooldown *= this.speedyTime == 0 ? 2 : 1;
                 return false;
             }
         }
@@ -60,10 +60,10 @@ public abstract class MixinBoreVisFrequencyReduction {
         // Speedy time can be exhausted in 1 second by a constantly-digging bore.
         // if the speedyTime doesn't change since last lookup, increase cooldown to 1/2s
         if (this.speedyTime > 1 && this.speedyTime < 20) {
-            if (this.speedyTime == gTNHLib$cachedTime) {
-                gTNHLib$cooldown = Math.min(gTNHLib$cooldown, 10);
-            } else gTNHLib$cooldown = 0;
-            gTNHLib$cachedTime = this.speedyTime;
+            if (this.speedyTime == hodgepodge$cachedTime) {
+                hodgepodge$cooldown = Math.min(hodgepodge$cooldown, 10);
+            } else hodgepodge$cooldown = 0;
+            hodgepodge$cachedTime = this.speedyTime;
         }
 
         // Cooldown's not up, don't do cvis thing.


### PR DESCRIPTION
Add cooldown to thaum's arcane bore cvis handling to decrease calls for cvis source checking. Should icnrease performance, especially since bores are usually spammed by hte hundreds.

If it has redstone, cooldown is 10s. If not, 30.

If it has any speedy time cached, the cooldown is skipped as long as its refilling. Otherwise, if it just has a bunch cached but isn't refilling or draining, it goes to 1/2s. This is still 10x less calls, even if they get suck in a state of only having some cvis forever.

If it never had cvis (going off of floating point imprecision for it), cooldown doubles. This won't happen on first placement if it has a source nearby, and presumably if you ever use cvis, it will never return to 0 (it subracts 1, without limiting it to 0). Otherwise, once cooldown is over, it won't double again. 