### PR TITLE
Fix shift clicking items out of filing cabinet voiding excess items

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -722,6 +722,10 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesFilingCabinetDupe;
 
+    @Config.Comment("Fixes shift clicking items from filing cabinets voiding what was left down to a stack")
+    @Config.DefaultBoolean(true)
+    public static boolean fixExtraUtilitiesFilingCabinetShiftClick;
+
     @Config.Comment("Prevent hotkeying other items onto item filters while they are open")
     @Config.DefaultBoolean(true)
     public static boolean fixExtraUtilitiesFilterDupe;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1843,8 +1843,13 @@ public enum Mixins implements IMixins {
             .addRequiredMod(TargetedMod.EXTRA_UTILITIES)
             .setPhase(Phase.LATE)),
     FIX_FILING_CABINET_DUPE(new MixinBuilder("Caps hotkey'd stacks to their maximum stack size in filing cabinets")
-            .addCommonMixins("extrautilities.MixinContainerFilingCabinet")
+            .addCommonMixins("extrautilities.MixinContainerFilingCabinetDupe")
             .setApplyIf(() -> FixesConfig.fixExtraUtilitiesFilingCabinetDupe)
+            .addRequiredMod(TargetedMod.EXTRA_UTILITIES)
+            .setPhase(Phase.LATE)),
+    FIX_FILING_CABINET_VOIDING(new MixinBuilder("Fixes shift clicking items from filing cabinets voiding what was left down to a stack")
+            .addCommonMixins("extrautilities.MixinContainerFilingCabinetShiftClick")
+            .setApplyIf(() -> FixesConfig.fixExtraUtilitiesFilingCabinetShiftClick)
             .addRequiredMod(TargetedMod.EXTRA_UTILITIES)
             .setPhase(Phase.LATE)),
     FIX_FILTER_DUPE(new MixinBuilder("Prevent hotkeying other items onto item filters while they are open")

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilingCabinetDupe.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilingCabinetDupe.java
@@ -20,7 +20,7 @@ import com.rwtema.extrautils.gui.ContainerFilingCabinet;
 import invtweaks.api.container.ContainerSection;
 
 @Mixin(value = ContainerFilingCabinet.class)
-public abstract class MixinContainerFilingCabinet extends Container {
+public abstract class MixinContainerFilingCabinetDupe extends Container {
 
     @Shadow(remap = false)
     public abstract Map<ContainerSection, List<Slot>> getSlots();

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilingCabinetShiftClick.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/extrautilities/MixinContainerFilingCabinetShiftClick.java
@@ -1,0 +1,57 @@
+package com.mitchej123.hodgepodge.mixins.late.extrautilities;
+
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.rwtema.extrautils.gui.ContainerFilingCabinet;
+
+@Mixin(value = ContainerFilingCabinet.class)
+public abstract class MixinContainerFilingCabinetShiftClick extends Container {
+    // The original code created a temp ItemStack, but still modified the original ItemStack's size before checking if
+    // the transfer could go through
+
+    // modify temp ItemStack's size instead of original ItemStack
+    @Redirect(
+            method = "transferStackInSlot",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/item/ItemStack;stackSize:I",
+                    opcode = Opcodes.PUTFIELD,
+                    ordinal = 0))
+    private void hodgepodge$modifyTempVariableStackSize(ItemStack itemstack1, int m,
+            @Local(name = "itemstack") ItemStack itemstack) {
+        itemstack.stackSize = m;
+    }
+
+    // use temp ItemStack in the merge function instead of the original
+    @ModifyArg(
+            method = "transferStackInSlot",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/rwtema/extrautils/gui/ContainerFilingCabinet;mergeItemStack(Lnet/minecraft/item/ItemStack;IIZ)Z",
+                    ordinal = 0))
+    private ItemStack hodgepodge$mergeItemStackWithTempVariable(ItemStack itemstack1,
+            @Local(name = "itemstack") ItemStack itemstack) {
+        return itemstack;
+    }
+
+    // since mergeItemStack sets the size of the ItemStack to 0, use the outer "m" variable to decrease the original
+    // ItemStack's size
+    @Redirect(
+            method = "transferStackInSlot",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/item/ItemStack;stackSize:I",
+                    opcode = Opcodes.PUTFIELD,
+                    ordinal = 1))
+    private void hodgepodge$decreaseStackSizeCorrectly(ItemStack itemstack1, int m, @Local(name = "m") int m_outer) {
+        itemstack1.stackSize -= m_outer;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a bug where shift clicking items out of a filing cabinet would void what was left down to a stack if you didn't have enough space in your inventory. (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19981)

### Example
<img width="2560" height="1440" alt="before" src="https://github.com/user-attachments/assets/7960630f-15b2-4a61-b62b-f3848ce04543" />
Before:
<img width="2560" height="1440" alt="after (before fix)" src="https://github.com/user-attachments/assets/b4e20d20-5926-421b-b539-73c7882ef4f9" />
After:
<img width="2560" height="1440" alt="after (after fix)" src="https://github.com/user-attachments/assets/708d907a-be16-4589-a8bb-dba60a268de1" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge