### PR TITLE
Prevent Bibliocraft Armor Stands from blindly destroying their other half

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -588,6 +588,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixBibliocraftPackets;
 
+    @Config.Comment("Fix Bibliocraft armor stands breaking their other half without checking if the other half is an Armor Stand.")
+    @Config.DefaultBoolean(true)
+    public static boolean fixBibliocraftArmorStandBreak;
+
     @Config.Comment("Fix Bibliocraft path sanitization")
     @Config.DefaultBoolean(true)
     public static boolean fixBibliocraftPathSanitization;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1959,6 +1959,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixBibliocraftPackets)
             .addRequiredMod(TargetedMod.BIBLIOCRAFT)
             .setPhase(Phase.LATE)),
+    BIBLIOCRAFT_ARMOR_STAND_BREAK_FIX(new MixinBuilder("Bibliocraft Armor Stand on-break-block fix")
+            .addCommonMixins("bibliocraft.MixinBlockArmorStand_CheckedBreak")
+            .setApplyIf(() -> FixesConfig.fixBibliocraftArmorStandBreak)
+            .addRequiredMod(TargetedMod.BIBLIOCRAFT)
+            .setPhase(Phase.LATE)),
     BIBLIOCRAFT_PATH_SANITIZATION_FIX(new MixinBuilder("Path sanitization fix")
             .addCommonMixins("bibliocraft.MixinPathSanitization")
             .setApplyIf(() -> FixesConfig.fixBibliocraftPathSanitization)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBlockArmorStand_CheckedBreak.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBlockArmorStand_CheckedBreak.java
@@ -24,20 +24,27 @@ public abstract class MixinBlockArmorStand_CheckedBreak extends BlockContainer {
     }
 
     @WrapMethod(method = "breakBlock")
-    private void checkMatchesBlock(World world, int x, int y, int z, Block blockBroken, int metaData,
+    private void checkMatchesBlock(World world, int x, int y, int z, Block blockBroken, int meta,
             Operation<Void> original) {
-        int otherY = metaData < 4 ? y + 1 : y - 1;
-        int otherMeta = metaData < 4 ? metaData + 4 : metaData - 4;
+        // For the Armor Stand, metadata 0-3 is the bottom half & metadata 4-7 is the top half.
+        // (metadata & 0b11) determines the rotation of the block.
+        boolean isBottomHalf = meta < 4;
+
+        // Calculate the expected position & meta of the other half of the Armor Stand.
+        int otherY = isBottomHalf ? y + 1 : y - 1;
+        int otherMeta = isBottomHalf ? meta + 4 : meta - 4;
 
         if (world.getBlock(x, otherY, z) == blockBroken && world.getBlockMetadata(x, otherY, z) == otherMeta) {
-            original.call(world, x, y, z, blockBroken, metaData);
+            // If both halves of the Armor Stand are present, destroy both.
+            original.call(world, x, y, z, blockBroken, meta);
         } else {
-            // If the block below / above it is not the other part of the armor stand, don't break that block.
-            if (metaData < 4) {
+            // If the block below / above it is not the other half of the armor stand, don't break it.
+            if (isBottomHalf) {
+                // The bottom half of the armor stand stores the inventory.
                 this.dropItems(world, x, y, z);
             }
 
-            super.breakBlock(world, x, y, z, blockBroken, metaData);
+            super.breakBlock(world, x, y, z, blockBroken, meta);
         }
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBlockArmorStand_CheckedBreak.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinBlockArmorStand_CheckedBreak.java
@@ -1,0 +1,43 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import jds.bibliocraft.blocks.BlockArmorStand;
+
+@Mixin(BlockArmorStand.class)
+public abstract class MixinBlockArmorStand_CheckedBreak extends BlockContainer {
+
+    @Shadow(remap = false)
+    protected abstract void dropItems(World world, int i, int j, int k);
+
+    protected MixinBlockArmorStand_CheckedBreak(Material p_i45386_1_) {
+        super(p_i45386_1_);
+    }
+
+    @WrapMethod(method = "breakBlock")
+    private void checkMatchesBlock(World world, int x, int y, int z, Block blockBroken, int metaData,
+            Operation<Void> original) {
+        int otherY = metaData < 4 ? y + 1 : y - 1;
+        int otherMeta = metaData < 4 ? metaData + 4 : metaData - 4;
+
+        if (world.getBlock(x, otherY, z) == blockBroken && world.getBlockMetadata(x, otherY, z) == otherMeta) {
+            original.call(world, x, y, z, blockBroken, metaData);
+        } else {
+            // If the block below / above it is not the other part of the armor stand, don't break that block.
+            if (metaData < 4) {
+                this.dropItems(world, x, y, z);
+            }
+
+            super.breakBlock(world, x, y, z, blockBroken, metaData);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Make Bibliocraft Armor Stands check that their other half is an Armor Stand before ejecting its items and destroying it.

Closes GTNewHorizons/Dupes-Exploits-GTNH#108.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack - I don't think Bibliocraft Armor Stands exist in full-pack anymore.
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
