### PR TITLE
Handle SIGINT/SIGTERM to shut down server gracefully

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/Common.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Common.java
@@ -61,28 +61,30 @@ public class Common {
     }
 
     private static void registerSignalHandler() {
-        SignalHandler signalHandler = sig -> {
-            log.info("Received {} signal", sig.getName());
-            MinecraftServer server = MinecraftServer.getServer();
-            if (server != null) {
-                if (server.isServerRunning()) {
-                    server.initiateShutdown();
-                    long start = System.currentTimeMillis();
-                    while (!server.isServerStopped()) {
-                        try {
-                            if (System.currentTimeMillis() - start > 30_000) {
+        try {
+            SignalHandler signalHandler = sig -> {
+                log.info("Received {} signal", sig.getName());
+                MinecraftServer server = MinecraftServer.getServer();
+                if (server != null) {
+                    if (server.isServerRunning()) {
+                        server.initiateShutdown();
+                        while (!server.isServerStopped()) {
+                            try {
+                                Thread.sleep(10);
+                            } catch (InterruptedException e) {
                                 break;
                             }
-                            Thread.sleep(10);
-                        } catch (InterruptedException e) {
-                            break;
                         }
                     }
                 }
-            }
-        };
-        Signal.handle(new Signal("INT"), signalHandler);
-        Signal.handle(new Signal("TERM"), signalHandler);
+            };
+            Signal.handle(new Signal("INT"), signalHandler);
+            Signal.handle(new Signal("TERM"), signalHandler);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "sun.misc.SignalHandler probably is unavailable on this JVM. Disable shutdownGracefullyOnSignal option in config or try another JVM.",
+                    e);
+        }
     }
 
 }

--- a/src/main/java/com/mitchej123/hodgepodge/Common.java
+++ b/src/main/java/com/mitchej123/hodgepodge/Common.java
@@ -4,6 +4,7 @@ import net.minecraft.block.BlockDispenser;
 import net.minecraft.dispenser.BehaviorDefaultDispenseItem;
 import net.minecraft.dispenser.IBlockSource;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 
@@ -12,10 +13,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
+import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
 import ic2.core.Ic2Items;
 import ic2.core.block.EntityItnt;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 public class Common {
 
@@ -26,6 +30,9 @@ public class Common {
     public static void init() {
         if (Compat.isIC2Present()) {
             ic2DispenserBehavior();
+        }
+        if (FixesConfig.shutdownGracefullyOnSignal) {
+            registerSignalHandler();
         }
     }
 
@@ -52,4 +59,30 @@ public class Common {
                     });
         }
     }
+
+    private static void registerSignalHandler() {
+        SignalHandler signalHandler = sig -> {
+            log.info("Received {} signal", sig.getName());
+            MinecraftServer server = MinecraftServer.getServer();
+            if (server != null) {
+                if (server.isServerRunning()) {
+                    server.initiateShutdown();
+                    long start = System.currentTimeMillis();
+                    while (!server.isServerStopped()) {
+                        try {
+                            if (System.currentTimeMillis() - start > 30_000) {
+                                break;
+                            }
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            break;
+                        }
+                    }
+                }
+            }
+        };
+        Signal.handle(new Signal("INT"), signalHandler);
+        Signal.handle(new Signal("TERM"), signalHandler);
+    }
+
 }

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -538,6 +538,11 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean witherSkeletonSpecialName;
+
+    @Config.Comment("Shutdown server gracefully on SIGINT/SIGTERM")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean shutdownGracefullyOnSignal;
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes


### PR DESCRIPTION
## Summary
I host GTNH server as systemd service and it is annoying to stop server gracefully.
MinecraftServer has ShutdownHook, but it seems that at time it's running some essential parts of server already shut down in a hard way, which leads to potential corruption of a save files.

Solution is to register signal handler to properly shutdown server. With that is is possible to correctly stop server with SIGINT or SIGTERM, which means no more need to use mcrcon, server wrappers, etc. In theory in also makes server resistant to OS shutdown, should fix [modpack/24651](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24651)

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
