### PR TITLE
Fix Ctrl shortcuts in text fields not working on some keyboard layouts

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -98,9 +98,9 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean enableDefaultLanPort;
 
-    @Config.Comment("Use CMD key on MacOS to COPY / INSERT / SELECT in text fields (Chat, NEI, Server IP etc.)")
+    @Config.Comment("Use CTRL (CMD on MacOS) to COPY / PASTE / SELECT ALL / CUT in text fields (Chat, NEI, Server IP etc.), fixes these shortcuts not working with some keyboard layouts")
     @Config.DefaultBoolean(true)
-    public static boolean enableMacosCmdShortcuts;
+    public static boolean enableTextFieldCtrlShortcuts;
 
     @Config.Comment("Shows renderer's impact on FPS in vanilla lagometer")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -613,9 +613,9 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinWorldClient")
             .setApplyIf(() -> TweaksConfig.removeSpawningMinecartSound)
             .setPhase(Phase.EARLY)),
-    MACOS_KEYS_TEXTFIELD_SHORTCUTS(new MixinBuilder("Macos use CMD to copy/select/delete text")
+    TEXTFIELD_CTRL_SHORTCUTS(new MixinBuilder("Use CTRL (CMD on MacOS) to copy/select/delete text")
             .addClientMixins("minecraft.MixinGuiTextField")
-            .setApplyIf(() -> TweaksConfig.enableMacosCmdShortcuts && System.getProperty("os.name").toLowerCase().contains("mac"))
+            .setApplyIf(() -> TweaksConfig.enableTextFieldCtrlShortcuts)
             .setPhase(Phase.EARLY)),
     FIX_FONT_RENDERER_LINEWRAP_RECURSION(new MixinBuilder("Replace recursion with iteration in FontRenderer line wrapping code")
             .addClientMixins("minecraft.MixinFontRenderer")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinGuiTextField.java
@@ -32,8 +32,7 @@ public abstract class MixinGuiTextField {
     public abstract String getSelectedText();
 
     @Inject(method = "textboxKeyTyped", at = @At(value = "HEAD"), cancellable = true)
-    private void hodgepodge$addMacCommandKeyShortcuts(char typedChar, int eventKey,
-            CallbackInfoReturnable<Boolean> cir) {
+    private void hodgepodge$addCtrlKeyShortcuts(char typedChar, int eventKey, CallbackInfoReturnable<Boolean> cir) {
         if (this.isFocused && GuiScreen.isCtrlKeyDown()) {
             if (eventKey == Keyboard.KEY_V) {
                 if (this.isEnabled) {


### PR DESCRIPTION
TEXTFIELD_CTRL_SHORTCUTS (formerly MACOS_KEYS_TEXTFIELD_SHORTCUTS) previously applied only on MacOS. Vanilla's own Ctrl+A/C/V/X handling in GuiTextField failed to trigger on Windows with a Cyrillic keyboard layout, breaking these shortcuts in NEI search, chat, server IP fields, etc.

The mixin's handler already matches on the physical keycode rather than the typed character, so enabling it on every platform fixes the layout issue without touching the copy/paste/select-all/cut logic itself. Renamed enableMacosCmdShortcuts to enableTextFieldCtrlShortcuts to match the wider scope.