### PR TITLE
Fix potion timers longer than 27 minutes

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -396,6 +396,11 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixEntityAttributesRange;
 
+    @Config.Comment("Display timers longer than an hour as h:mm:ss instead of vanilla's unbounded mm:ss")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixLongTimerFormat;
+
     @Config.Comment("Fixes items bouncing on stairs and other blocks with odd hitboxes")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -217,6 +217,19 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixPotionLimit;
 
+    @Config.Comment({
+            "Show potion durations longer than 27 minutes correctly instead of freezing at 27:18 or showing **:**.",
+            "The vanilla effect packet truncates the duration to a short, so the real value is sent in a separate Hodgepodge packet.",
+            "Requires the mod on both sides; vanilla clients keep the vanilla behaviour." })
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixLongPotionDuration;
+
+    @Config.Comment("Display timers longer than an hour as h:mm:ss instead of vanilla's unbounded mm:ss")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixLongTimerFormat;
+
     @Config.Comment("Fix game window becoming not resizable after toggling fullscrean in any way")
     @Config.DefaultBoolean(true)
     public static boolean fixResizableFullscreen;
@@ -395,19 +408,6 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean fixEntityAttributesRange;
-
-    @Config.Comment({
-            "Show potion durations longer than 27 minutes correctly instead of freezing at 27:18 or showing **:**.",
-            "The vanilla effect packet truncates the duration to a short, so the real value is sent in a separate Hodgepodge packet.",
-            "Requires the mod on both sides; vanilla clients keep the vanilla behaviour." })
-    @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
-    public static boolean fixLongPotionDuration;
-
-    @Config.Comment("Display timers longer than an hour as h:mm:ss instead of vanilla's unbounded mm:ss")
-    @Config.DefaultBoolean(true)
-    @Config.RequiresMcRestart
-    public static boolean fixLongTimerFormat;
 
     @Config.Comment("Fixes items bouncing on stairs and other blocks with odd hitboxes")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -396,6 +396,14 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixEntityAttributesRange;
 
+    @Config.Comment({
+            "Show potion durations longer than 27 minutes correctly instead of freezing at 27:18 or showing **:**.",
+            "The vanilla effect packet truncates the duration to a short, so the real value is sent in a separate Hodgepodge packet.",
+            "Requires the mod on both sides; vanilla clients keep the vanilla behaviour." })
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixLongPotionDuration;
+
     @Config.Comment("Display timers longer than an hour as h:mm:ss instead of vanilla's unbounded mm:ss")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -239,6 +239,12 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinNetHandlerPlayClient_FixEntityAttributesRange")
             .setApplyIf(() -> FixesConfig.fixEntityAttributesRange)
             .setPhase(Phase.EARLY)),
