### PR TITLE
add fps counter to `/allocationshud`

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/AllocationRateHUD.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/AllocationRateHUD.java
@@ -17,10 +17,12 @@ public final class AllocationRateHUD {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onRenderGameOverlayTextEvent(RenderGameOverlayEvent.Text event) {
         if (!Minecraft.getMinecraft().gameSettings.showDebugInfo) {
+            final Minecraft mc = Minecraft.getMinecraft();
+            final FontRenderer fr = mc.fontRenderer;
             final String text = this.updateText();
-            final FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
             final int strWidth = fr.getStringWidth(text);
             fr.drawStringWithShadow(text, event.resolution.getScaledWidth() - strWidth - 2, 2, 0xFFFFFFFF);
+            fr.drawStringWithShadow(String.format("FPS: %d", mc.debugFPS), 2, 2, 0xFFFFFFFF);
         }
     }
 

--- a/src/main/resources/META-INF/hodgepodge_at.cfg
+++ b/src/main/resources/META-INF/hodgepodge_at.cfg
@@ -1,4 +1,5 @@
 public net.minecraft.client.Minecraft field_110446_Y # fileAssets
+public net.minecraft.client.Minecraft field_71470_ab # debugFPS
 public net.minecraft.client.Minecraft field_110449_ao # defaultResourcePacks
 public net.minecraft.client.gui.FontRenderer func_78282_e(Ljava/lang/String;)Ljava/lang/String; # getFormatFromString(String) String
 public net.minecraft.client.gui.GuiNewChat field_146252_h # chatLines


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Use case: i'm hunting memory allocations, but sometimes, the allocations are done in the renderer so they are FPS dependant so i need to have access to that info. If i open the debug screen, it impacts the profiling.
<img width="1920" height="1017" alt="2026-08-05_00 28 46" src="https://github.com/user-attachments/assets/fc1216a0-078c-43cf-bdf0-b93ea2661be5" />

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
