### PR TITLE
Make hardcoded kick messages translatable

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -145,6 +145,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixHugeChatKick;
 
+    @Config.Comment("Send a translatable message instead of a hardcoded English one when rejecting logins while the server is still starting")
+    @Config.DefaultBoolean(true)
+    public static boolean fixHandshakeStartingKickTranslatable;
+
     @Config.Comment("Fix the bug that makes fireballs stop moving when chunk unloads")
     @Config.DefaultBoolean(true)
     public static boolean fixImmobileFireballs;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -389,6 +389,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.packets.MixinS02PacketChat_FixHugeChatKick")
             .setApplyIf(() -> FixesConfig.fixHugeChatKick)
             .setPhase(Phase.EARLY)),
+    FIX_HANDSHAKE_STARTING_KICK_TRANSLATABLE(new MixinBuilder("Send a translatable message instead of a hardcoded English one when rejecting logins while the server is still starting")
+            .addCommonMixins("minecraft.MixinNetHandlerHandshakeTCP_TranslatableKick")
+            .setApplyIf(() -> FixesConfig.fixHandshakeStartingKickTranslatable)
+            .setPhase(Phase.EARLY)),
     FIX_BOGUS_INTEGRATED_SERVER_NPE(new MixinBuilder("Fix bogus FMLProxyPacket NPEs on integrated server crashes")
             .addCommonMixins(
                     "fml.MixinFMLProxyPacket",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerHandshakeTCP_TranslatableKick.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerHandshakeTCP_TranslatableKick.java
@@ -33,8 +33,8 @@ public abstract class MixinNetHandlerHandshakeTCP_TranslatableKick {
     private void hodgepodge$translatableStartingKick(C00Handshake packet, CallbackInfo ci) {
         if (!FMLCommonHandler.instance().shouldAllowPlayerLogins()) {
             IChatComponent message = new ChatComponentTranslation("hodgepodge.multiplayer.disconnect.server_starting");
-            this.field_147386_b.func_150725_a(new S00PacketDisconnect(message), new GenericFutureListener[0]);
-            this.field_147386_b.func_150718_a(message);
+            this.field_147386_b.scheduleOutboundPacket(new S00PacketDisconnect(message), new GenericFutureListener[0]);
+            this.field_147386_b.closeChannel(message);
             ci.cancel();
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerHandshakeTCP_TranslatableKick.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerHandshakeTCP_TranslatableKick.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.handshake.client.C00Handshake;
+import net.minecraft.network.login.server.S00PacketDisconnect;
+import net.minecraft.server.network.NetHandlerHandshakeTCP;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import io.netty.util.concurrent.GenericFutureListener;
+
+/**
+ * Forge's NetHandlerHandshakeTCP patch rejects logins while the server is still starting with a hardcoded English
+ * ChatComponentText, so the message cannot be localized. Replicate the shouldAllowPlayerLogins() guard at HEAD and send
+ * a ChatComponentTranslation instead, letting clients resolve it from their own lang file.
+ */
+@Mixin(NetHandlerHandshakeTCP.class)
+public abstract class MixinNetHandlerHandshakeTCP_TranslatableKick {
+
+    @Shadow
+    @Final
+    private NetworkManager field_147386_b;
+
+    @Inject(method = "func_147383_a", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$translatableStartingKick(C00Handshake packet, CallbackInfo ci) {
+        if (!FMLCommonHandler.instance().shouldAllowPlayerLogins()) {
+            IChatComponent message = new ChatComponentTranslation("hodgepodge.multiplayer.disconnect.server_starting");
+            this.field_147386_b.func_150725_a(new S00PacketDisconnect(message), new GenericFutureListener[0]);
+            this.field_147386_b.func_150718_a(message);
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS02PacketChat_FixHugeChatKick.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS02PacketChat_FixHugeChatKick.java
@@ -5,8 +5,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.S02PacketChat;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.IChatComponent.Serializer;
 
@@ -40,32 +39,22 @@ public abstract class MixinS02PacketChat_FixHugeChatKick {
     public void hodgepodge$redirectSerialize(PacketBuffer instance, String s) {
         byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         if (bytes.length > 32767) {
+            String messageStart = field_148919_a.getUnformattedText().substring(0, 30);
             if (FixesConfig.logHugeChat) {
                 String incidentId = "" + System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000);
                 LOGGER.info("HUGE chat message caught. Incident ID {}. Serialized message {}.", incidentId, s);
                 bytes = Serializer
                         .func_150696_a /* componentToJson */ (
-                                new ChatComponentText(
-                                        EnumChatFormatting.RED
-                                                + "Someone tried to sent you a huge chat message that would kick you. "
-                                                + "Ask your server admin to see details."
-                                                + " Please provide these info while reporting: Incident ID "
-                                                + EnumChatFormatting.UNDERLINE
-                                                + incidentId
-                                                + EnumChatFormatting.RESET
-                                                + ". Start of original message: "
-                                                + field_148919_a.getUnformattedText().substring(0, 30)))
+                                new ChatComponentTranslation(
+                                        "hodgepodge.chat.huge_message.logged",
+                                        incidentId,
+                                        messageStart))
                         .getBytes(StandardCharsets.UTF_8);
             } else {
                 LOGGER.info("HUGE chat message caught. Details are not logged here as requested in config.");
-                bytes = Serializer.func_150696_a /* componentToJson */ (
-                        new ChatComponentText(
-                                EnumChatFormatting.RED
-                                        + "Someone tried to sent you a huge chat message that would kick you. "
-                                        + "Ask your server admin to turn on logHugeChat in HodgePodge if you cannot identify the source of this and this keeps happening. "
-                                        + EnumChatFormatting.RESET
-                                        + "Start of original message: "
-                                        + field_148919_a.getUnformattedText().substring(0, 30)))
+                bytes = Serializer
+                        .func_150696_a /* componentToJson */ (
+                                new ChatComponentTranslation("hodgepodge.chat.huge_message.unlogged", messageStart))
                         .getBytes(StandardCharsets.UTF_8);
             }
         }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS02PacketChat_FixHugeChatKick.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS02PacketChat_FixHugeChatKick.java
@@ -43,12 +43,8 @@ public abstract class MixinS02PacketChat_FixHugeChatKick {
             if (FixesConfig.logHugeChat) {
                 String incidentId = "" + System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000);
                 LOGGER.info("HUGE chat message caught. Incident ID {}. Serialized message {}.", incidentId, s);
-                bytes = Serializer
-                        .func_150696_a /* componentToJson */ (
-                                new ChatComponentTranslation(
-                                        "hodgepodge.chat.huge_message.logged",
-                                        incidentId,
-                                        messageStart))
+                bytes = Serializer.func_150696_a /* componentToJson */ (
+                        new ChatComponentTranslation("hodgepodge.chat.huge_message.logged", incidentId, messageStart))
                         .getBytes(StandardCharsets.UTF_8);
             } else {
                 LOGGER.info("HUGE chat message caught. Details are not logged here as requested in config.");

--- a/src/main/resources/assets/hodgepodge/lang/en_US.lang
+++ b/src/main/resources/assets/hodgepodge/lang/en_US.lang
@@ -36,6 +36,10 @@ hodgepodge.soundsmenu.refreshsounds=Refresh Sounds
 hodgepodge.bed_respawn.msg=Respawn point set
 hodgepodge.menu.mod_options=Mod Options...
 
+hodgepodge.multiplayer.disconnect.server_starting=Server is still starting! Please wait before reconnecting.
+hodgepodge.chat.huge_message.logged=§cSomeone tried to send you a huge chat message that would kick you. Ask your server admin to see details. Please provide these info while reporting: Incident ID §n%s§r. Start of original message: %s
+hodgepodge.chat.huge_message.unlogged=§cSomeone tried to send you a huge chat message that would kick you. Ask your server admin to turn on logHugeChat in HodgePodge if you cannot identify the source of this and this keeps happening. §rStart of original message: %s
+
 bettermodlist.sort.normal=Normal
 bettermodlist.sort.a_to_z=A-Z
 bettermodlist.sort.z_to_a=Z-A

--- a/src/main/resources/assets/hodgepodge/lang/ru_RU.lang
+++ b/src/main/resources/assets/hodgepodge/lang/ru_RU.lang
@@ -36,6 +36,10 @@ hodgepodge.soundsmenu.refreshsounds=Обновить звуки
 hodgepodge.bed_respawn.msg=Установить точку респауна
 hodgepodge.menu.mod_options=Настройки модов...
 
+hodgepodge.multiplayer.disconnect.server_starting=Сервер ещё запускается! Подождите перед повторным подключением.
+hodgepodge.chat.huge_message.logged=§cКто-то попытался отправить вам огромное сообщение в чат, которое выкинуло бы вас с сервера. Обратитесь к администратору сервера за подробностями. При обращении укажите эти данные: идентификатор инцидента §n%s§r. Начало исходного сообщения: %s
+hodgepodge.chat.huge_message.unlogged=§cКто-то попытался отправить вам огромное сообщение в чат, которое выкинуло бы вас с сервера. Если вы не можете определить источник и это повторяется, попросите администратора сервера включить logHugeChat в HodgePodge. §rНачало исходного сообщения: %s
+
 bettermodlist.sort.normal=Обычный
 bettermodlist.sort.a_to_z=A-Z
 bettermodlist.sort.z_to_a=Z-A


### PR DESCRIPTION
The Forge "server still starting" handshake kick and Hodgepodge's huge-chat kick both sent hardcoded English ChatComponentText, so neither could be localized. Both now send ChatComponentTranslation resolved from the client's lang file, with en_US and ru_RU entries added. The handshake replacement is gated behind a new fixHandshakeStartingKickTranslatable toggle.