### PR TITLE
Fix Flatworld Customization NPE

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -489,6 +489,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixSaveFileWrittenToExistingDirectory;
 
+    @Config.Comment("Fix a crash in the Superflat world customization screen when a layer's block has no registered ItemBlock")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixFlatWorldLayerMissingItemBlockCrash;
+
     @Config.Comment("Fix a crash caused when a mod tries to send a chat message to a FakePlayer")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1081,6 +1081,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinGuiCreateWorld_NotWriteToExistDir")
             .setApplyIf(() -> FixesConfig.fixSaveFileWrittenToExistingDirectory)
             .setPhase(Phase.EARLY)),
+    FIX_FLAT_WORLD_LAYER_MISSING_ITEM_BLOCK_CRASH(new MixinBuilder()
+            .addClientMixins("minecraft.MixinGuiCreateFlatWorld_FixItemCrash")
+            .setApplyIf(() -> FixesConfig.fixFlatWorldLayerMissingItemBlockCrash)
+            .setPhase(Phase.EARLY)),
     FIX_FAKE_PLAYER_CHAT_CRASH(new MixinBuilder()
             .addCommonMixins("forge.MixinFakePlayer")
             .setApplyIf(() -> FixesConfig.fixFakePlayerChatCrash)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiCreateFlatWorld_FixItemCrash.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiCreateFlatWorld_FixItemCrash.java
@@ -1,14 +1,16 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.gen.FlatLayerInfo;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(targets = "net.minecraft.client.gui.GuiCreateFlatWorld$Details")
 public class MixinGuiCreateFlatWorld_FixItemCrash {
@@ -22,7 +24,8 @@ public class MixinGuiCreateFlatWorld_FixItemCrash {
     }
 
     @ModifyVariable(method = "drawSlot", at = @At(value = "STORE"), name = "s")
-    private String hodgepodge$fixMissingItemBlockLabel(String s, @Local(name = "flatlayerinfo") FlatLayerInfo flatlayerinfo) {
+    private String hodgepodge$fixMissingItemBlockLabel(String s,
+            @Local(name = "flatlayerinfo") FlatLayerInfo flatlayerinfo) {
         Block block = flatlayerinfo.func_151536_b();
         if (block == Blocks.air || Item.getItemFromBlock(block) != null) {
             return s;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiCreateFlatWorld_FixItemCrash.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiCreateFlatWorld_FixItemCrash.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.gen.FlatLayerInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(targets = "net.minecraft.client.gui.GuiCreateFlatWorld$Details")
+public class MixinGuiCreateFlatWorld_FixItemCrash {
+
+    /**
+     * Setting a layer with no registered ItemBlock produces an NPE. Need to bypass and set name.
+     */
+    @ModifyVariable(method = "drawSlot", at = @At(value = "STORE"), name = "itemstack")
+    private ItemStack hodgepodge$nullIfMissingItemBlock(ItemStack itemstack) {
+        return itemstack != null && itemstack.getItem() == null ? null : itemstack;
+    }
+
+    @ModifyVariable(method = "drawSlot", at = @At(value = "STORE"), name = "s")
+    private String hodgepodge$fixMissingItemBlockLabel(String s, @Local(name = "flatlayerinfo") FlatLayerInfo flatlayerinfo) {
+        Block block = flatlayerinfo.func_151536_b();
+        if (block == Blocks.air || Item.getItemFromBlock(block) != null) {
+            return s;
+        }
+        return block.getLocalizedName();
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Fixes a NPE when setting a block like redstone wire or tripwire as a layer.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
