### PR TITLE
Add localization to entity name chat components & give Wither Skeletons their own unique name

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -520,6 +520,15 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixVillagerTradingDesync;
 
+    @Config.Comment("Fix death messages containing English-localized entity names even on non-English clients.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean entityNameLocalization;
+
+    @Config.Comment("Makes Wither Skeletons not appear as just \"Skeleton\" in death messages and WAILA.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean witherSkeletonSpecialName;
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1118,6 +1118,20 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinEntityItemFrame_FixDupe")
             .setApplyIf(() -> FixesConfig.fixItemFrameDupe)
             .setPhase(Phase.EARLY)),
+    FIX_ENTITY_NAME_LOCALIZATION(new MixinBuilder()
+            .addCommonMixins(
+                    "minecraft.MixinEntity_TranslateNameComponent",
+                    "minecraft.MixinEntityHorse_ChatComponentName",
+                    "minecraft.MixinEntityItem_ChatComponentName",
+                    "minecraft.MixinEntityLiving_ChatComponentName",
+                    "minecraft.MixinEntityMinecart_ChatComponentName",
+                    "minecraft.MixinEntityOcelot_ChatComponentName")
+            .setApplyIf(() -> FixesConfig.entityNameLocalization)
+            .setPhase(Phase.EARLY)),
+    WITHER_SKELETON_CUSTOM_NAME(new MixinBuilder()
+            .addCommonMixins("minecraft.MixinEntitySkeleton_CustomWitherName")
+            .setApplyIf(() -> FixesConfig.witherSkeletonSpecialName)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityHorse_ChatComponentName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityHorse_ChatComponentName.java
@@ -1,0 +1,36 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntityHorse.class)
+public abstract class MixinEntityHorse_ChatComponentName extends EntityAnimal {
+
+    private MixinEntityHorse_ChatComponentName(World p_i1681_1_) {
+        super(p_i1681_1_);
+    }
+
+    @Shadow
+    public abstract int getHorseType();
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (!this.hasCustomNameTag()) {
+            return new ChatComponentTranslation(switch (this.getHorseType()) {
+                case 1 -> "entity.donkey.name";
+                case 2 -> "entity.mule.name";
+                case 3 -> "entity.zombiehorse.name";
+                case 4 -> "entity.skeletonhorse.name";
+                default -> "entity.horse.name";
+            });
+        } else {
+            return super.func_145748_c_();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityItem_ChatComponentName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityItem_ChatComponentName.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntityItem.class)
+public abstract class MixinEntityItem_ChatComponentName extends Entity {
+
+    private MixinEntityItem_ChatComponentName(World worldIn) {
+        super(worldIn);
+    }
+
+    @Shadow
+    public abstract ItemStack getEntityItem();
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        return new ChatComponentTranslation("item." + this.getEntityItem().getUnlocalizedName());
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityLiving_ChatComponentName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityLiving_ChatComponentName.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntityLiving.class)
+public abstract class MixinEntityLiving_ChatComponentName extends EntityLivingBase {
+
+    private MixinEntityLiving_ChatComponentName(World p_i1594_1_) {
+        super(p_i1594_1_);
+    }
+
+    @Shadow
+    public abstract boolean hasCustomNameTag();
+
+    @Shadow
+    public abstract String getCustomNameTag();
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.hasCustomNameTag()) {
+            return new ChatComponentText(this.getCustomNameTag());
+        } else {
+            return super.func_145748_c_();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityMinecart_ChatComponentName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityMinecart_ChatComponentName.java
@@ -1,0 +1,30 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntityMinecart.class)
+public abstract class MixinEntityMinecart_ChatComponentName extends Entity {
+
+    private MixinEntityMinecart_ChatComponentName(World worldIn) {
+        super(worldIn);
+    }
+
+    @Shadow
+    private String entityName;
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.entityName != null) {
+            return new ChatComponentText(this.entityName);
+        } else {
+            return super.func_145748_c_();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityOcelot_ChatComponentName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityOcelot_ChatComponentName.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.passive.EntityOcelot;
+import net.minecraft.entity.passive.EntityTameable;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntityOcelot.class)
+public abstract class MixinEntityOcelot_ChatComponentName extends EntityTameable {
+
+    private MixinEntityOcelot_ChatComponentName(World p_i1604_1_) {
+        super(p_i1604_1_);
+    }
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (!this.hasCustomNameTag() && this.isTamed()) {
+            return new ChatComponentTranslation("entity.Cat.name");
+        } else {
+            return super.func_145748_c_();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntitySkeleton_CustomWitherName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntitySkeleton_CustomWitherName.java
@@ -1,0 +1,40 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.monster.EntitySkeleton;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(EntitySkeleton.class)
+public abstract class MixinEntitySkeleton_CustomWitherName extends EntityMob {
+
+    private MixinEntitySkeleton_CustomWitherName(World p_i1738_1_) {
+        super(p_i1738_1_);
+    }
+
+    @Shadow
+    public abstract int getSkeletonType();
+
+    @Override
+    public String getCommandSenderName() {
+        if (this.getSkeletonType() == 1) {
+            return StatCollector.translateToLocal("entity.Skeleton.wither.name");
+        } else {
+            return super.getCommandSenderName();
+        }
+    }
+
+    @Override
+    public IChatComponent func_145748_c_() {
+        if (this.getSkeletonType() == 1) {
+            return new ChatComponentTranslation("entity.Skeleton.wither.name");
+        } else {
+            return super.func_145748_c_();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntitySkeleton_CustomWitherName.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntitySkeleton_CustomWitherName.java
@@ -22,7 +22,7 @@ public abstract class MixinEntitySkeleton_CustomWitherName extends EntityMob {
 
     @Override
     public String getCommandSenderName() {
-        if (this.getSkeletonType() == 1) {
+        if (!this.hasCustomNameTag() && this.getSkeletonType() == 1) {
             return StatCollector.translateToLocal("entity.Skeleton.wither.name");
         } else {
             return super.getCommandSenderName();
@@ -31,7 +31,7 @@ public abstract class MixinEntitySkeleton_CustomWitherName extends EntityMob {
 
     @Override
     public IChatComponent func_145748_c_() {
-        if (this.getSkeletonType() == 1) {
+        if (!this.hasCustomNameTag() && this.getSkeletonType() == 1) {
             return new ChatComponentTranslation("entity.Skeleton.wither.name");
         } else {
             return super.func_145748_c_();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntity_TranslateNameComponent.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntity_TranslateNameComponent.java
@@ -13,7 +13,9 @@ public abstract class MixinEntity_TranslateNameComponent {
 
     /**
      * New implementation based on {@link Entity#getCommandSenderName()}. This may cause issues with mods that override
-     * {@link Entity#getCommandSenderName()} but not {@link Entity#func_145748_c_()}.
+     * {@link Entity#getCommandSenderName()} but not {@link Entity#func_145748_c_()}. (Specifically,
+     * {@code func_145748_c_} will return a translation key of {@code entity.[entity ID].name}, which may not be the
+     * same as the text returned by the mod's implementation of {@code getCommandSenderName}.)
      *
      * @author nicksitnikov
      * @reason This method initially returned a component that was translated on the server. Replacing it with a

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntity_TranslateNameComponent.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntity_TranslateNameComponent.java
@@ -1,0 +1,33 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(Entity.class)
+public abstract class MixinEntity_TranslateNameComponent {
+
+    /**
+     * New implementation based on {@link Entity#getCommandSenderName()}. This may cause issues with mods that override
+     * {@link Entity#getCommandSenderName()} but not {@link Entity#func_145748_c_()}.
+     *
+     * @author nicksitnikov
+     * @reason This method initially returned a component that was translated on the server. Replacing it with a
+     *         {@link ChatComponentTranslation} allows the name of the entity to be correctly translated to the client's
+     *         language.
+     */
+    @Overwrite
+    public IChatComponent func_145748_c_() {
+        String s = EntityList.getEntityString((Entity) (Object) this);
+
+        if (s == null) {
+            s = "generic";
+        }
+
+        return new ChatComponentTranslation("entity." + s + ".name");
+    }
+}

--- a/src/main/resources/assets/hodgepodge/lang/en_US.lang
+++ b/src/main/resources/assets/hodgepodge/lang/en_US.lang
@@ -21,6 +21,8 @@ item.dyePowder.name=Dye
 item.skull.name=Skull
 item.fish.name=Fish
 
+entity.Skeleton.wither.name=Wither Skeleton
+
 commands.time.get=The current world time is %s (time of day: %s)
 commands.time.usageWithGet=/time <set|add> <value> OR /time get
 

--- a/src/main/resources/assets/hodgepodge/lang/en_US.lang
+++ b/src/main/resources/assets/hodgepodge/lang/en_US.lang
@@ -22,6 +22,12 @@ item.skull.name=Skull
 item.fish.name=Fish
 
 entity.Skeleton.wither.name=Wither Skeleton
+entity.MinecartRideable.name=Minecart
+entity.MinecartChest.name=Minecart with Chest
+entity.MinecartFurnace.name=Minecart with Furnace
+entity.MinecartTNT.name=Minecart with TNT
+entity.MinecartHopper.name=Minecart with Hopper
+entity.MinecartCommandBlock.name=Minecart with Command Block
 
 commands.time.get=The current world time is %s (time of day: %s)
 commands.time.usageWithGet=/time <set|add> <value> OR /time get

--- a/src/main/resources/assets/hodgepodge/lang/ru_RU.lang
+++ b/src/main/resources/assets/hodgepodge/lang/ru_RU.lang
@@ -22,6 +22,12 @@ item.skull.name=Череп
 item.fish.name=Рыба
 
 entity.Skeleton.wither.name=Скелет-иссушитель
+entity.MinecartRideable.name=Вагонетка
+entity.MinecartChest.name=Грузовая вагонетка
+entity.MinecartFurnace.name=Самоходная вагонетка
+entity.MinecartTNT.name=Вагонетка с динамитом
+entity.MinecartHopper.name=Вагонетка с загрузочной воронкой
+entity.MinecartCommandBlock.name=Вагонетка с командным блоком
 
 commands.time.get=Текущее мировое время составляет %s (время суток: %s)
 commands.time.usageWithGet=/time <set|add> <value> ИЛИ /time get

--- a/src/main/resources/assets/hodgepodge/lang/ru_RU.lang
+++ b/src/main/resources/assets/hodgepodge/lang/ru_RU.lang
@@ -21,6 +21,8 @@ item.dyePowder.name=Краситель
 item.skull.name=Череп
 item.fish.name=Рыба
 
+entity.Skeleton.wither.name=Скелет-иссушитель
+
 commands.time.get=Текущее мировое время составляет %s (время суток: %s)
 commands.time.usageWithGet=/time <set|add> <value> ИЛИ /time get
 


### PR DESCRIPTION
Adds two configs:

`entityNameLocalization` adds overrides of `func_145748_c_` to all vanilla classes that override `getCommandSenderName`. This allows death messages to be correctly translated on non-English clients even when the server is set to English.

`witherSkeletonSpecialName` overrides the command sender name of the wither skeleton from "Skeleton" to "Wither Skeleton", as well as also adding the corresponding override to `func_145748_c`.

Before:
<img width="2560" height="1361" alt="2026-06-23_03 07 59" src="https://github.com/user-attachments/assets/9f555573-9ce0-40af-93a9-f23505c8b1e3" />


After:
<img width="2560" height="1361" alt="2026-06-23_02 57 05" src="https://github.com/user-attachments/assets/447983c6-41ff-4575-aa61-e5aea71a9e8d" />
