### PR TITLE
Clamp looting to a minimum of 0

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -498,6 +498,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean clipPlayerRenderInGuis;
 
+    @Config.Comment("Sets a minimum of 0 for Looting. Negative values still exist, but are treated as 0 for most purposes. Fixes crashes when killing mobs with negative looting, if you somehow manage to achieve it.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean minLootingIsZero;
+
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1091,6 +1091,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiInventory_ClipPlayer", "minecraft.MixinGuiContainerCreative_ClipPlayer", "minecraft.MixinGuiScreenHorseInventory_ClipPlayer")
             .setApplyIf(() -> FixesConfig.clipPlayerRenderInGuis)
             .setPhase(Phase.EARLY)),
+    FIX_NEGATIVE_LOOTING_CRASH(new MixinBuilder()
+            .addCommonMixins("minecraft.crashfixes.MixinEnchantmentHelper")
+            .setApplyIf(() -> FixesConfig.minLootingIsZero)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/crashfixes/MixinEnchantmentHelper.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/crashfixes/MixinEnchantmentHelper.java
@@ -1,0 +1,23 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.crashfixes;
+
+import static java.lang.Math.max;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+@Mixin(EnchantmentHelper.class)
+public class MixinEnchantmentHelper {
+
+    @ModifyExpressionValue(
+            method = "getLootingModifier",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/enchantment/EnchantmentHelper;getEnchantmentLevel(ILnet/minecraft/item/ItemStack;)I"))
+    private static int hodge$noNegativeLooting(int original) {
+        return max(0, original);
+    }
+}


### PR DESCRIPTION
Killing a mob with negative looting crashes the game, because Minecraft (and likely other mods) don't expect negative values here. Blocking all negative enchantments is hard, but clamping is easy - this mixes into the EnchantmentHelper, clamping negative values to zero for most purposes.