### PR TITLE
fix: use renderViewEntity for fog origin

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/biomesoplenty/BOPFogHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/biomesoplenty/BOPFogHandler.java
@@ -3,7 +3,6 @@ package com.mitchej123.hodgepodge.client.biomesoplenty;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -68,7 +67,7 @@ public class BOPFogHandler {
                         for (int x = -distance; x <= distance; x++) {
                             for (int z = -distance; z <= distance; z++) {
 
-                                EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
+                                EntityLivingBase player = Minecraft.getMinecraft().renderViewEntity;
                                 int playerX = MathHelper.floor_double(player.posX);
                                 int playerY = MathHelper.floor_double(player.posY);
                                 int playerZ = MathHelper.floor_double(player.posZ);
@@ -115,8 +114,8 @@ public class BOPFogHandler {
                         float farPlaneDistanceScaleBiome = (0.1f * (1.0f - fpDistanceBiomeFogAvg)
                                 + 0.75f * fpDistanceBiomeFogAvg);
 
-                        AccessorFogHandler.setFogX(Minecraft.getMinecraft().thePlayer.posX);
-                        AccessorFogHandler.setFogZ(Minecraft.getMinecraft().thePlayer.posZ);
+                        AccessorFogHandler.setFogX(Minecraft.getMinecraft().renderViewEntity.posX);
+                        AccessorFogHandler.setFogZ(Minecraft.getMinecraft().renderViewEntity.posZ);
                         farPlaneDistanceScale = (farPlaneDistanceScaleBiome * weightBiomeFog + 0.75f * weightDefault)
                                 / weightMixed;
                         AccessorFogHandler.setFogFarPlaneDistance(Math.min(farPlaneDistance, farPlaneDistanceM));


### PR DESCRIPTION
## Summary
Freecam compat - use renderViewEntity for fog origin


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
