### PR TITLE
Fixed furnace BurnTime overflow with high BurnTime fuels

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -113,6 +113,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixFriendlyCreatureSounds;
 
+    @Config.Comment("Fix vanilla furnaces' burn time overflowing from long burn time fuel")
+    @Config.DefaultBoolean(true)
+    public static boolean fixFuelOverflow;
+
     @Config.Comment("Fix Volume Slider is ineffective until reaching the lower end")
     @Config.DefaultBoolean(true)
     public static boolean logarithmicVolumeControl;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -341,6 +341,10 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> SpeedupsConfig.speedupVanillaFurnace)
             .addRequiredMod(TargetedMod.GTNHLIB)
             .setPhase(Phase.EARLY)),
+    FIX_FUEL_OVERFLOW(new MixinBuilder("Fix vanilla furnace fuel overflow")
+            .addCommonMixins("minecraft.MixinTileEntityFurnace_FixFuelOverflow")
+            .setApplyIf(() -> FixesConfig.fixFuelOverflow)
+            .setPhase(Phase.EARLY)),
     GAMEOVER_GUI_LOCKED_DISABLED(new MixinBuilder("Fix Gameover GUI")
             .addClientMixins("minecraft.MixinGuiGameOver")
             .setApplyIf(() -> FixesConfig.fixGuiGameOver)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnace_FixFuelOverflow.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnace_FixFuelOverflow.java
@@ -3,11 +3,12 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
 
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(TileEntityFurnace.class)
 public class MixinTileEntityFurnace_FixFuelOverflow {
@@ -30,12 +31,16 @@ public class MixinTileEntityFurnace_FixFuelOverflow {
     /**
      * Fixes BurnTime overflow with fuel over Short.MAX_VALUE BurnTime
      * <p>
-     * Overwrites the getShort earlier in the method, additionally allows conversion of old short BurnTime to an Integer
+     * Overwrites the getShort with the getInteger value when it attempts to write the short value
      */
-    @Inject(method = "readFromNBT", at = @At("RETURN"))
-    private void hodgepodge$readBurnTime(NBTTagCompound compound, CallbackInfo ci) {
-        if (compound.hasKey("BurnTime", 3)) {
-            ((TileEntityFurnace) (Object) this).furnaceBurnTime = compound.getInteger("BurnTime");
-        }
+    @Redirect(
+            method = "readFromNBT",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/tileentity/TileEntityFurnace;furnaceBurnTime:I",
+                    opcode = Opcodes.PUTFIELD))
+    private void hodgepodge$readBurnTime(TileEntityFurnace instance, int value,
+            @Local(argsOnly = true) NBTTagCompound compound) {
+        instance.furnaceBurnTime = compound.getInteger("BurnTime");
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnace_FixFuelOverflow.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnace_FixFuelOverflow.java
@@ -1,11 +1,9 @@
 package com.mitchej123.hodgepodge.mixins.early.minecraft;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnace_FixFuelOverflow.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinTileEntityFurnace_FixFuelOverflow.java
@@ -1,0 +1,43 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntityFurnace;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityFurnace.class)
+public class MixinTileEntityFurnace_FixFuelOverflow {
+
+    /**
+     * Fixes BurnTime overflow with fuel over Short.MAX_VALUE BurnTime
+     * <p>
+     * Writes an Integer instead of a short for the BurnTime tag
+     */
+    @Redirect(
+            method = "writeToNBT",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/nbt/NBTTagCompound;setShort(Ljava/lang/String;S)V",
+                    ordinal = 0))
+    private void hodgepodge$writeBurnTime(NBTTagCompound compound, String key, short value) {
+        compound.setInteger(key, ((TileEntityFurnace) (Object) this).furnaceBurnTime);
+    }
+
+    /**
+     * Fixes BurnTime overflow with fuel over Short.MAX_VALUE BurnTime
+     * <p>
+     * Overwrites the getShort earlier in the method, additionally allows conversion of old short BurnTime to an Integer
+     */
+    @Inject(method = "readFromNBT", at = @At("RETURN"))
+    private void hodgepodge$readBurnTime(NBTTagCompound compound, CallbackInfo ci) {
+        if (compound.hasKey("BurnTime", 3)) {
+            ((TileEntityFurnace) (Object) this).furnaceBurnTime = compound.getInteger("BurnTime");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes this bug for vanilla furnaces https://github.com/GTNewHorizons/Et-Futurum-Requiem/pull/113
([original issue](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25273))

Changes the "BurnTime" component in the Furnace tile entity to use an Integer tag instead of a Short tag to prevent BurnTime overflow.

The write uses a Redirect injector, but the read is more complicated because I can't cleanly change the return signature of getShort. It injects itself at the return of the readNBT, allowing it to overwrite the short-casted version of BurnTime. It also has a check for if the Integer version of the BurnTime tag has been made, as to not overwrite the BurnTime with 0 when updating the pack.

I can use more direct ways to change the readNBT part to use an Integer, but this seemed like the best option to me?
alexdoru please tell me how i'm wrong :)

## Todo

Fix this bug in all other BurnTime implementations, I know that at least Natura nether furnaces still use shorts too. (outside of this repo's scope)

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
