### PR TITLE
Fix bug in fast block lookup

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinGameData_BlockArraySync.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/preinit/MixinGameData_BlockArraySync.java
@@ -40,7 +40,7 @@ public class MixinGameData_BlockArraySync {
 
     @Inject(
             method = "injectWorldIDMap(Ljava/util/Map;Ljava/util/Set;Ljava/util/Map;Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;ZZ)Ljava/util/List;",
-            at = @At("RETURN"))
+            at = @At(value = "INVOKE", target = "Lcpw/mods/fml/common/Loader;fireRemapEvent(Ljava/util/Map;)V"))
     private static void hodgepodge$rebuildBlockArrayOnInject(Map<String, Integer> dataList, Set<Integer> blockedIds,
             Map<String, String> blockAliases, Map<String, String> itemAliases, Set<String> blockSubstitutions,
             Set<String> itemSubstitutions, boolean injectFrozenData, boolean isLocalWorld,


### PR DESCRIPTION
Currently fast block lookup is only refreshed _after_ the `FMLModIdMappingEvent` event is called, causing `Block.getIdFromBlock` to return incorrect IDs. This is an issue because postea [uses it](https://github.com/GTNewHorizons/Postea/blob/a8038450178682cd9baaab767d2e66051097a8ac/src/main/java/com/gtnewhorizons/postea/Postea.java#L49) for block transformations.
Changing it from TAIL doesn't matter because if `injectWorldIDMap` returns early FML refuses to load the world and shuts the server down.



### Checklist
✅ I have tested this PR in DevEnv
❌ I have tested this PR in Fullpack
✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
❌ This PR requires another PR in order to merge
