### PR TITLE
Prevent Wither Skeletons from trying to burn in sunlight

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -515,6 +515,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean minLootingIsZero;
 
+    @Config.Comment("Prevent Zombies & Skeletons from flickering with fire when exposed to the sun while immune to fire (in particular, Wither Skeletons)")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean preventFireImmuneUndeadFlicker;
+
     @Config.Comment("Fix Villagers only updating out-of-stock state after reopening GUI")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1114,6 +1114,10 @@ public enum Mixins implements IMixins {
                     "minecraft.villager.MixinNpcMerchant")
             .setApplyIf(() -> FixesConfig.fixVillagerTradingDesync)
             .setPhase(Phase.EARLY)),
+    FIX_UNDEAD_FIRE_FLICKER(new MixinBuilder("Fix undead entities flickering with fire when exposed to the sun while immune to fire")
+            .addCommonMixins("minecraft.MixinEntityUndead_SunFireImmunity")
+            .setApplyIf(() -> FixesConfig.preventFireImmuneUndeadFlicker)
+            .setPhase(Phase.EARLY)),
     FIX_ITEM_FRAME_DUPE(new MixinBuilder("Fix vanilla item frame duplication.")
             .addCommonMixins("minecraft.MixinEntityItemFrame_FixDupe")
             .setApplyIf(() -> FixesConfig.fixItemFrameDupe)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityUndead_SunFireImmunity.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinEntityUndead_SunFireImmunity.java
@@ -1,0 +1,26 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.monster.EntitySkeleton;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+@Mixin({ EntitySkeleton.class, EntityZombie.class })
+public abstract class MixinEntityUndead_SunFireImmunity extends EntityMob {
+
+    private MixinEntityUndead_SunFireImmunity(World p_i1738_1_) {
+        super(p_i1738_1_);
+    }
+
+    @ModifyExpressionValue(
+            method = "onLivingUpdate",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isDaytime()Z"))
+    private boolean fireImmunityCheck(boolean original) {
+        return original && !this.isImmuneToFire;
+    }
+}


### PR DESCRIPTION
Wither Skeletons (and Zombies) did not check `this.isImmuneToFire` before trying to burn in the sunlight, causing them to flicker in the sunlight and deal durability damage to their helmet even when they could not take damage from the sun. This adds an extra check to prevent this from happening.

Before:
https://github.com/user-attachments/assets/16b58f45-d6d4-4895-8fa3-dc52c2b12e7d

After:
https://github.com/user-attachments/assets/061ffc1d-3b9d-4631-b936-2eb58f2d87fd
