### PR TITLE
Fix vanilla item frame duplication bug

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -69,6 +69,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixDuplicateSounds;
 
+    @Config.Comment("Fix vanilla item frame duplication.")
+    @Config.DefaultBoolean(true)
+    public static boolean fixItemFrameDupe;
+
     @Config.Comment("Fix deleting stack when eating mushroom stew")
     @Config.DefaultBoolean(true)
     public static boolean fixEatingStackedStew;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1114,6 +1114,10 @@ public enum Mixins implements IMixins {
                     "minecraft.villager.MixinNpcMerchant")
             .setApplyIf(() -> FixesConfig.fixVillagerTradingDesync)
             .setPhase(Phase.EARLY)),
+    FIX_ITEM_FRAME_DUPE(new MixinBuilder("Fix vanilla item frame duplication.")
+            .addCommonMixins("minecraft.MixinEntityItemFrame_FixDupe")
+            .setApplyIf(() -> FixesConfig.fixItemFrameDupe)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityItemFrame_FixDupe.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityItemFrame_FixDupe.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.item.EntityItemFrame;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+/**
+ * Fixes the vanilla item frame item duplication trick.
+ * <p>
+ * Ensure the item inside a frame get cleared instantly and not later so if it's called twice in same tick (ex: left
+ * click + piston) it doesn't duplicate the item displayed.
+ */
+@Mixin(EntityItemFrame.class)
+public class MixinEntityItemFrame_FixDupe {
+
+    @WrapOperation(
+            method = "func_146065_b",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/item/EntityItemFrame;getDisplayedItem()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack hodgepodge$captureAndClearDisplayedItem(EntityItemFrame self, Operation<ItemStack> original) {
+        ItemStack stack = original.call(self);
+        if (stack != null && !self.worldObj.isRemote) {
+            self.setDisplayedItem(null);
+        }
+        return stack;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/276
Fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/288

Ensure the item inside a frame get cleared instantly and not later