### PR TITLE
Better BiblioCraft Printing Press automation

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/TweaksConfig.java
@@ -326,6 +326,12 @@ public class TweaksConfig {
     @Config.DefaultBoolean(true)
     public static boolean thirstyTankContainer;
 
+    // BiblioCraft
+
+    @Config.Comment("Better Printing Press automation")
+    @Config.DefaultBoolean(true)
+    public static boolean betterPrintingPressAutomation;
+
     // Biomes O' Plenty
 
     @Config.Comment("Allow 5 Fir Sapling planted together ('+' shape) to grow to a big fir tree")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1943,7 +1943,8 @@ public enum Mixins implements IMixins {
             .addRequiredMod(TargetedMod.ENDLESSIDS)
             .setPhase(Phase.LATE)),
 
-    // Various Exploits/Fixes
+    // BiblioCraft
+
     BIBLIOCRAFT_PACKET_FIX(new MixinBuilder("Packet Fix")
             .addCommonMixins("bibliocraft.MixinBibliocraftPatchPacketExploits")
             .setApplyIf(() -> FixesConfig.fixBibliocraftPackets)
@@ -1985,6 +1986,14 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> MemoryConfig.leaks.fixBibliocraftTESRWorldLeak)
             .addRequiredMod(TargetedMod.BIBLIOCRAFT)
             .setPhase(Phase.LATE)),
+    BIBLIOCRAFT_BETTER_PRINTING_PRESS_AUTOMATION(new MixinBuilder("Better Printing Press automation")
+            .addCommonMixins("bibliocraft.MixinBiblioCraftPrintPress")
+            .setApplyIf(() -> TweaksConfig.betterPrintingPressAutomation)
+            .addRequiredMod(TargetedMod.BIBLIOCRAFT)
+            .setPhase(Phase.LATE)),
+
+    // Various Exploits/Fixes
+
     ZTONES_PACKET_FIX(new MixinBuilder("Packet Fix")
             .addCommonMixins("ztones.MixinZtonesPatchPacketExploits")
             .setApplyIf(() -> FixesConfig.fixZTonesPackets)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBiblioCraftPrintPress.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBiblioCraftPrintPress.java
@@ -1,0 +1,92 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+
+import com.mitchej123.hodgepodge.util.BlockRelativeSide;
+
+import jds.bibliocraft.tileentities.TileEntityPrintPress;
+
+@Mixin(TileEntityPrintPress.class)
+public abstract class MixinBiblioCraftPrintPress extends TileEntity {
+
+    /**
+     * @author vladislemon
+     * @reason better automation
+     */
+    @Overwrite
+    public int[] getAccessibleSlotsFromSide(int side) {
+        if (side == hodgepodge$getSide(BlockRelativeSide.BACK)) { // plate
+            int[] sides = new int[1];
+            sides[0] = 1;
+            return sides;
+        } else if (side == hodgepodge$getSide(BlockRelativeSide.RIGHT)) { // printed book
+            int[] sides = new int[1];
+            sides[0] = 3;
+            return sides;
+        } else {
+            int[] sides = new int[2];
+            sides[0] = 0;
+            sides[1] = 2;
+            return sides;
+        }
+    }
+
+    /**
+     * @author vladislemon
+     * @reason better automation
+     */
+    @Overwrite
+    public boolean canExtractItem(int slot, ItemStack itemstack, int side) {
+        // plate
+        if (slot == 1 && side == hodgepodge$getSide(BlockRelativeSide.BACK)) {
+            return true;
+        }
+        // printed book
+        if (slot == 3 && side == hodgepodge$getSide(BlockRelativeSide.RIGHT)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Unique
+    private int hodgepodge$getSide(BlockRelativeSide blockSide) {
+        return switch (blockSide) {
+            case BOTTOM -> 0;
+            case TOP -> 1;
+            case LEFT -> switch (getBlockMetadata()) {
+                    case 0 -> 2;
+                    case 1 -> 5;
+                    case 2 -> 3;
+                    case 3 -> 4;
+                    default -> -1;
+                };
+            case RIGHT -> switch (getBlockMetadata()) {
+                    case 0 -> 3;
+                    case 1 -> 4;
+                    case 2 -> 2;
+                    case 3 -> 5;
+                    default -> -1;
+                };
+            case FRONT -> switch (getBlockMetadata()) {
+                    case 0 -> 4;
+                    case 1 -> 2;
+                    case 2 -> 5;
+                    case 3 -> 3;
+                    default -> -1;
+                };
+            case BACK -> switch (getBlockMetadata()) {
+                    case 0 -> 5;
+                    case 1 -> 3;
+                    case 2 -> 4;
+                    case 3 -> 2;
+                    default -> -1;
+                };
+        };
+    }
+
+}

--- a/src/main/java/com/mitchej123/hodgepodge/util/BlockRelativeSide.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/BlockRelativeSide.java
@@ -1,0 +1,10 @@
+package com.mitchej123.hodgepodge.util;
+
+public enum BlockRelativeSide {
+    BOTTOM,
+    TOP,
+    LEFT,
+    RIGHT,
+    FRONT,
+    BACK
+}


### PR DESCRIPTION
## Summary
It is impossible to fully automate Printing Press because you can't extract plate, only printed books.
Press automation in general isn't intuitive. Printed books stacks on right side, but extraction only allowed from bottom.

Changes in this PR:
- extraction of printed books allowed from right side
- extraction and insertion of plate allowed from back side
- extraction and insertion of non-printed books and ink sacs allowed from remaining sides

With this I finally can print barrels of enchanted books without large amount of manual labor (and you too!).


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
