### PR TITLE
Optimize TE packets

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -210,15 +210,15 @@ public class SpeedupsConfig {
     @Config.DefaultStringList({})
     public static String[] batchDescriptionBlacklist;
 
-    @Config.Comment("Transfer special S35PacketUpdateTileEntity buffers directly without NBT (Enables Mixins)")
+    @Config.Comment("Transfer S35PacketUpdateTileEntity array buffers directly without NBT (Enables Mixins)")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
-    public static boolean skipTileEntityNbtSerializationMixins;
+    public static boolean directTileEntityArraySerializationMixins;
 
-    @Config.Comment("Transfer special S35PacketUpdateTileEntity buffers directly without NBT")
+    @Config.Comment("Transfer S35PacketUpdateTileEntity array buffers directly without NBT")
     @Config.DefaultBoolean(true)
     @Config.Sync
-    public static boolean skipTileEntityNbtSerializationCode;
+    public static boolean directTileEntityArraySerializationCode;
 
     @Config.Comment("Pool Inflater/Deflater instances for NBT compression to reduce native cleanup overhead")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -212,7 +212,7 @@ public class SpeedupsConfig {
 
     @Config.Comment({ "Transfer S35PacketUpdateTileEntity array buffers directly without NBT.",
             "The NBT contained in S35PacketUpdateTileEntity must be of the format {[one character]: [byte array]}",
-            "(e.g. {\"X\": [0, 1]}) for this to apply for a given TileEntity." })
+            "(e.g. {\"X\": [B;0b, 1b]}) for this to apply for a given TileEntity." })
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean directTileEntityArraySerialization;

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -213,12 +213,7 @@ public class SpeedupsConfig {
     @Config.Comment("Transfer S35PacketUpdateTileEntity array buffers directly without NBT (Enables Mixins)")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
-    public static boolean directTileEntityArraySerializationMixins;
-
-    @Config.Comment("Transfer S35PacketUpdateTileEntity array buffers directly without NBT")
-    @Config.DefaultBoolean(true)
-    @Config.Sync
-    public static boolean directTileEntityArraySerializationCode;
+    public static boolean directTileEntityArraySerialization;
 
     @Config.Comment("Pool Inflater/Deflater instances for NBT compression to reduce native cleanup overhead")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -210,7 +210,9 @@ public class SpeedupsConfig {
     @Config.DefaultStringList({})
     public static String[] batchDescriptionBlacklist;
 
-    @Config.Comment("Transfer S35PacketUpdateTileEntity array buffers directly without NBT (Enables Mixins)")
+    @Config.Comment({ "Transfer S35PacketUpdateTileEntity array buffers directly without NBT.",
+            "The NBT contained in S35PacketUpdateTileEntity must be of the format {[one character]: [byte array]}",
+            "(e.g. {\"X\": [0, 1]}) for this to apply for a given TileEntity." })
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean directTileEntityArraySerialization;

--- a/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/SpeedupsConfig.java
@@ -203,12 +203,22 @@ public class SpeedupsConfig {
     public static boolean batchDescriptionPacketsMixins;
 
     @Config.Comment("Batch Tile Entity Description S35PacketUpdateTileEntity Packets (Enables Code, Does not require restart)")
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     public static boolean batchDescriptionPacketsCode;
 
     @Config.Comment("Tile Entity Packet Batching Blacklist (Fully Qualified Class Names, Does not require restart)")
     @Config.DefaultStringList({})
     public static String[] batchDescriptionBlacklist;
+
+    @Config.Comment("Transfer special S35PacketUpdateTileEntity buffers directly without NBT (Enables Mixins)")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean skipTileEntityNbtSerializationMixins;
+
+    @Config.Comment("Transfer special S35PacketUpdateTileEntity buffers directly without NBT")
+    @Config.DefaultBoolean(true)
+    @Config.Sync
+    public static boolean skipTileEntityNbtSerializationCode;
 
     @Config.Comment("Pool Inflater/Deflater instances for NBT compression to reduce native cleanup overhead")
     @Config.DefaultBoolean(true)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1040,9 +1040,9 @@ public enum Mixins implements IMixins {
                     "forge.tiledescriptions.MixinForgeHooks")
             .setApplyIf(() -> SpeedupsConfig.batchDescriptionPacketsMixins)
             .setPhase(Phase.EARLY)),
-    SPEEDUP_TILE_DESCRIPTION_PACKETS_NBT(new MixinBuilder("Optimize S35PacketUpdateTileEntity Packets")
+    SPEEDUP_TILE_DESCRIPTION_PACKETS_NBT(new MixinBuilder("Optimize S35PacketUpdateTileEntity Array Packets")
             .addCommonMixins("minecraft.packets.MixinS35PacketUpdateTileEntity_ByteArray")
-            .setApplyIf(() -> SpeedupsConfig.skipTileEntityNbtSerializationMixins)
+            .setApplyIf(() -> SpeedupsConfig.directTileEntityArraySerializationMixins)
             .setPhase(Phase.EARLY)),
     HIDE_DEPRECATED_ID_NOTICE(new MixinBuilder()
             .addClientMixins("minecraft.MixinHideDeprecatedIdNotice")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1042,7 +1042,7 @@ public enum Mixins implements IMixins {
             .setPhase(Phase.EARLY)),
     SPEEDUP_TILE_DESCRIPTION_PACKETS_NBT(new MixinBuilder("Optimize S35PacketUpdateTileEntity Array Packets")
             .addCommonMixins("minecraft.packets.MixinS35PacketUpdateTileEntity_ByteArray")
-            .setApplyIf(() -> SpeedupsConfig.directTileEntityArraySerializationMixins)
+            .setApplyIf(() -> SpeedupsConfig.directTileEntityArraySerialization)
             .setPhase(Phase.EARLY)),
     HIDE_DEPRECATED_ID_NOTICE(new MixinBuilder()
             .addClientMixins("minecraft.MixinHideDeprecatedIdNotice")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1040,6 +1040,10 @@ public enum Mixins implements IMixins {
                     "forge.tiledescriptions.MixinForgeHooks")
             .setApplyIf(() -> SpeedupsConfig.batchDescriptionPacketsMixins)
             .setPhase(Phase.EARLY)),
+    SPEEDUP_TILE_DESCRIPTION_PACKETS_NBT(new MixinBuilder("Optimize S35PacketUpdateTileEntity Packets")
+            .addCommonMixins("minecraft.packets.MixinS35PacketUpdateTileEntity_ByteArray")
+            .setApplyIf(() -> SpeedupsConfig.skipTileEntityNbtSerializationMixins)
+            .setPhase(Phase.EARLY)),
     HIDE_DEPRECATED_ID_NOTICE(new MixinBuilder()
             .addClientMixins("minecraft.MixinHideDeprecatedIdNotice")
             .setApplyIf(() -> TweaksConfig.hideDeprecatedIdNotice)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -1,0 +1,79 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.packets;
+
+import com.mitchej123.hodgepodge.config.SpeedupsConfig;
+import com.mitchej123.hodgepodge.config.TweaksConfig;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.client.C01PacketChatMessage;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraftforge.common.util.Constants;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.io.IOException;
+import java.util.Set;
+
+@Mixin(S35PacketUpdateTileEntity.class)
+public class MixinS35PacketUpdateTileEntity_ByteArray {
+
+    @Redirect(method = "readPacketData",
+    at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;"))
+    public NBTTagCompound hodgepodge$readNBTTagCompoundFromBuffer(PacketBuffer data) throws IOException {
+        if (!SpeedupsConfig.skipTileEntityNbtSerializationCode) {
+            return data.readNBTTagCompoundFromBuffer();
+        }
+        byte id = data.readByte();
+        if (id == 0) {
+            return data.readNBTTagCompoundFromBuffer();
+        }
+        String key = String.valueOf((char) id);
+        byte[] buffer = new byte[data.readVarIntFromBuffer()];
+        data.readBytes(buffer);
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setByteArray(key, buffer);
+        return tag;
+    }
+
+    @Redirect(method = "writePacketData",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/PacketBuffer;writeNBTTagCompoundToBuffer(Lnet/minecraft/nbt/NBTTagCompound;)V"))
+    public void hodgepodge$writeNBTTagCompoundFromBuffer(PacketBuffer data, NBTTagCompound nbt) throws IOException {
+        if (!SpeedupsConfig.skipTileEntityNbtSerializationCode) {
+            data.writeNBTTagCompoundToBuffer(nbt);
+            return;
+        }
+        Set<String> keys = nbt.func_150296_c();
+        if (keys.size() != 1) {
+            data.writeByte(0);
+            data.writeNBTTagCompoundToBuffer(nbt);
+            return;
+        }
+        String key = keys.iterator().next();
+        if (key.length() != 1) {
+            data.writeByte(0);
+            data.writeNBTTagCompoundToBuffer(nbt);
+            return;
+        }
+        char k = key.charAt(0);
+        if (k == 0 || k > 255) {
+            data.writeByte(0);
+            data.writeNBTTagCompoundToBuffer(nbt);
+            return;
+        }
+        if (!nbt.hasKey(key, Constants.NBT.TAG_BYTE_ARRAY)) {
+            data.writeByte(0);
+            data.writeNBTTagCompoundToBuffer(nbt);
+            return;
+        }
+        byte[] arr = nbt.getByteArray(key);
+        data.writeByte(k);
+        data.writeVarIntToBuffer(arr.length);
+        data.writeBytes(arr);
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -23,7 +23,7 @@ public class MixinS35PacketUpdateTileEntity_ByteArray {
                     value = "INVOKE",
                     target = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;"))
     public NBTTagCompound hodgepodge$readNBTTagCompoundFromBuffer(PacketBuffer data) throws IOException {
-        if (!SpeedupsConfig.skipTileEntityNbtSerializationCode) {
+        if (!SpeedupsConfig.directTileEntityArraySerializationCode) {
             return data.readNBTTagCompoundFromBuffer();
         }
         byte id = data.readByte();
@@ -44,7 +44,7 @@ public class MixinS35PacketUpdateTileEntity_ByteArray {
                     value = "INVOKE",
                     target = "Lnet/minecraft/network/PacketBuffer;writeNBTTagCompoundToBuffer(Lnet/minecraft/nbt/NBTTagCompound;)V"))
     public void hodgepodge$writeNBTTagCompoundFromBuffer(PacketBuffer data, NBTTagCompound nbt) throws IOException {
-        if (!SpeedupsConfig.skipTileEntityNbtSerializationCode) {
+        if (!SpeedupsConfig.directTileEntityArraySerializationCode) {
             data.writeNBTTagCompoundToBuffer(nbt);
             return;
         }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -1,28 +1,27 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft.packets;
 
-import com.mitchej123.hodgepodge.config.SpeedupsConfig;
-import com.mitchej123.hodgepodge.config.TweaksConfig;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.PacketBuffer;
-import net.minecraft.network.play.client.C01PacketChatMessage;
-import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
-import net.minecraftforge.common.util.Constants;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
-import org.spongepowered.asm.mixin.injection.Redirect;
-
 import java.io.IOException;
 import java.util.Set;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
+import net.minecraftforge.common.util.Constants;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.mitchej123.hodgepodge.config.SpeedupsConfig;
 
 @Mixin(S35PacketUpdateTileEntity.class)
 public class MixinS35PacketUpdateTileEntity_ByteArray {
 
-    @Redirect(method = "readPacketData",
-    at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;"))
+    @Redirect(
+            method = "readPacketData",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;"))
     public NBTTagCompound hodgepodge$readNBTTagCompoundFromBuffer(PacketBuffer data) throws IOException {
         if (!SpeedupsConfig.skipTileEntityNbtSerializationCode) {
             return data.readNBTTagCompoundFromBuffer();
@@ -39,7 +38,8 @@ public class MixinS35PacketUpdateTileEntity_ByteArray {
         return tag;
     }
 
-    @Redirect(method = "writePacketData",
+    @Redirect(
+            method = "writePacketData",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/network/PacketBuffer;writeNBTTagCompoundToBuffer(Lnet/minecraft/nbt/NBTTagCompound;)V"))

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
- * Optimize NBT of the form {[one character]: [byte array]}, e.g. {"X": [0, 1]}. This skips the compression and the NBT
+ * Optimize NBT of the form {[one character]: [byte array]}, e.g. {"X": [B;0b, 1b]}. This skips the compression and the NBT
  * overhead on the network. NBT that does not follow this will get sent normally with an extra byte instead.
  */
 @Mixin(S35PacketUpdateTileEntity.class)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -13,6 +13,10 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+/**
+ * Optimize NBT of the form {[one character]: [byte array]}, e.g. {"X": [0, 1]}. This skips the compression and the NBT
+ * overhead on the network. NBT that does not follow this will get sent normally with an extra byte instead.
+ */
 @Mixin(S35PacketUpdateTileEntity.class)
 public class MixinS35PacketUpdateTileEntity_ByteArray {
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -9,10 +9,9 @@ import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraftforge.common.util.Constants;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-
-import com.mitchej123.hodgepodge.config.SpeedupsConfig;
 
 @Mixin(S35PacketUpdateTileEntity.class)
 public class MixinS35PacketUpdateTileEntity_ByteArray {
@@ -23,9 +22,6 @@ public class MixinS35PacketUpdateTileEntity_ByteArray {
                     value = "INVOKE",
                     target = "Lnet/minecraft/network/PacketBuffer;readNBTTagCompoundFromBuffer()Lnet/minecraft/nbt/NBTTagCompound;"))
     public NBTTagCompound hodgepodge$readNBTTagCompoundFromBuffer(PacketBuffer data) throws IOException {
-        if (!SpeedupsConfig.directTileEntityArraySerializationCode) {
-            return data.readNBTTagCompoundFromBuffer();
-        }
         byte id = data.readByte();
         if (id == 0) {
             return data.readNBTTagCompoundFromBuffer();
@@ -44,36 +40,33 @@ public class MixinS35PacketUpdateTileEntity_ByteArray {
                     value = "INVOKE",
                     target = "Lnet/minecraft/network/PacketBuffer;writeNBTTagCompoundToBuffer(Lnet/minecraft/nbt/NBTTagCompound;)V"))
     public void hodgepodge$writeNBTTagCompoundFromBuffer(PacketBuffer data, NBTTagCompound nbt) throws IOException {
-        if (!SpeedupsConfig.directTileEntityArraySerializationCode) {
-            data.writeNBTTagCompoundToBuffer(nbt);
-            return;
-        }
         Set<String> keys = nbt.func_150296_c();
         if (keys.size() != 1) {
-            data.writeByte(0);
-            data.writeNBTTagCompoundToBuffer(nbt);
+            hodgepodge$bailOut(data, nbt);
             return;
         }
         String key = keys.iterator().next();
         if (key.length() != 1) {
-            data.writeByte(0);
-            data.writeNBTTagCompoundToBuffer(nbt);
+            hodgepodge$bailOut(data, nbt);
             return;
         }
         char k = key.charAt(0);
         if (k == 0 || k > 255) {
-            data.writeByte(0);
-            data.writeNBTTagCompoundToBuffer(nbt);
             return;
         }
         if (!nbt.hasKey(key, Constants.NBT.TAG_BYTE_ARRAY)) {
-            data.writeByte(0);
-            data.writeNBTTagCompoundToBuffer(nbt);
+            hodgepodge$bailOut(data, nbt);
             return;
         }
         byte[] arr = nbt.getByteArray(key);
         data.writeByte(k);
         data.writeVarIntToBuffer(arr.length);
         data.writeBytes(arr);
+    }
+
+    @Unique
+    private void hodgepodge$bailOut(PacketBuffer data, NBTTagCompound nbt) throws IOException {
+        data.writeByte(0);
+        data.writeNBTTagCompoundToBuffer(nbt);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -52,6 +52,7 @@ public class MixinS35PacketUpdateTileEntity_ByteArray {
         }
         char k = key.charAt(0);
         if (k == 0 || k > 255) {
+            hodgepodge$bailOut(data, nbt);
             return;
         }
         if (!nbt.hasKey(key, Constants.NBT.TAG_BYTE_ARRAY)) {

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinS35PacketUpdateTileEntity_ByteArray.java
@@ -14,8 +14,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
- * Optimize NBT of the form {[one character]: [byte array]}, e.g. {"X": [B;0b, 1b]}. This skips the compression and the NBT
- * overhead on the network. NBT that does not follow this will get sent normally with an extra byte instead.
+ * Optimize NBT of the form {[one character]: [byte array]}, e.g. {"X": [B;0b, 1b]}. This skips the compression and the
+ * NBT overhead on the network. NBT that does not follow this will get sent normally with an extra byte instead.
  */
 @Mixin(S35PacketUpdateTileEntity.class)
 public class MixinS35PacketUpdateTileEntity_ByteArray {


### PR DESCRIPTION
## Summary

Tested both with `batchDescriptionPacketsCode=false`, because it cause `.name` gt block due to packet reordering and I don't like it (and it will mess with packet types for my testing). Tested with <https://github.com/GTNewHorizons/GT5-Unofficial/pull/7821> so that optimization apply to both gt and ae2 tiles which accounts for over 90% of TE in end game base.

With new option checked:
```
/netstat hottest-write
[Server thread/INFO]: PacketStat(53){totalBytes=93015879, count=2415288, averageBytes=38.0}
/netstat most-write
[Server thread/INFO]: PacketStat(53){totalBytes=93015879, count=2415288, averageBytes=38.0}
```

With new option unchecked:
```
/netstat hottest-write
[Server thread/INFO]: PacketStat(53){totalBytes=23063083, count=313312, averageBytes=73.0}
/netstat most-write
[Server thread/INFO]: PacketStat(53){totalBytes=23063380, count=313315, averageBytes=73.0}
```

Since NBT parsing and GZIP compression is completely skipped in this code path, this results in both faster packet processing and less bandwidth usage.

In the future, stream level compression could be tried to further reduce the bandwidth usage, since these arrays are not very dense in terms of data, and is very repetitive due to many tile entities have similar/same states. Compressing per packet would be much less efficient due to the fact that the repetitive nature cannot be exploited.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
