### PR TITLE
Set f1ShowHand default config to false

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -252,7 +252,7 @@ public class TweaksConfig {
     public static boolean cleanChatLogs = true;
 
     @Config.Comment("Enable extra F1 toggle to hide GUI but keep rendering hand")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean f1ShowHand;
 


### PR DESCRIPTION
This option changes the default f1 behavior to instead cycle through 3 modes: normal, hide gui but show hand, hide gui and hand.
I've never seen this behavior before and imo it's frustrating and I don't think people want to use it intentionally
I asked in #meta-dev and got no pushback, can make poll if needed 


## Checklist
- ❌ I have tested this PR in DevEnv
- ❌ I have tested this PR in Fullpack
- ✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- ❌ This PR requires another PR in order to merge
