### PR TITLE
addClientMixins instead of addCommonMixins for the "fixSaveFileWrittenToExistingDirectory" mixin

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1059,7 +1059,7 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixBreakingSpecialArmorHelmetOnBlockFall)
             .setPhase(Phase.EARLY)),
     FIX_SAVE_FILE_WRITTEN_TO_EXIST_DIRECTORY(new MixinBuilder()
-            .addCommonMixins("minecraft.MixinGuiCreateWorld_NotWriteToExistDir")
+            .addClientMixins("minecraft.MixinGuiCreateWorld_NotWriteToExistDir")
             .setApplyIf(() -> FixesConfig.fixSaveFileWrittenToExistingDirectory)
             .setPhase(Phase.EARLY)),
     FIX_FAKE_PLAYER_CHAT_CRASH(new MixinBuilder()


### PR DESCRIPTION
Makes Hodgepodge add the `fixSaveFileWrittenToExistingDirectory` mixin only on the Client side, instead of both sides. The Mixin targets a client-only class, and does not function on the server besides printing a warning about the invalid side in the log.