### PR TITLE
Fix condition to check absolute value in toRomanLimited

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/util/RomanNumerals.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/RomanNumerals.java
@@ -38,7 +38,7 @@ public class RomanNumerals {
      * returns a readable number
      */
     public static String toRomanLimited(int number, int limit) {
-        if (number > limit) {
+        if (Math.abs(number) > limit) {
             return String.valueOf(number);
         }
         return toRoman(number);


### PR DESCRIPTION
Fixes it so that the level cap for readability is also respected for negative enchantments.