### PR TITLE
(temp) Set async icon loading to default false

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -83,12 +83,12 @@ public class SpeedupsConfig {
     public static boolean speedupLeafDecay;
 
     @Config.Comment("Load texture map icons on multiple threads")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean asyncIconLoading;
 
     @Config.Comment("Remove icon loading on texture map init")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     @Config.RequiresMcRestart
     public static boolean removeExtraIconLoad;
 


### PR DESCRIPTION
## Summary
The async icon loading pr https://github.com/GTNewHorizons/Hodgepodge/pull/908 seems to be causing some issues that need to be fixed. Temporarily sets the default to false while I work through the issues

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
