### PR TITLE
Fix HRTF affecting UI sounds and music

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/sound/LibraryHodgepodgeOpenAL.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/sound/LibraryHodgepodgeOpenAL.java
@@ -3,11 +3,11 @@ package com.mitchej123.hodgepodge.client.sound;
 import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.config.SoundConfig;
 
+import paulscode.sound.Channel;
 import paulscode.sound.FilenameURL;
 import paulscode.sound.SoundBuffer;
 import paulscode.sound.SoundSystemConfig;
 import paulscode.sound.SoundSystemException;
-import paulscode.sound.Source;
 import paulscode.sound.libraries.ChannelLWJGLOpenAL;
 import paulscode.sound.libraries.LibraryLWJGLOpenAL;
 
@@ -20,11 +20,10 @@ import paulscode.sound.libraries.LibraryLWJGLOpenAL;
  * <li><b>Release redundant decoded data.</b> {@code loadSound} keeps the decoded PCM in a Java {@code byte[]} after
  * uploading it to OpenAL. Nothing reads the heap copy afterwards, so it is released here. See
  * {@link #loadSound(FilenameURL)}.</li>
- * <li><b>Stereo sounds cannot be positioned.</b> OpenAL skips its 3D pipeline for multi-channel buffers unless asked
- * not to. {@link #play(Source)} sets AL_SOURCE_SPATIALIZE_SOFT per source, which lets stereo sounds keep their width
- * instead of being downmixed. See {@link SpatializeSupport}.</li>
- * <li><b>Environmental reverb needs a per-source send.</b> {@link #play(Source)} also routes positional sources through
- * the shared effect slot and clears that state when a pooled channel is reused. See {@link ReverbSupport}.</li>
+ * <li><b>World and UI sounds need different routing.</b> {@link #createChannel(int)} configures positional stereo and
+ * direct UI/music playback before a channel starts. See {@link SpatializeSupport}.</li>
+ * <li><b>Environmental reverb needs a per-source send.</b> The channel also routes positional sources through the
+ * shared effect slot and clears that state when reused. See {@link ReverbSupport}.</li>
  * </ul>
  */
 public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
@@ -74,24 +73,31 @@ public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
     }
 
     /**
-     * Configures the source once it has a channel; Paulscode attaches it inside super.play().
+     * Keeps Paulscode's source allocation and failure handling, but configures routing before playback starts.
      * <p>
-     * The {@code attachedSource} check is not optional. {@code play()} can return without assigning a channel. The
-     * source may be inactive, already playing, or every channel may be busy. Meanwhile, {@code source.channel} can
-     * still point at a channel {@code getNextChannel} has since handed to a different source, since it reassigns
-     * without clearing the previous owner's reference. Paulscode guards every one of its own AL accesses the same way.
+     * SourceLWJGLOpenAL calls Channel.play() after both sides of the channel assignment are set, for normal sounds and
+     * file streams alike. Streams are handed to the preload worker afterwards, so their later direct alSourcePlay calls
+     * retain these settings. No source selection, buffering, or playback state is changed here.
      */
     @Override
-    public void play(Source source) {
-        super.play(source);
-        if (source == null || !(source.channel instanceof ChannelLWJGLOpenAL channel)) return;
-        if (channel.attachedSource != source || channel.ALSource == null) return;
+    protected Channel createChannel(int type) {
+        final Channel channel = super.createChannel(type);
+        if (!(channel instanceof ChannelLWJGLOpenAL openAL)) return channel;
 
-        final int alSource = channel.ALSource.get(0);
-        // Channels are pooled, so both of these must be written on every attach, not just when switching on -
-        // otherwise a UI click inherits the settings of whatever world sound used the channel last.
-        final boolean positional = source.attModel != SoundSystemConfig.ATTENUATION_NONE;
-        SpatializeSupport.apply(alSource, positional);
-        ReverbSupport.route(alSource, positional);
+        // The stock constructor only stores the source handle; the replacement owns its normal cleanup.
+        return new ChannelLWJGLOpenAL(type, openAL.ALSource) {
+
+            @Override
+            public void play() {
+                // A previous owner can retain a stale channel reference after the channel is reassigned.
+                if (attachedSource != null && attachedSource.channel == this && ALSource != null) {
+                    final int alSource = ALSource.get(0);
+                    final boolean positional = attachedSource.attModel != SoundSystemConfig.ATTENUATION_NONE;
+                    SpatializeSupport.apply(alSource, positional);
+                    ReverbSupport.route(alSource, positional);
+                }
+                super.play();
+            }
+        };
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/client/sound/LibraryHodgepodgeOpenAL.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/sound/LibraryHodgepodgeOpenAL.java
@@ -36,6 +36,7 @@ public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
         // is not enough. Doing it here rather than off a device-change check also keeps it working on Java 8.
         ReverbSupport.invalidate();
         SoundDeviceTweaks.invalidate();
+        SpatializeSupport.invalidate();
     }
 
     /**

--- a/src/main/java/com/mitchej123/hodgepodge/client/sound/LibraryHodgepodgeOpenAL.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/sound/LibraryHodgepodgeOpenAL.java
@@ -8,6 +8,7 @@ import paulscode.sound.FilenameURL;
 import paulscode.sound.SoundBuffer;
 import paulscode.sound.SoundSystemConfig;
 import paulscode.sound.SoundSystemException;
+import paulscode.sound.Source;
 import paulscode.sound.libraries.ChannelLWJGLOpenAL;
 import paulscode.sound.libraries.LibraryLWJGLOpenAL;
 
@@ -27,6 +28,9 @@ import paulscode.sound.libraries.LibraryLWJGLOpenAL;
  * </ul>
  */
 public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
+
+    // Paulscode serializes library commands; this is only set during its synchronous raw-data feed.
+    private Source feedingRawSource;
 
     public LibraryHodgepodgeOpenAL() throws SoundSystemException {
         super();
@@ -77,7 +81,7 @@ public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
      * <p>
      * SourceLWJGLOpenAL calls Channel.play() after both sides of the channel assignment are set, for normal sounds and
      * file streams alike. Streams are handed to the preload worker afterwards, so their later direct alSourcePlay calls
-     * retain these settings. No source selection, buffering, or playback state is changed here.
+     * retain these settings. Raw streams instead start directly inside feedRawAudioData().
      */
     @Override
     protected Channel createChannel(int type) {
@@ -89,6 +93,21 @@ public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
 
             @Override
             public void play() {
+                configureRouting();
+                super.play();
+            }
+
+            @Override
+            public int feedRawAudioData(byte[] buffer) {
+                // Library assigns attachedSource after feeding, but the feed itself can already start playback.
+                if (feedingRawSource != null && feedingRawSource.channel == this) {
+                    attachedSource = feedingRawSource;
+                }
+                configureRouting();
+                return super.feedRawAudioData(buffer);
+            }
+
+            private void configureRouting() {
                 // A previous owner can retain a stale channel reference after the channel is reassigned.
                 if (attachedSource != null && attachedSource.channel == this && ALSource != null) {
                     final int alSource = ALSource.get(0);
@@ -96,8 +115,24 @@ public class LibraryHodgepodgeOpenAL extends LibraryLWJGLOpenAL {
                     SpatializeSupport.apply(alSource, positional);
                     ReverbSupport.route(alSource, positional);
                 }
-                super.play();
             }
         };
+    }
+
+    @Override
+    public int feedRawAudioData(Source source, byte[] buffer) {
+        // As in Library.play(), discard a stale channel reference so Source closes a reassigned channel first.
+        if (source != null && source.rawDataStream
+                && source.active()
+                && source.channel != null
+                && source.channel.attachedSource != source) {
+            source.channel = null;
+        }
+        feedingRawSource = source;
+        try {
+            return super.feedRawAudioData(source, buffer);
+        } finally {
+            feedingRawSource = null;
+        }
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/client/sound/SpatializeSupport.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/sound/SpatializeSupport.java
@@ -7,7 +7,7 @@ import com.mitchej123.hodgepodge.Compat;
 import com.mitchej123.hodgepodge.config.SoundConfig;
 
 /**
- * Lets OpenAL spatialize positional stereo sources without downmixing them to mono first.
+ * Positions world sounds and keeps non-positional stereo sounds out of OpenAL's HRTF virtualization.
  * <p>
  * Needs AL_SOFT_source_spatialize, which arrived in OpenAL Soft 1.19, long after the OpenAL LWJGL2 bundles. This is
  * therefore lwjgl3ify-only and stays off on the Java 8 build. Reflective for the same reason as
@@ -19,58 +19,75 @@ public final class SpatializeSupport {
     private SpatializeSupport() {}
 
     private static final int AL_SOURCE_SPATIALIZE_SOFT = 4628;
+    private static final int AL_DIRECT_CHANNELS_SOFT = 4147;
     private static final int AL_AUTO_SOFT = 2;
     private static final int AL_TRUE = 1;
+    private static final int AL_FALSE = 0;
 
     private static Method alSourcei;
     private static boolean resolved = false;
-    private static boolean supported = false;
-    private static boolean everApplied = false;
+    private static boolean spatializeSupported = false;
+    private static boolean directChannelsSupported = false;
+
+    /** Extension support belongs to the context, which a sound reload replaces. */
+    static synchronized void invalidate() {
+        resolved = false;
+        spatializeSupported = false;
+        directChannelsSupported = false;
+        alSourcei = null;
+    }
 
     /**
-     * True when the codec should keep buffers stereo. {@link #apply(int, boolean)} then decides per playback whether to
-     * force spatialization or leave the source on OpenAL's automatic behavior.
+     * True when the codec should keep buffers stereo for positional playback.
      */
     public static boolean active() {
-        return SoundConfig.spatializeStereoSounds && resolve();
+        if (!SoundConfig.spatializeStereoSounds) return false;
+        resolve();
+        return spatializeSupported;
     }
 
     /**
-     * Sets the flag on an OpenAL source. Channels are pooled and OpenAL keeps source properties across buffer
-     * attachment, so this writes on <i>every</i> attach. That includes AL_AUTO, which restores stock behaviour for UI
-     * sounds and for channels left forced-on after the setting is switched off.
+     * Writes both properties on every attach because channels are pooled. Non-positional sounds must use FALSE, not
+     * AUTO (which still positions mono), plus direct routing to bypass HRTF's virtual speakers for stereo. Direct
+     * routing does not bypass HRTF for mono buffers. World sounds always clear it, including when stereo spatialization
+     * is disabled. UI/music routing is independent of that preference.
      */
     static void apply(int alSource, boolean positional) {
-        final boolean want = SoundConfig.spatializeStereoSounds && positional;
-        if (!want && !everApplied) return; // nothing was ever forced on, so nothing to undo
-        if (!resolve()) return;
+        resolve();
         try {
-            alSourcei.invoke(null, alSource, AL_SOURCE_SPATIALIZE_SOFT, want ? AL_TRUE : AL_AUTO_SOFT);
-            everApplied = true;
+            if (spatializeSupported) {
+                final int spatialize = !positional ? AL_FALSE
+                        : SoundConfig.spatializeStereoSounds ? AL_TRUE : AL_AUTO_SOFT;
+                alSourcei.invoke(null, alSource, AL_SOURCE_SPATIALIZE_SOFT, spatialize);
+            }
+            if (directChannelsSupported) {
+                alSourcei.invoke(null, alSource, AL_DIRECT_CHANNELS_SOFT, positional ? AL_FALSE : AL_TRUE);
+            }
         } catch (Throwable t) {
-            supported = false; // stop trying; the codec falls back to downmixing on the next decode
-            Common.log.warn("Could not set source spatialization, falling back to downmixing", t);
+            spatializeSupported = false;
+            directChannelsSupported = false;
+            Common.log.warn("Could not configure source routing, disabling sound routing enhancements", t);
         }
     }
 
-    private static synchronized boolean resolve() {
-        if (resolved) return supported;
+    private static synchronized void resolve() {
+        if (resolved) return;
         resolved = true;
-        if (!Compat.isLwjgl3ifyPresent()) return false; // LWJGL2's OpenAL predates the extension
+        if (!Compat.isLwjgl3ifyPresent()) return; // LWJGL2's OpenAL predates the extensions
         try {
             final Class<?> al10 = Class.forName("org.lwjgl.openal.AL10");
-            final boolean present = (Boolean) al10.getMethod("alIsExtensionPresent", CharSequence.class)
-                    .invoke(null, "AL_SOFT_source_spatialize");
-            if (!present) {
-                Common.log.info("AL_SOFT_source_spatialize unavailable, stereo sounds will be downmixed instead");
-                return false;
-            }
+            final Method isPresent = al10.getMethod("alIsExtensionPresent", CharSequence.class);
             alSourcei = al10.getMethod("alSourcei", int.class, int.class, int.class);
-            supported = true;
-            Common.log.info("Using AL_SOFT_source_spatialize; stereo sounds keep their width");
+            spatializeSupported = (Boolean) isPresent.invoke(null, "AL_SOFT_source_spatialize");
+            directChannelsSupported = (Boolean) isPresent.invoke(null, "AL_SOFT_direct_channels");
+            Common.log.info(
+                    "OpenAL source routing: stereo spatialization {}, direct UI/music channels {}",
+                    spatializeSupported,
+                    directChannelsSupported);
         } catch (Throwable t) {
-            Common.log.warn("Could not set up source spatialization, stereo sounds will be downmixed instead", t);
+            spatializeSupported = false;
+            directChannelsSupported = false;
+            Common.log.warn("Could not set up source routing, leaving OpenAL defaults", t);
         }
-        return supported;
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/client/sound/SpatializeSupport.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/sound/SpatializeSupport.java
@@ -1,13 +1,15 @@
 package com.mitchej123.hodgepodge.client.sound;
 
 import java.lang.reflect.Method;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.mitchej123.hodgepodge.Common;
 import com.mitchej123.hodgepodge.Compat;
 import com.mitchej123.hodgepodge.config.SoundConfig;
 
 /**
- * Positions world sounds and keeps non-positional stereo sounds out of OpenAL's HRTF virtualization.
+ * Positions world sounds and keeps non-positional sounds out of OpenAL's HRTF virtualization where supported.
  * <p>
  * Needs AL_SOFT_source_spatialize, which arrived in OpenAL Soft 1.19, long after the OpenAL LWJGL2 bundles. This is
  * therefore lwjgl3ify-only and stays off on the Java 8 build. Reflective for the same reason as
@@ -20,21 +22,27 @@ public final class SpatializeSupport {
 
     private static final int AL_SOURCE_SPATIALIZE_SOFT = 4628;
     private static final int AL_DIRECT_CHANNELS_SOFT = 4147;
+    private static final int AL_PANNING_ENABLED_SOFT = 6636;
+    private static final int AL_PAN_SOFT = 6637;
+    private static final int AL_VERSION = 45058;
     private static final int AL_AUTO_SOFT = 2;
     private static final int AL_TRUE = 1;
     private static final int AL_FALSE = 0;
 
-    private static Method alSourcei;
+    private static Method alSourcei, alSourcef;
     private static boolean resolved = false;
     private static boolean spatializeSupported = false;
     private static boolean directChannelsSupported = false;
+    private static boolean panningSupported = false;
 
     /** Extension support belongs to the context, which a sound reload replaces. */
     static synchronized void invalidate() {
         resolved = false;
         spatializeSupported = false;
         directChannelsSupported = false;
+        panningSupported = false;
         alSourcei = null;
+        alSourcef = null;
     }
 
     /**
@@ -47,10 +55,11 @@ public final class SpatializeSupport {
     }
 
     /**
-     * Writes both properties on every attach because channels are pooled. Non-positional sounds must use FALSE, not
-     * AUTO (which still positions mono), plus direct routing to bypass HRTF's virtual speakers for stereo. Direct
-     * routing does not bypass HRTF for mono buffers. World sounds always clear it, including when stereo spatialization
-     * is disabled. UI/music routing is independent of that preference.
+     * Writes routing properties on every attach because channels are pooled. Non-positional sounds must use FALSE, not
+     * AUTO (which still positions mono), plus direct routing to bypass HRTF's virtual speakers. Experimental panning
+     * lets mono use that direct stereo path without copying its PCM. Centered panning preserves stereo and plays mono
+     * equally in both ears at the requested source gain. World sounds always clear panning and direct routing,
+     * including when stereo spatialization is disabled. UI/music routing is independent of that preference.
      */
     static void apply(int alSource, boolean positional) {
         resolve();
@@ -63,9 +72,14 @@ public final class SpatializeSupport {
             if (directChannelsSupported) {
                 alSourcei.invoke(null, alSource, AL_DIRECT_CHANNELS_SOFT, positional ? AL_FALSE : AL_TRUE);
             }
+            if (panningSupported) {
+                alSourcei.invoke(null, alSource, AL_PANNING_ENABLED_SOFT, positional ? AL_FALSE : AL_TRUE);
+                alSourcef.invoke(null, alSource, AL_PAN_SOFT, 0.0f);
+            }
         } catch (Throwable t) {
             spatializeSupported = false;
             directChannelsSupported = false;
+            panningSupported = false;
             Common.log.warn("Could not configure source routing, disabling sound routing enhancements", t);
         }
     }
@@ -78,15 +92,26 @@ public final class SpatializeSupport {
             final Class<?> al10 = Class.forName("org.lwjgl.openal.AL10");
             final Method isPresent = al10.getMethod("alIsExtensionPresent", CharSequence.class);
             alSourcei = al10.getMethod("alSourcei", int.class, int.class, int.class);
+            alSourcef = al10.getMethod("alSourcef", int.class, int.class, float.class);
             spatializeSupported = (Boolean) isPresent.invoke(null, "AL_SOFT_source_spatialize");
             directChannelsSupported = (Boolean) isPresent.invoke(null, "AL_SOFT_direct_channels");
+            if (directChannelsSupported && (Boolean) isPresent.invoke(null, "AL_SOFTX_source_panning")) {
+                // Before 1.25, even writing the same flag to a paused source raises AL_INVALID_OPERATION.
+                // Restrict this experimental path to versions that allow our normal playback/resume hook.
+                final String version = (String) al10.getMethod("alGetString", int.class).invoke(null, AL_VERSION);
+                final Matcher match = Pattern.compile(".*\\bALSOFT (\\d+)\\.(\\d+).*").matcher(version);
+                panningSupported = match.matches() && (Integer.parseInt(match.group(1)) > 1
+                        || Integer.parseInt(match.group(1)) == 1 && Integer.parseInt(match.group(2)) >= 25);
+            }
             Common.log.info(
-                    "OpenAL source routing: stereo spatialization {}, direct UI/music channels {}",
+                    "OpenAL source routing: stereo spatialization {}, direct UI/music channels {}, experimental mono panning {}",
                     spatializeSupported,
-                    directChannelsSupported);
+                    directChannelsSupported,
+                    panningSupported);
         } catch (Throwable t) {
             spatializeSupported = false;
             directChannelsSupported = false;
+            panningSupported = false;
             Common.log.warn("Could not set up source routing, leaving OpenAL defaults", t);
         }
     }


### PR DESCRIPTION
## Summary
Fixes GTNewHorizons/GT-New-Horizons-Modpack#26634

Non positional sound had HRTF processing applied which was affecting menu sounds and music, it should now directly be outputted without unwanted processing.
For audio source that are mono the bypass use an experimental OpenAL feature (source panning) that may not always work but it's either that or a very complicated and messy alternative.

Also a few other fixes to the order of how things are configured in the sound pipeline



## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
