### PR TITLE
Fix BiblioCraft FancySign shift-click dupe

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1959,7 +1959,9 @@ public enum Mixins implements IMixins {
 
     // Various Exploits/Fixes
     BIBLIOCRAFT_PACKET_FIX(new MixinBuilder("Packet Fix")
-            .addCommonMixins("bibliocraft.MixinBibliocraftPatchPacketExploits")
+            .addCommonMixins(
+                    "bibliocraft.MixinBibliocraftPatchPacketExploits",
+                    "bibliocraft.MixinContainerFancySign")
             .setApplyIf(() -> FixesConfig.fixBibliocraftPackets)
             .addRequiredMod(TargetedMod.BIBLIOCRAFT)
             .setPhase(Phase.LATE)),

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinContainerFancySign.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinContainerFancySign.java
@@ -1,0 +1,41 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import jds.bibliocraft.blocks.ContainerFancySign;
+
+@Mixin(ContainerFancySign.class)
+public abstract class MixinContainerFancySign extends Container {
+
+    @WrapOperation(
+            method = "transferStackInSlot",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljds/bibliocraft/blocks/ContainerFancySign;mergeItemStack(Lnet/minecraft/item/ItemStack;IIZ)Z"))
+    private boolean hodgepodge$respectFancySignSlotLimits(ContainerFancySign instance, ItemStack stack, int start,
+            int end, boolean reverse, Operation<Boolean> original) {
+        if (start == 0 && end == 2) {
+
+            boolean changed = false;
+            for (int i = 0; i < 2 && stack.stackSize > 0; i++) {
+                Slot slot = inventorySlots.get(i);
+                if (!slot.getHasStack() && slot.isItemValid(stack)) {
+                    slot.putStack(stack.splitStack(Math.min(stack.stackSize, slot.getSlotStackLimit())));
+                    slot.onSlotChanged();
+                    changed = true;
+                }
+            }
+            return changed;
+        }
+
+        return original.call(instance, stack, start, end, reverse);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the BiblioCraft FancySign shift-click duplication exploit by respecting the sign slots’ stack limit during transfers. Shift-click remains supported, placing one item in each sign slot and leaving the remainder in the player’s inventory.

Fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/197

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
