### PR TITLE
Fix boss bar texture when hiding crosshair

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairGuiOpen.java
@@ -17,6 +17,9 @@ public class MixinGuiIngameForge_CrosshairGuiOpen extends GuiIngame {
     public void hodgepodge$hideCrosshairInGui(int width, int height, Operation<Void> original) {
         if (mc.currentScreen == null || mc.currentScreen instanceof GuiChat) {
             original.call(width, height);
+        } else {
+            // Preserve the texture bind that Forge's boss bar relies on.
+            mc.getTextureManager().bindTexture(icons);
         }
     }
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairThirdPerson.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/forge/MixinGuiIngameForge_CrosshairThirdPerson.java
@@ -15,6 +15,8 @@ public class MixinGuiIngameForge_CrosshairThirdPerson extends GuiIngame {
     @Inject(method = "renderCrosshairs", at = @At("HEAD"), cancellable = true, remap = false)
     public void hodgepodge$hideCrosshairThirdPerson(int width, int height, CallbackInfo ci) {
         if (mc.gameSettings.thirdPersonView != 0) {
+            // Preserve the texture bind that Forge's boss bar relies on.
+            mc.getTextureManager().bindTexture(icons);
             ci.cancel();
         }
     }


### PR DESCRIPTION
## Summary
Hodgepodge doen't bind `textures/gui/icons.png` when it decides to skip rendering the crosshair. This makes the boss bar take the first bound texture, often resulting in a black bar. This PR correctly binds icons.png, while in third person mode, and non-chat guis.


## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
