### PR TITLE
Cross-hair rendering

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -142,6 +142,10 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean hideCrosshairInThirdPerson;
 
+    @Config.Comment("Stops rendering the crosshair when a GUI screen (e.g. an inventory) is open")
+    @Config.DefaultBoolean(true)
+    public static boolean hideCrosshairInGui;
+
     @Config.Comment("Increase particle limit")
     @Config.DefaultBoolean(true)
     public static boolean increaseParticleLimit;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -585,6 +585,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("forge.MixinGuiIngameForge_CrosshairThirdPerson")
             .setApplyIf(() -> TweaksConfig.hideCrosshairInThirdPerson)
             .setPhase(Phase.EARLY)),
+    CROSSHAIR_GUI_OPEN(new MixinBuilder("Stops rendering the crosshair when a GUI screen is open")
+            .addClientMixins("forge.MixinGuiIngameForge_CrosshairGuiOpen")
+            .setApplyIf(() -> TweaksConfig.hideCrosshairInGui)
+            .setPhase(Phase.EARLY)),
     DONT_INVERT_CROSSHAIR_COLORS(new MixinBuilder("Don't invert crosshair colors")
             .addClientMixins("forge.MixinGuiIngameForge_CrosshairInvertColors")
             .setApplyIf(() -> TweaksConfig.dontInvertCrosshairColor)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
@@ -1,6 +1,7 @@
 package com.mitchej123.hodgepodge.mixins.early.forge;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.gui.GuiIngame;
 import net.minecraftforge.client.GuiIngameForge;
 
@@ -14,7 +15,7 @@ public class MixinGuiIngameForge_CrosshairGuiOpen extends GuiIngame {
 
     @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
     public void hodgepodge$hideCrosshairInGui(int width, int height, CallbackInfo ci) {
-        if (mc.currentScreen != null) {
+        if (mc.currentScreen != null && !(mc.currentScreen instanceof GuiChat)) {
             ci.cancel();
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
@@ -1,0 +1,25 @@
+package com.mitchej123.hodgepodge.mixins.early.forge;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraftforge.client.GuiIngameForge;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiIngameForge.class)
+public class MixinGuiIngameForge_CrosshairGuiOpen extends GuiIngame {
+
+    @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
+    public void hodgepodge$hideCrosshairInGui(int width, int height, CallbackInfo ci) {
+        if (mc.currentScreen != null) {
+            ci.cancel();
+        }
+    }
+
+    private MixinGuiIngameForge_CrosshairGuiOpen(Minecraft mc) {
+        super(mc);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
@@ -6,17 +6,17 @@ import net.minecraft.client.gui.GuiIngame;
 import net.minecraftforge.client.GuiIngameForge;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
 @Mixin(GuiIngameForge.class)
 public class MixinGuiIngameForge_CrosshairGuiOpen extends GuiIngame {
 
-    @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
-    public void hodgepodge$hideCrosshairInGui(int width, int height, CallbackInfo ci) {
-        if (mc.currentScreen != null && !(mc.currentScreen instanceof GuiChat)) {
-            ci.cancel();
+    @WrapMethod(method = "renderCrosshairs", remap = false)
+    public void hodgepodge$hideCrosshairInGui(int width, int height, Operation<Void> original) {
+        if (mc.currentScreen == null || mc.currentScreen instanceof GuiChat) {
+            original.call(width, height);
         }
     }
 


### PR DESCRIPTION
## Summary
Stops rendering the crosshair when gui screen is open. Made for transparent gui resource pack (tested with https://github.com/S4mpsa/Glass-UI). Config enabled by default (do not render).

| Before | After |
| - | - |
| <img width="562" height="528" alt="Pre" src="https://github.com/user-attachments/assets/4449f9cf-3c84-45e8-b2ce-3b3536f453ee" /> | <img width="576" height="555" alt="Post" src="https://github.com/user-attachments/assets/2d17d984-f0b9-4a3d-bd63-322828d19ef5" /> |

@S4mpsa 

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
