### PR TITLE
Enable distance culling for frames and items in frames

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -16,6 +16,10 @@ public class SpeedupsConfig {
     @Config.RequiresMcRestart
     public static boolean fastItemEntityPhysics;
 
+    @Config.Comment("Skip rendering item frame contents farther than 64 blocks and entire frames farther than 96 blocks")
+    @Config.DefaultBoolean(true)
+    public static boolean cullDistantItemFrameContents;
+
     @Config.Comment("Optimize ASMDataTable getAnnotationsFor for faster startup")
     @Config.DefaultBoolean(true)
     public static boolean optimizeASMDataTable;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -962,6 +962,10 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> SpeedupsConfig.fastItemEntityPhysics)
             .addExcludedMod(TargetedMod.FALSETWEAKS)
             .setPhase(Phase.EARLY)),
+    CULL_DISTANT_ITEM_FRAME_CONTENTS(new MixinBuilder("Skip rendering distant item frames and their contents")
+            .addClientMixins("minecraft.MixinRenderItemFrame_CullDistantContents")
+            .setApplyIf(() -> SpeedupsConfig.cullDistantItemFrameContents)
+            .setPhase(Phase.EARLY)),
     FIX_FENCE_RIGHT_CLICK(new MixinBuilder()
             .addCommonMixins("minecraft.MixinBlockFence_RightClick")
             .setApplyIf(() -> FixesConfig.fixFenceRightClick)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRenderItemFrame_CullDistantContents.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRenderItemFrame_CullDistantContents.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.tileentity.RenderItemFrame;
 import net.minecraft.entity.item.EntityItemFrame;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -12,20 +13,27 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(RenderItemFrame.class)
 public class MixinRenderItemFrame_CullDistantContents {
 
+    // Compared with squared distances to avoid a square root: 64 * 64 means a 64-block radius.
+    @Unique
+    private static final double CONTENT_RENDER_DISTANCE_SQ = 64.0D * 64.0D;
+
+    @Unique
+    private static final double FRAME_RENDER_DISTANCE_SQ = 96.0D * 96.0D;
+
     @Inject(
             method = "doRender(Lnet/minecraft/entity/item/EntityItemFrame;DDDFF)V",
             at = @At("HEAD"),
             cancellable = true)
     private void hodgepodge$cullDistantFrame(EntityItemFrame frame, double x, double y, double z, float yaw,
             float partialTicks, CallbackInfo ci) {
-        if (frame.getDistanceSqToEntity(Minecraft.getMinecraft().renderViewEntity) >= 9216.0D) {
+        if (frame.getDistanceSqToEntity(Minecraft.getMinecraft().renderViewEntity) >= FRAME_RENDER_DISTANCE_SQ) {
             ci.cancel();
         }
     }
 
     @Inject(method = "func_82402_b", at = @At("HEAD"), cancellable = true)
     private void hodgepodge$cullDistantContents(EntityItemFrame frame, CallbackInfo ci) {
-        if (frame.getDistanceSqToEntity(Minecraft.getMinecraft().renderViewEntity) >= 4096.0D) {
+        if (frame.getDistanceSqToEntity(Minecraft.getMinecraft().renderViewEntity) >= CONTENT_RENDER_DISTANCE_SQ) {
             ci.cancel();
         }
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRenderItemFrame_CullDistantContents.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinRenderItemFrame_CullDistantContents.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.tileentity.RenderItemFrame;
+import net.minecraft.entity.item.EntityItemFrame;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderItemFrame.class)
+public class MixinRenderItemFrame_CullDistantContents {
+
+    @Inject(
+            method = "doRender(Lnet/minecraft/entity/item/EntityItemFrame;DDDFF)V",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void hodgepodge$cullDistantFrame(EntityItemFrame frame, double x, double y, double z, float yaw,
+            float partialTicks, CallbackInfo ci) {
+        if (frame.getDistanceSqToEntity(Minecraft.getMinecraft().renderViewEntity) >= 9216.0D) {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "func_82402_b", at = @At("HEAD"), cancellable = true)
+    private void hodgepodge$cullDistantContents(EntityItemFrame frame, CallbackInfo ci) {
+        if (frame.getDistanceSqToEntity(Minecraft.getMinecraft().renderViewEntity) >= 4096.0D) {
+            ci.cancel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Encountered this while working on PR https://github.com/GTNewHorizons/GT5-Unofficial/pull/7464

For some reason vanilla render both frame and content without distance limit (it override it even). So everything stay visible until max entity rendering distance.

Add distance culling for in frames item and frame.
Content of frames stop showing at 64 blocks (same as signs), frames themselves at 96 blocks.

This help a lot for performances with the ore showroom which is pretty brutal benchmark on this.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
