### PR TITLE
Raise FPS limit in FML missing mapping screen

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -529,6 +529,11 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean witherSkeletonSpecialName;
+
+    @Config.Comment("Raise FPS limit in the FML missing items screen (or any other FML StartupQuery).")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean raiseMissingItemsFPS;
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1132,6 +1132,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinEntitySkeleton_CustomWitherName")
             .setApplyIf(() -> FixesConfig.witherSkeletonSpecialName)
             .setPhase(Phase.EARLY)),
+    FML_QUERY_SCREEN_FPS(new MixinBuilder()
+            .addCommonMixins("minecraft.MixinMinecraft_FMLQueryFPS")
+            .setApplyIf(() -> FixesConfig.raiseMissingItemsFPS)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FMLQueryFPS.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FMLQueryFPS.java
@@ -1,0 +1,19 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft_FMLQueryFPS {
+
+    @ModifyArg(
+            method = "launchIntegratedServer(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/WorldSettings;)V",
+            at = @At(value = "INVOKE", target = "Ljava/lang/Thread;sleep(J)V"),
+            remap = false)
+    private long hodgepodge$raiseFMLQueryFPS(long millis) {
+        return 34;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FMLQueryFPS.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraft_FMLQueryFPS.java
@@ -11,8 +11,7 @@ public class MixinMinecraft_FMLQueryFPS {
 
     @ModifyArg(
             method = "launchIntegratedServer(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/world/WorldSettings;)V",
-            at = @At(value = "INVOKE", target = "Ljava/lang/Thread;sleep(J)V"),
-            remap = false)
+            at = @At(value = "INVOKE", target = "Ljava/lang/Thread;sleep(J)V"))
     private long hodgepodge$raiseFMLQueryFPS(long millis) {
         return 34;
     }


### PR DESCRIPTION
## Summary
Raises the FPS limit in the missing items screen aka this thing up from 5 to 30
<img width="381" height="237" alt="image" src="https://github.com/user-attachments/assets/6573f82e-d007-401e-a78e-c23840607d88" />

Would be a nice qol improvement for https://github.com/GTNewHorizons/GTNHLib/pull/409 since it has to use the same system for displaying the warnings.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
