### PR TITLE
fix: Orient particles from render view entity instead of player

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -185,6 +185,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixPerspectiveCamera;
 
+    @Config.Comment("Orient particles from the render view entity instead of the player, so detached cameras (freecam, spectator-likes) do not tilt them (MC-46445)")
+    @Config.DefaultBoolean(true)
+    public static boolean fixCameraParticleRotation;
+
     @Config.Comment("Allow some mods to properly fetch the player skin")
     @Config.DefaultBoolean(true)
     public static boolean fixPlayerSkinFetching;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -164,6 +164,10 @@ public enum Mixins implements IMixins {
             .addExcludedMod(TargetedMod.ANGELICA)
             .setApplyIf(() -> FixesConfig.fixPerspectiveCamera)
             .setPhase(Phase.EARLY)),
+    FIX_CAMERA_PARTICLE_ROTATION(new MixinBuilder("Orient particles from the render view entity (MC-46445)")
+            .addClientMixins("minecraft.MixinActiveRenderInfo_CameraRotation")
+            .setApplyIf(() -> FixesConfig.fixCameraParticleRotation)
+            .setPhase(Phase.EARLY)),
     FIX_DEBUG_BOUNDING_BOX(new MixinBuilder("Fix Bounding Box")
             .addClientMixins("minecraft.MixinRenderManager")
             .setApplyIf(() -> FixesConfig.fixDebugBoundingBox)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinActiveRenderInfo_CameraRotation.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinActiveRenderInfo_CameraRotation.java
@@ -1,0 +1,43 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.MathHelper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ActiveRenderInfo.class)
+public class MixinActiveRenderInfo_CameraRotation {
+
+    /**
+     * MC-46445: EntityRenderer.renderWorld calls updateRenderInfo with mc.thePlayer instead of mc.renderViewEntity, so
+     * with any camera-detaching mod the particle billboard vectors are built from the player's angles while the camera
+     * looks elsewhere. Positions stay correct (they come from the unprojected modelview matrix), only the orientation
+     * is wrong. Forge fixed this in 1.12 by switching the callsite to getRenderViewEntity().
+     */
+    @Inject(method = "updateRenderInfo", at = @At("TAIL"))
+    private static void hodgepodge$rotateFromRenderViewEntity(EntityPlayer entity, boolean frontView, CallbackInfo ci) {
+        final Minecraft mc = Minecraft.getMinecraft();
+        final EntityLivingBase view = mc.renderViewEntity;
+        // Only correct the vanilla-style call that means "the camera". Callers that deliberately pass the player
+        // (BetterQuesting's entity previews) are left alone whenever the camera is not detached.
+        if (view == null || view == entity || entity != mc.thePlayer) {
+            return;
+        }
+
+        // Same math as vanilla, with (1 - i * 2) collapsed into s.
+        final float s = frontView ? -1.0F : 1.0F;
+        final float yaw = view.rotationYaw * (float) Math.PI / 180.0F;
+        final float pitch = view.rotationPitch * (float) Math.PI / 180.0F;
+        ActiveRenderInfo.rotationX = MathHelper.cos(yaw) * s;
+        ActiveRenderInfo.rotationZ = MathHelper.sin(yaw) * s;
+        ActiveRenderInfo.rotationYZ = -ActiveRenderInfo.rotationZ * MathHelper.sin(pitch) * s;
+        ActiveRenderInfo.rotationXY = ActiveRenderInfo.rotationX * MathHelper.sin(pitch) * s;
+        ActiveRenderInfo.rotationXZ = MathHelper.cos(pitch);
+    }
+}


### PR DESCRIPTION
## Summary
Orient particles from render view entity instead of player. Most obvious with Botania particles with Freecam

Backported fix from Forge 1.12 for https://mojira.dev/MC-46445


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
