### PR TITLE
Fix Furnace doesn't save current item burn time to NBT

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -575,7 +575,7 @@ public class FixesConfig {
     @Config.RequiresMcRestart
     public static boolean fixBlockHitDelay;
 
-    @Config.Comment("Fix Furnace doesn't save current item burn time to NBT.")
+    @Config.Comment("Make the Furnace save the max burn time of the current fuel to NBT, so WAILA can determine the percent fuel remaining.")
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean furnaceSaveItemBurnTimeToNBT;

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -565,6 +565,11 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     @Config.RequiresMcRestart
     public static boolean fixBlockHitDelay;
+
+    @Config.Comment("Fix Furnace doesn't save current item burn time to NBT.")
+    @Config.DefaultBoolean(true)
+    @Config.RequiresMcRestart
+    public static boolean furnaceSaveItemBurnTimeToNBT;
     /* ====== Minecraft fixes end ===== */
 
     // bukkit fixes

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1217,6 +1217,7 @@ public enum Mixins implements IMixins {
     FURNACE_SAVE_ITEM_BURN_TIME_TO_NBT(new MixinBuilder()
             .addCommonMixins("minecraft.MixinFurnaceSaveItemBurnTimeToNBT")
             .setApplyIf(() -> FixesConfig.furnaceSaveItemBurnTimeToNBT)
+            .setPhase(Phase.EARLY)),
     TRACK_INCOMING_PACKETS(new MixinBuilder("Track incoming packets for /packetstats")
             .addClientMixins("debug.MixinNetworkManager_TrackIncomingPackets")
             .setApplyIf(() -> DebugConfig.trackIncomingPackets)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1214,6 +1214,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinAbstractResourcePack")
             .setApplyIf(() -> SpeedupsConfig.optimizeResourcePackPath)
             .setPhase(Phase.EARLY)),
+    FURNACE_SAVE_ITEM_BURN_TIME_TO_NBT(new MixinBuilder()
+            .addCommonMixins("minecraft.MixinFurnaceSaveItemBurnTimeToNBT")
+            .setApplyIf(() -> FixesConfig.furnaceSaveItemBurnTimeToNBT)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFurnaceSaveItemBurnTimeToNBT.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFurnaceSaveItemBurnTimeToNBT.java
@@ -3,6 +3,7 @@ package com.mitchej123.hodgepodge.mixins.early.minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,9 +21,7 @@ public class MixinFurnaceSaveItemBurnTimeToNBT {
             method = "readFromNBT",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/tileentity/TileEntityFurnace;getItemBurnTime(Lnet/minecraft/item/ItemStack;)I"
-            )
-    )
+                    target = "Lnet/minecraft/tileentity/TileEntityFurnace;getItemBurnTime(Lnet/minecraft/item/ItemStack;)I"))
     private int readFromNBTItemBurnTime(ItemStack stack, NBTTagCompound compound) {
         return compound.getInteger("ItemBurnTime");
     }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFurnaceSaveItemBurnTimeToNBT.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinFurnaceSaveItemBurnTimeToNBT.java
@@ -1,0 +1,34 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntityFurnace;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityFurnace.class)
+public class MixinFurnaceSaveItemBurnTimeToNBT {
+
+    @Shadow
+    public int currentItemBurnTime;
+
+    @Redirect(
+            method = "readFromNBT",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/tileentity/TileEntityFurnace;getItemBurnTime(Lnet/minecraft/item/ItemStack;)I"
+            )
+    )
+    private int readFromNBTItemBurnTime(ItemStack stack, NBTTagCompound compound) {
+        return compound.getInteger("ItemBurnTime");
+    }
+
+    @Inject(method = "writeToNBT", at = @At("RETURN"))
+    private void writeToNBTItemBurnTime(NBTTagCompound compound, CallbackInfo ci) {
+        compound.setInteger("ItemBurnTime", this.currentItemBurnTime);
+    }
+}


### PR DESCRIPTION
## Summary
Vanilla furnace doesn't save current item burn time to NBT, so if you rejoin world currentItemBurnTime value will not be correct. (It will be 0 if there no another item in fuel slot, or it will be the burn value of item currently in fuel slot, rather than the burn value of item currently used). This value is used in waila to show progress bar.
Before:
<img width="1177" height="800" alt="image" src="https://github.com/user-attachments/assets/cd8cd676-1cae-4506-8cf6-b054da6775fe" />
After:
<img width="1217" height="818" alt="image" src="https://github.com/user-attachments/assets/9650a44b-bb03-4b93-89cb-eb2a6b084a3b" />

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