+    FIX_LONG_POTION_DURATION(new MixinBuilder("Fix Potion Durations Longer Than 27 Minutes")
+            .addCommonMixins(
+                    "minecraft.MixinS1DPacketEntityEffect_LongDuration",
+                    "minecraft.MixinNetHandlerPlayServer_LongPotionDuration")
+            .setApplyIf(() -> FixesConfig.fixLongPotionDuration)
+            .setPhase(Phase.EARLY)),
     FIX_LONG_TIMER_FORMAT(new MixinBuilder("Show Timers Longer Than An Hour As h:mm:ss")
             .addClientMixins("minecraft.MixinStringUtils_LongTimer")
             .setApplyIf(() -> FixesConfig.fixLongTimerFormat)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -242,7 +242,8 @@ public enum Mixins implements IMixins {
     FIX_LONG_POTION_DURATION(new MixinBuilder("Fix Potion Durations Longer Than 27 Minutes")
             .addCommonMixins(
                     "minecraft.MixinS1DPacketEntityEffect_LongDuration",
-                    "minecraft.MixinNetHandlerPlayServer_LongPotionDuration")
+                    "minecraft.MixinNetHandlerPlayServer_LongPotionDuration",
+                    "minecraft.PotionEffectAccessor")
             .setApplyIf(() -> FixesConfig.fixLongPotionDuration)
             .setPhase(Phase.EARLY)),
     FIX_LONG_TIMER_FORMAT(new MixinBuilder("Show Timers Longer Than An Hour As h:mm:ss")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -239,6 +239,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinNetHandlerPlayClient_FixEntityAttributesRange")
             .setApplyIf(() -> FixesConfig.fixEntityAttributesRange)
             .setPhase(Phase.EARLY)),
+    FIX_LONG_TIMER_FORMAT(new MixinBuilder("Show Timers Longer Than An Hour As h:mm:ss")
+            .addClientMixins("minecraft.MixinStringUtils_LongTimer")
+            .setApplyIf(() -> FixesConfig.fixLongTimerFormat)
+            .setPhase(Phase.EARLY)),
     ENDERMAN_BLOCK_GRAB_DISABLE(new MixinBuilder("Disable Endermen Grabbing Blocks")
             .addCommonMixins("minecraft.MixinEntityEndermanGrab")
             .setApplyIf(() -> TweaksConfig.endermanBlockGrabDisable)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_LongPotionDuration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinNetHandlerPlayServer_LongPotionDuration.java
@@ -1,0 +1,37 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.mixins.interfaces.S1DPacketEntityEffectExt;
+import com.mitchej123.hodgepodge.net.MessagePotionDuration;
+import com.mitchej123.hodgepodge.net.NetworkHandler;
+
+@Mixin(NetHandlerPlayServer.class)
+public class MixinNetHandlerPlayServer_LongPotionDuration {
+
+    @Shadow
+    public EntityPlayerMP playerEntity;
+
+    /**
+     * Follow up every effect packet whose duration did not fit in a short with the real duration. Clients without
+     * Hodgepodge simply never receive it and keep the vanilla behaviour.
+     */
+    @Inject(method = "sendPacket", at = @At("RETURN"))
+    private void hodgepodge$sendRealPotionDuration(Packet packetIn, CallbackInfo ci) {
+        if (!(packetIn instanceof S1DPacketEntityEffect)) return;
+
+        final MessagePotionDuration message = ((S1DPacketEntityEffectExt) packetIn).hodgepodge$getDurationMessage();
+        if (message != null) {
+            NetworkHandler.instance.sendTo(message, this.playerEntity);
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinS1DPacketEntityEffect_LongDuration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinS1DPacketEntityEffect_LongDuration.java
@@ -1,0 +1,35 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
+import net.minecraft.potion.PotionEffect;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.mixins.interfaces.S1DPacketEntityEffectExt;
+import com.mitchej123.hodgepodge.net.MessagePotionDuration;
+
+@Mixin(S1DPacketEntityEffect.class)
+public class MixinS1DPacketEntityEffect_LongDuration implements S1DPacketEntityEffectExt {
+
+    @Unique
+    private MessagePotionDuration hodgepodge$durationMessage;
+
+    @Inject(method = "<init>(ILnet/minecraft/potion/PotionEffect;)V", at = @At("RETURN"))
+    private void hodgepodge$keepRealDuration(int entityId, PotionEffect effect, CallbackInfo ci) {
+        if (effect.getDuration() > Short.MAX_VALUE) {
+            this.hodgepodge$durationMessage = new MessagePotionDuration(
+                    entityId,
+                    effect.getPotionID(),
+                    effect.getDuration());
+        }
+    }
+
+    @Override
+    public MessagePotionDuration hodgepodge$getDurationMessage() {
+        return this.hodgepodge$durationMessage;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinStringUtils_LongTimer.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinStringUtils_LongTimer.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.util.StringUtils;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(StringUtils.class)
+public class MixinStringUtils_LongTimer {
+
+    /**
+     * @author Eldrinn-Elantey
+     * @reason Vanilla only formats mm:ss, so an hour long potion effect reads as 60:00. Show h:mm:ss past the hour.
+     */
+    @Overwrite
+    public static String ticksToElapsedTime(int ticks) {
+        int seconds = ticks / 20;
+        final int minutes = seconds / 60;
+        seconds %= 60;
+
+        if (minutes < 60) {
+            return String.format("%d:%02d", minutes, seconds);
+        }
+
+        return String.format("%d:%02d:%02d", minutes / 60, minutes % 60, seconds);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/PotionEffectAccessor.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/PotionEffectAccessor.java
@@ -1,0 +1,13 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.potion.PotionEffect;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PotionEffect.class)
+public interface PotionEffectAccessor {
+
+    @Accessor("duration")
+    void setDuration(int duration);
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/S1DPacketEntityEffectExt.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/interfaces/S1DPacketEntityEffectExt.java
@@ -1,0 +1,9 @@
+package com.mitchej123.hodgepodge.mixins.interfaces;
+
+import com.mitchej123.hodgepodge.net.MessagePotionDuration;
+
+public interface S1DPacketEntityEffectExt {
+
+    /** The message correcting the truncated duration, or null if the duration fits in a short. */
+    MessagePotionDuration hodgepodge$getDurationMessage();
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessagePotionDuration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessagePotionDuration.java
@@ -1,0 +1,65 @@
+package com.mitchej123.hodgepodge.net;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Carries the real duration of a potion effect, which S1DPacketEntityEffect truncates to a short (32767 ticks, about 27
+ * minutes). Sent right after the vanilla packet, so it always arrives after the effect it corrects.
+ */
+public class MessagePotionDuration implements IMessage, IMessageHandler<MessagePotionDuration, IMessage> {
+
+    public int entityId;
+    public int potionId;
+    public int duration;
+
+    public MessagePotionDuration(int entityId, int potionId, int duration) {
+        this.entityId = entityId;
+        this.potionId = potionId;
+        this.duration = duration;
+    }
+
+    public MessagePotionDuration() {}
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.entityId = buf.readInt();
+        this.potionId = buf.readInt();
+        this.duration = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(this.entityId);
+        buf.writeInt(this.potionId);
+        buf.writeInt(this.duration);
+    }
+
+    @Override
+    public IMessage onMessage(MessagePotionDuration message, MessageContext ctx) {
+        if (Minecraft.getMinecraft().theWorld == null) return null;
+        if (message.potionId < 0 || message.potionId >= Potion.potionTypes.length) return null;
+        final Potion potion = Potion.potionTypes[message.potionId];
+        if (potion == null) return null;
+
+        final Entity entity = Minecraft.getMinecraft().theWorld.getEntityByID(message.entityId);
+        if (!(entity instanceof EntityLivingBase)) return null;
+
+        final PotionEffect effect = ((EntityLivingBase) entity).getActivePotionEffect(potion);
+        if (effect == null) return null;
+
+        // combine() is the only public way to raise the duration; it takes the larger of the two
+        effect.combine(new PotionEffect(message.potionId, message.duration, effect.getAmplifier()));
+        effect.setPotionDurationMax(false);
+
+        return null;
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/net/MessagePotionDuration.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/MessagePotionDuration.java
@@ -6,6 +6,8 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 
+import com.mitchej123.hodgepodge.mixins.early.minecraft.PotionEffectAccessor;
+
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
@@ -56,8 +58,7 @@ public class MessagePotionDuration implements IMessage, IMessageHandler<MessageP
         final PotionEffect effect = ((EntityLivingBase) entity).getActivePotionEffect(potion);
         if (effect == null) return null;
 
-        // combine() is the only public way to raise the duration; it takes the larger of the two
-        effect.combine(new PotionEffect(message.potionId, message.duration, effect.getAmplifier()));
+        ((PotionEffectAccessor) effect).setDuration(message.duration);
         effect.setPotionDurationMax(false);
 
         return null;

--- a/src/main/java/com/mitchej123/hodgepodge/net/NetworkHandler.java
+++ b/src/main/java/com/mitchej123/hodgepodge/net/NetworkHandler.java
@@ -15,5 +15,6 @@ public class NetworkHandler {
         instance.registerMessage(MessageConfigSync.class, MessageConfigSync.class, 0, Side.CLIENT);
         instance.registerMessage(BatchedDescriptionHandler.class, BatchedDescriptionPacket.class, 1, Side.CLIENT);
         instance.registerMessage(MessageChangeDifficulty.class, MessageChangeDifficulty.class, 2, Side.CLIENT);
+        instance.registerMessage(MessagePotionDuration.class, MessagePotionDuration.class, 3, Side.CLIENT);
     }
 }


### PR DESCRIPTION
## Summary
S1DPacketEntityEffect stores the effect duration in a short, so anything above 32767 ticks reaches the client clamped at 27:18, or as \*\*:\*\* when it lands exactly on the cap. The client side copy then counts down and expires while the server still holds the effect, so the icon disappears from the HUD until the next relog.

The real duration is now sent in a separate Hodgepodge packet right after the vanilla one, which leaves the protocol untouched, so vanilla clients keep the vanilla behaviour. Separately, the timer text past the hour now reads h:mm:ss instead of vanilla's unbounded mm:ss.

Both are behind config options, fixLongPotionDuration and fixLongTimerFormat.

Tested in game with /effect Developer 1 3600 0, including a relog.

|Before|After|
|-|-|
<img width="622" height="372" alt="java_E7g4qdAZrc" src="https://github.com/user-attachments/assets/ab4f24eb-5ad5-4334-800f-e110a7098d58" />|<img width="636" height="396" alt="java_CfjjZWqztF" src="https://github.com/user-attachments/assets/3eacb8f4-9f7d-4caf-872f-0ee0993d5127" /> <img width="635" height="406" alt="java_ERZIFffMOh" src="https://github.com/user-attachments/assets/b52bea88-aa90-4053-81f0-fa5e87612183" />| 

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
