### PR TITLE
Fix controls menu crash when keybind categories share a localized name

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -149,6 +149,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixImmobileFireballs;
 
+    @Config.Comment("Fix crash in the controls menu when two keybind categories share the same localized name")
+    @Config.DefaultBoolean(true)
+    public static boolean fixKeybindCategorySorting;
+
     @Config.Comment("Fix Sugar Cane inability to replace replaceable blocks indirectly.")
     @Config.DefaultBoolean(true)
     public static boolean fixSugarCanePlacement;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -604,6 +604,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.triggerAllConflictingKeybindings)
             .addExcludedMod(TargetedMod.MODERNKEYBINDING)
             .setPhase(Phase.EARLY)),
+    FIX_KEYBIND_CATEGORY_SORTING(new MixinBuilder("Fix controls menu crash on colliding localized category names")
+            .addClientMixins("minecraft.MixinKeyBinding_FixComparison")
+            .setApplyIf(() -> FixesConfig.fixKeybindCategorySorting)
+            .addExcludedMod(TargetedMod.MODERNKEYBINDING)
+            .setPhase(Phase.EARLY)),
     REMOVE_SPAWN_MINECART_SOUND(new MixinBuilder("Remove sound when spawning a minecart")
             .addClientMixins("minecraft.MixinWorldClient")
             .setApplyIf(() -> TweaksConfig.removeSpawningMinecartSound)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinKeyBinding_FixComparison.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinKeyBinding_FixComparison.java
@@ -1,0 +1,37 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.settings.KeyBinding;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(KeyBinding.class)
+public class MixinKeyBinding_FixComparison {
+
+    @Shadow
+    @Final
+    private String keyDescription;
+    @Shadow
+    @Final
+    private String keyCategory;
+
+    /**
+     * @author Algent
+     * @reason Fix controls menu crash when keybind categories share a localized name which can crash the game.
+     */
+    @Overwrite(remap = false)
+    public int compareTo(KeyBinding other) {
+        final MixinKeyBinding_FixComparison mixinOther = (MixinKeyBinding_FixComparison) (Object) other;
+        int result = I18n.format(this.keyCategory).compareTo(I18n.format(mixinOther.keyCategory));
+        if (result == 0) {
+            result = this.keyCategory.compareTo(mixinOther.keyCategory);
+            if (result == 0) {
+                result = I18n.format(this.keyDescription).compareTo(I18n.format(mixinOther.keyDescription));
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25698

## Summary
Avoid an ArrayIndexOutOfBoundsException if translated keybind categories cause collisions due to having same localized name.

Repro step:
- GTNH 2.9.0-beta-2 →  set game language to `Русский` (Russian)
- Then go into Options → Controls
- Without this you'll get a crash message, with the change it's fixed


## Checklist
- ✅ I have tested this PR in DevEnv
- ✅ I have tested this PR in Fullpack
- ✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
