### PR TITLE
Fix block hit delay after survival/creative mode switch

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -547,6 +547,11 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean raiseMissingItemsFPS;
+
+    @Config.Comment("Fix block hit delay after game mode changed from creative to survival.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean fixBlockHitDelay;
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1174,6 +1174,10 @@ public enum Mixins implements IMixins {
             .addCommonMixins("minecraft.MixinMinecraft_FMLQueryFPS")
             .setApplyIf(() -> FixesConfig.raiseMissingItemsFPS)
             .setPhase(Phase.EARLY)),
+    FIX_BLOCK_HIT_DELAY(new MixinBuilder()
+            .addClientMixins("minecraft.MixinPlayerControllerMP_BlockHitDelay")
+            .setApplyIf(() -> FixesConfig.fixBlockHitDelay)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPlayerControllerMP_BlockHitDelay.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinPlayerControllerMP_BlockHitDelay.java
@@ -1,0 +1,21 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.client.multiplayer.PlayerControllerMP;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerControllerMP.class)
+public class MixinPlayerControllerMP_BlockHitDelay {
+
+    @Shadow
+    private int blockHitDelay;
+
+    @Inject(method = "clickBlock", at = @At("HEAD"))
+    public void clickBlock(int x, int y, int z, int side, CallbackInfo ci) {
+        blockHitDelay = 0;
+    }
+}


### PR DESCRIPTION
## Summary
blockHitDelay is set to 5 after breaking a block but never set to 0. Hence if you break a block in creative and then mode switch to survival, there will be an initial hit delay. This patches the behaviour.

This is needed for upcoming vajra configuration, as blockHitDelay will be used there.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
