### PR TITLE
Gracefully handle TE sync error

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/hax/TileEntityDescriptionBatcher.java
+++ b/src/main/java/com/mitchej123/hodgepodge/hax/TileEntityDescriptionBatcher.java
@@ -157,7 +157,11 @@ public class TileEntityDescriptionBatcher {
                     if (!packets.isEmpty()) {
                         Minecraft.getMinecraft().func_152344_a(() -> {
                             for (S35PacketUpdateTileEntity packet : packets) {
-                                client.handleUpdateTileEntity(packet);
+                                try {
+                                    client.handleUpdateTileEntity(packet);
+                                } catch (Exception e) {
+                                    LOGGER.error("Error handling packet update!", e);
+                                }
                             }
                         });
                     }


### PR DESCRIPTION
## Summary
This just add a try catch to prevent one tile entity to cause cascading effect.
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25680
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25654

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
