### PR TITLE
Fix chunk NBT corruption during concurrent saves

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -581,6 +581,7 @@ public enum Mixins implements IMixins {
                     "minecraft.MixinMapStorage_threadedIO",
                     "minecraft.MixinSaveHandler_threadedIO",
                     "minecraft.MixinMinecraftServer_WorldDataSave",
+                    "minecraft.MixinCommandSaveAll_WorldDataSave",
                     "minecraft.MixinScoreboardSaveData_threadedIO",
                     "minecraft.MixinVillageCollection_threadedIO",
                     "minecraft.MixinMapData_threadedIO",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -580,6 +580,7 @@ public enum Mixins implements IMixins {
             .addCommonMixins(
                     "minecraft.MixinMapStorage_threadedIO",
                     "minecraft.MixinSaveHandler_threadedIO",
+                    "minecraft.MixinMinecraftServer_WorldDataSave",
                     "minecraft.MixinScoreboardSaveData_threadedIO",
                     "minecraft.MixinVillageCollection_threadedIO",
                     "minecraft.MixinMapData_threadedIO",

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAnvilChunkLoader_FastChunkWrite.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAnvilChunkLoader_FastChunkWrite.java
@@ -38,7 +38,8 @@ public class MixinAnvilChunkLoader_FastChunkWrite {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/nbt/CompressedStreamTools;write(Lnet/minecraft/nbt/NBTTagCompound;Ljava/io/DataOutput;)V"))
-    private void hodgepodge$batchedNBTWrite(NBTTagCompound nbt, DataOutput dataOutput) throws IOException {
+    // The file IO thread and save-all flush can serialize chunks on the same loader concurrently.
+    private synchronized void hodgepodge$batchedNBTWrite(NBTTagCompound nbt, DataOutput dataOutput) throws IOException {
         // Write to a reused buffer to avoid multiple allocations and resizes
         hodgepodge$nbtBuffer.reset();
         CompressedStreamTools.func_150663_a(nbt, hodgepodge$nbtDataOutput);

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAnvilChunkLoader_FastChunkWrite.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinAnvilChunkLoader_FastChunkWrite.java
@@ -38,22 +38,27 @@ public class MixinAnvilChunkLoader_FastChunkWrite {
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/nbt/CompressedStreamTools;write(Lnet/minecraft/nbt/NBTTagCompound;Ljava/io/DataOutput;)V"))
-    // The file IO thread and save-all flush can serialize chunks on the same loader concurrently.
-    private synchronized void hodgepodge$batchedNBTWrite(NBTTagCompound nbt, DataOutput dataOutput) throws IOException {
-        // Write to a reused buffer to avoid multiple allocations and resizes
-        hodgepodge$nbtBuffer.reset();
-        CompressedStreamTools.func_150663_a(nbt, hodgepodge$nbtDataOutput);
-        dataOutput.write(hodgepodge$nbtBuffer.toByteArray());
+    private void hodgepodge$batchedNBTWrite(NBTTagCompound nbt, DataOutput dataOutput) throws IOException {
+        final byte[] serializedNbt;
+        // The file IO thread and save-all flush share these buffers, including their resize bookkeeping.
+        synchronized (this) {
+            // Write to a reused buffer to avoid multiple allocations and resizes
+            hodgepodge$nbtBuffer.reset();
+            CompressedStreamTools.func_150663_a(nbt, hodgepodge$nbtDataOutput);
+            serializedNbt = hodgepodge$nbtBuffer.toByteArray();
 
-        // Shrink if we've seen a streak of smaller chunks
-        if (hodgepodge$nbtBuffer.size() < hodgepodge$SHRINK_THRESHOLD) {
-            if (++hodgepodge$smallWriteStreak >= hodgepodge$SHRINK_AFTER_STREAK) {
-                hodgepodge$nbtBuffer = new ByteArrayOutputStream(hodgepodge$DEFAULT_BUFFER_SIZE);
-                hodgepodge$nbtDataOutput = new DataOutputStream(hodgepodge$nbtBuffer);
+            // Shrink if we've seen a streak of smaller chunks
+            if (hodgepodge$nbtBuffer.size() < hodgepodge$SHRINK_THRESHOLD) {
+                if (++hodgepodge$smallWriteStreak >= hodgepodge$SHRINK_AFTER_STREAK) {
+                    hodgepodge$nbtBuffer = new ByteArrayOutputStream(hodgepodge$DEFAULT_BUFFER_SIZE);
+                    hodgepodge$nbtDataOutput = new DataOutputStream(hodgepodge$nbtBuffer);
+                    hodgepodge$smallWriteStreak = 0;
+                }
+            } else {
                 hodgepodge$smallWriteStreak = 0;
             }
-        } else {
-            hodgepodge$smallWriteStreak = 0;
         }
+        // Compression uses its own copy and can proceed without blocking another chunk's serialization.
+        dataOutput.write(serializedNbt);
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCommandSaveAll_WorldDataSave.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinCommandSaveAll_WorldDataSave.java
@@ -1,0 +1,29 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import java.io.IOException;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.server.CommandSaveAll;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.util.WorldDataSaver;
+
+@Mixin(CommandSaveAll.class)
+public class MixinCommandSaveAll_WorldDataSave {
+
+    @Inject(method = "processCommand", at = @At(value = "CONSTANT", args = "stringValue=commands.save.flushEnd"))
+    private void hodgepodge$flushWorldData(CallbackInfo ci) {
+        try {
+            WorldDataSaver.INSTANCE.flush();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CommandException("commands.save.failed", "Interrupted while flushing world data");
+        } catch (IOException e) {
+            throw new CommandException("commands.save.failed", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraftServer_WorldDataSave.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraftServer_WorldDataSave.java
@@ -1,0 +1,27 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft;
+
+import net.minecraft.server.MinecraftServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mitchej123.hodgepodge.util.WorldDataSaver;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer_WorldDataSave {
+
+    // Run before serverStopped becomes true, including when stopServer throws during crash shutdown.
+    @WrapOperation(
+            method = "run",
+            remap = false,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;stopServer()V", remap = true))
+    private void hodgepodge$closeWorldData(MinecraftServer server, Operation<Void> original) {
+        try {
+            original.call(server);
+        } finally {
+            WorldDataSaver.INSTANCE.closeSession();
+        }
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraftServer_WorldDataSave.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/MixinMinecraftServer_WorldDataSave.java
@@ -13,6 +13,7 @@ import com.mitchej123.hodgepodge.util.WorldDataSaver;
 public class MixinMinecraftServer_WorldDataSave {
 
     // Run before serverStopped becomes true, including when stopServer throws during crash shutdown.
+    // Stay after stopServer: ServerUtilities restores saving at its HEAD, then shutdown queues the final saves.
     @WrapOperation(
             method = "run",
             remap = false,

--- a/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
@@ -1,6 +1,6 @@
 package com.mitchej123.hodgepodge.util;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -151,15 +151,6 @@ public class WorldDataSaver implements IThreadedFileIO {
     }
 
     static void writeData(File file, NBTTagCompound data, boolean compressed, boolean backup) throws IOException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        if (compressed) {
-            CompressedStreamTools.writeCompressed(data, bytes);
-        } else {
-            try (DataOutputStream output = new DataOutputStream(bytes)) {
-                CompressedStreamTools.write(data, output);
-            }
-        }
-
         Path target = file.toPath().toAbsolutePath();
         Path parent = target.getParent();
         Files.createDirectories(parent);
@@ -179,8 +170,17 @@ public class WorldDataSaver implements IThreadedFileIO {
                 Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(target));
             }
             try (FileOutputStream output = new FileOutputStream(temporary.toFile())) {
-                output.write(bytes.toByteArray());
-                output.getFD().sync();
+                if (compressed) {
+                    CompressedStreamTools.writeCompressed(data, output);
+                } else {
+                    try (DataOutputStream stream = new DataOutputStream(new BufferedOutputStream(output))) {
+                        CompressedStreamTools.write(data, stream);
+                    }
+                }
+            }
+            // writeCompressed closes the stream it is given, so sync through a fresh handle.
+            try (FileChannel channel = FileChannel.open(temporary, StandardOpenOption.WRITE)) {
+                channel.force(true);
             }
             if (backup && Files.exists(target)) {
                 oldTemporary = Files.createTempFile(parent, "." + file.getName() + "-old-", ".tmp");

--- a/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
@@ -102,6 +102,52 @@ public class WorldDataSaver implements IThreadedFileIO {
         ThreadedFileIOBase.threadedIOInstance.queueIO(task);
     }
 
+    protected void awaitIO() throws InterruptedException {
+        ThreadedFileIOBase.threadedIOInstance.waitForFinish();
+    }
+
+    public void flush() throws InterruptedException, IOException {
+        awaitIO();
+        synchronized (pendingData) {
+            if (!failedData.isEmpty()) {
+                failedData.forEach(pendingData::putIfAbsent);
+                failedData.clear();
+                if (!queued) {
+                    queued = true;
+                    queueIO(new DrainTask());
+                }
+            }
+        }
+        awaitIO();
+        synchronized (pendingData) {
+            if (!failedData.isEmpty()) throw new IOException("World data could not be saved: " + failedData.keySet());
+        }
+    }
+
+    public void closeSession() {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    flush();
+                    break;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                } catch (IOException e) {
+                    LOGGER.error(
+                            "Closing world with unsaved data; these writes will not be replayed in another session",
+                            e);
+                    break;
+                }
+            }
+            synchronized (pendingData) {
+                failedData.clear();
+            }
+        } finally {
+            if (interrupted) Thread.currentThread().interrupt();
+        }
+    }
+
     static void writeData(File file, NBTTagCompound data, boolean compressed, boolean backup) throws IOException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         if (compressed) {

--- a/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
@@ -10,6 +10,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -161,10 +163,20 @@ public class WorldDataSaver implements IThreadedFileIO {
         Path target = file.toPath().toAbsolutePath();
         Path parent = target.getParent();
         Files.createDirectories(parent);
-        Path temporary = Files.createTempFile(parent, "." + file.getName() + "-", ".tmp");
+        boolean posix = Files.getFileAttributeView(parent, PosixFileAttributeView.class) != null;
+        Path temporary = posix
+                ? Files.createTempFile(
+                        parent,
+                        "." + file.getName() + "-",
+                        ".tmp",
+                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-rw-rw-")))
+                : Files.createTempFile(parent, "." + file.getName() + "-", ".tmp");
         Path old = target.resolveSibling(file.getName() + "_old");
         Path oldTemporary = null;
         try {
+            if (posix && Files.exists(target)) {
+                Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(target));
+            }
             try (FileOutputStream output = new FileOutputStream(temporary.toFile())) {
                 output.write(bytes.toByteArray());
                 output.getFD().sync();

--- a/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
@@ -166,9 +166,6 @@ public class WorldDataSaver implements IThreadedFileIO {
         Path old = target.resolveSibling(file.getName() + "_old");
         Path oldTemporary = null;
         try {
-            if (posix && Files.exists(target)) {
-                Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(target));
-            }
             try (FileOutputStream output = new FileOutputStream(temporary.toFile())) {
                 if (compressed) {
                     CompressedStreamTools.writeCompressed(data, output);
@@ -181,6 +178,10 @@ public class WorldDataSaver implements IThreadedFileIO {
             // writeCompressed closes the stream it is given, so sync through a fresh handle.
             try (FileChannel channel = FileChannel.open(temporary, StandardOpenOption.WRITE)) {
                 channel.force(true);
+            }
+            // After writing: a target mode without owner write would otherwise block our own open.
+            if (posix && Files.exists(target)) {
+                Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(target));
             }
             if (backup && Files.exists(target)) {
                 oldTemporary = Files.createTempFile(parent, "." + file.getName() + "-old-", ".tmp");

--- a/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
@@ -164,6 +164,7 @@ public class WorldDataSaver implements IThreadedFileIO {
         Path parent = target.getParent();
         Files.createDirectories(parent);
         boolean posix = Files.getFileAttributeView(parent, PosixFileAttributeView.class) != null;
+        // Initial POSIX permissions are filtered by umask; replacements keep the target's existing mode below.
         Path temporary = posix
                 ? Files.createTempFile(
                         parent,

--- a/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
+++ b/src/main/java/com/mitchej123/hodgepodge/util/WorldDataSaver.java
@@ -1,8 +1,15 @@
 package com.mitchej123.hodgepodge.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.util.Collections;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -38,7 +45,9 @@ public class WorldDataSaver implements IThreadedFileIO {
 
     protected WorldDataSaver() {}
 
-    private final Map<File, WrappedNBTTagCompound> pendingData = Collections.synchronizedMap(new LinkedHashMap<>());
+    private final Map<File, WrappedNBTTagCompound> pendingData = new LinkedHashMap<>();
+    private final Map<File, WrappedNBTTagCompound> failedData = new LinkedHashMap<>();
+    private boolean queued;
 
     @Override
     public boolean writeNextIO() {
@@ -50,6 +59,7 @@ public class WorldDataSaver implements IThreadedFileIO {
         synchronized (pendingData) {
             Iterator<Map.Entry<File, WrappedNBTTagCompound>> it = pendingData.entrySet().iterator();
             if (!it.hasNext()) {
+                queued = false;
                 return false;
             }
             Map.Entry<File, WrappedNBTTagCompound> entry = it.next();
@@ -61,22 +71,15 @@ public class WorldDataSaver implements IThreadedFileIO {
             it.remove();
 
         }
-        if (backup) {
-            final File backupFile = new File(file.getParentFile(), file.getName() + "_old");
-            if (backupFile.exists()) {
-                backupFile.delete();
-            }
-            file.renameTo(backupFile);
-        }
-
         try {
-            if (compressed) {
-                try (FileOutputStream fileoutputstream = new FileOutputStream(file)) {
-                    CompressedStreamTools.writeCompressed(data, fileoutputstream);
-                }
-            } else CompressedStreamTools.write(data, file);
-
+            writeData(file, data, compressed, backup);
+            synchronized (pendingData) {
+                failedData.remove(file);
+            }
         } catch (Exception e) {
+            synchronized (pendingData) {
+                if (!pendingData.containsKey(file)) failedData.put(file, wrapped);
+            }
             LOGGER.error("Failed to write data to file {}", file, e);
             Common.log.error(e);
         }
@@ -85,11 +88,65 @@ public class WorldDataSaver implements IThreadedFileIO {
 
     public void saveData(File file, NBTTagCompound parentTag, boolean compressed, boolean backup) {
         WrappedNBTTagCompound wrapped = new WrappedNBTTagCompound(parentTag, compressed, backup);
-        if (pendingData.containsKey(file)) {
-            pendingData.replace(file, wrapped);
-        } else {
+        synchronized (pendingData) {
+            failedData.forEach(pendingData::putIfAbsent);
+            failedData.clear();
             pendingData.put(file, wrapped);
+            if (queued) return;
+            queued = true;
+            queueIO(new DrainTask());
         }
-        ThreadedFileIOBase.threadedIOInstance.queueIO(this);
+    }
+
+    protected void queueIO(IThreadedFileIO task) {
+        ThreadedFileIOBase.threadedIOInstance.queueIO(task);
+    }
+
+    static void writeData(File file, NBTTagCompound data, boolean compressed, boolean backup) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        if (compressed) {
+            CompressedStreamTools.writeCompressed(data, bytes);
+        } else {
+            try (DataOutputStream output = new DataOutputStream(bytes)) {
+                CompressedStreamTools.write(data, output);
+            }
+        }
+
+        Path target = file.toPath().toAbsolutePath();
+        Path parent = target.getParent();
+        Files.createDirectories(parent);
+        Path temporary = Files.createTempFile(parent, "." + file.getName() + "-", ".tmp");
+        Path old = target.resolveSibling(file.getName() + "_old");
+        Path oldTemporary = null;
+        try {
+            try (FileOutputStream output = new FileOutputStream(temporary.toFile())) {
+                output.write(bytes.toByteArray());
+                output.getFD().sync();
+            }
+            if (backup && Files.exists(target)) {
+                oldTemporary = Files.createTempFile(parent, "." + file.getName() + "-old-", ".tmp");
+                Files.copy(
+                        target,
+                        oldTemporary,
+                        StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.COPY_ATTRIBUTES);
+                try (FileChannel channel = FileChannel.open(oldTemporary, StandardOpenOption.WRITE)) {
+                    channel.force(true);
+                }
+                Files.move(oldTemporary, old, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            }
+            Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } finally {
+            if (oldTemporary != null) Files.deleteIfExists(oldTemporary);
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private final class DrainTask implements IThreadedFileIO {
+
+        @Override
+        public boolean writeNextIO() {
+            return WorldDataSaver.this.writeNextIO();
+        }
     }
 }

--- a/src/test/java/com/mitchej123/hodgepodge/util/CommandSaveFlushTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/CommandSaveFlushTest.java
@@ -1,0 +1,51 @@
+package com.mitchej123.hodgepodge.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.mixins.early.minecraft.MixinCommandSaveAll_WorldDataSave;
+
+class CommandSaveFlushTest {
+
+    @TempDir
+    Path temporary;
+
+    @Test
+    void commandFlushWaitsForRealIoAndReportsFailure() throws Exception {
+        Method flush = MixinCommandSaveAll_WorldDataSave.class
+                .getDeclaredMethod("hodgepodge$flushWorldData", CallbackInfo.class);
+        flush.setAccessible(true);
+        Object command = new MixinCommandSaveAll_WorldDataSave();
+        NBTTagCompound data = new NBTTagCompound();
+        data.setString("value", "saved");
+        Path file = temporary.resolve("data.dat");
+        try {
+            WorldDataSaver.INSTANCE.saveData(file.toFile(), data, false, false);
+            flush.invoke(command, new Object[] { null });
+            assertEquals("saved", CompressedStreamTools.read(file.toFile()).getString("value"));
+            Path blocked = Files.createDirectory(temporary.resolve("blocked"));
+            Files.write(blocked.resolve("keep"), new byte[] { 1 });
+            WorldDataSaver.INSTANCE.saveData(blocked.toFile(), data, false, false);
+            InvocationTargetException failure = assertThrows(
+                    InvocationTargetException.class,
+                    () -> flush.invoke(command, new Object[] { null }));
+            assertInstanceOf(CommandException.class, failure.getCause());
+        } finally {
+            WorldDataSaver.INSTANCE.closeSession();
+        }
+    }
+}

--- a/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
@@ -41,6 +41,13 @@ class WorldDataSaverTest {
         Files.setPosixFilePermissions(target, permissions);
         WorldDataSaver.writeData(target.toFile(), tag("replacement"), false, false);
         assertEquals(permissions, Files.getPosixFilePermissions(target));
+
+        java.util.Set<java.nio.file.attribute.PosixFilePermission> readOnlyOwner = java.nio.file.attribute.PosixFilePermissions
+                .fromString("r--rw-rw-");
+        Files.setPosixFilePermissions(target, readOnlyOwner);
+        WorldDataSaver.writeData(target.toFile(), tag("read-only-owner"), false, false);
+        assertEquals(readOnlyOwner, Files.getPosixFilePermissions(target));
+        assertEquals("read-only-owner", CompressedStreamTools.read(target.toFile()).getString("value"));
     }
 
     @Test

--- a/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
@@ -1,0 +1,125 @@
+package com.mitchej123.hodgepodge.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.storage.IThreadedFileIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class WorldDataSaverTest {
+
+    @TempDir
+    Path temporary;
+
+    @Test
+    void saveQueuedDuringRemovalGetsANewDrainTask() throws Exception {
+        TestSaver saver = new TestSaver();
+        File file = temporary.resolve("data.dat").toFile();
+        saver.saveData(file, tag("first"), false, false);
+        IThreadedFileIO first = saver.tasks.get(0);
+        assertTrue(first.writeNextIO());
+        assertFalse(first.writeNextIO());
+
+        saver.saveData(file, tag("second"), false, false);
+        saver.tasks.remove(first);
+
+        assertEquals(1, saver.tasks.size());
+        assertNotSame(first, saver.tasks.get(0));
+        assertTrue(saver.tasks.get(0).writeNextIO());
+        assertEquals("second", CompressedStreamTools.read(file).getString("value"));
+    }
+
+    @Test
+    void pendingWritesForTheSameFileKeepTheLatestSnapshot() throws Exception {
+        TestSaver saver = new TestSaver();
+        File file = temporary.resolve("data.dat").toFile();
+        saver.saveData(file, tag("first"), false, false);
+        saver.saveData(file, tag("second"), false, false);
+
+        assertEquals(1, saver.tasks.size());
+        assertTrue(saver.tasks.get(0).writeNextIO());
+        assertEquals("second", CompressedStreamTools.read(file).getString("value"));
+    }
+
+    @Test
+    void failedSerializationPreservesTheExistingFile() throws Exception {
+        File file = temporary.resolve("data.dat").toFile();
+        byte[] original = "original".getBytes(StandardCharsets.UTF_8);
+        Files.write(file.toPath(), original);
+
+        assertThrows(NullPointerException.class, () -> WorldDataSaver.writeData(file, null, true, false));
+        assertArrayEquals(original, Files.readAllBytes(file.toPath()));
+    }
+
+    @Test
+    void failedWriteIsRetriedOnTheNextSaveEvent() throws Exception {
+        TestSaver saver = new TestSaver();
+        Path target = Files.createDirectory(temporary.resolve("blocked.dat"));
+        Path blocker = Files.write(target.resolve("keep"), new byte[] { 1 });
+        saver.saveData(target.toFile(), tag("retried"), false, false);
+        IThreadedFileIO first = saver.tasks.get(0);
+        assertTrue(first.writeNextIO());
+        assertFalse(first.writeNextIO());
+        saver.tasks.remove(first);
+
+        Files.delete(blocker);
+        Files.delete(target);
+        File trigger = temporary.resolve("trigger.dat").toFile();
+        saver.saveData(trigger, tag("trigger"), false, false);
+
+        IThreadedFileIO retry = saver.tasks.get(0);
+        assertTrue(retry.writeNextIO());
+        assertEquals("retried", CompressedStreamTools.read(target.toFile()).getString("value"));
+        assertTrue(retry.writeNextIO());
+        assertEquals("trigger", CompressedStreamTools.read(trigger).getString("value"));
+    }
+
+    @Test
+    void backupWriteReplacesTheFileAndKeepsItsPreviousVersion() throws Exception {
+        File file = temporary.resolve("level.dat").toFile();
+        WorldDataSaver.writeData(file, tag("first"), true, false);
+        WorldDataSaver.writeData(file, tag("second"), true, true);
+
+        assertEquals("second", readCompressed(file).getString("value"));
+        assertEquals("first", readCompressed(temporary.resolve("level.dat_old").toFile()).getString("value"));
+    }
+
+    private static NBTTagCompound readCompressed(File file) throws IOException {
+        try (InputStream input = Files.newInputStream(file.toPath())) {
+            return CompressedStreamTools.readCompressed(input);
+        }
+    }
+
+    private static NBTTagCompound tag(String value) {
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setString("value", value);
+        return tag;
+    }
+
+    private static class TestSaver extends WorldDataSaver {
+
+        final List<IThreadedFileIO> tasks = new ArrayList<>();
+
+        @Override
+        protected void queueIO(IThreadedFileIO task) {
+            if (!tasks.contains(task)) tasks.add(task);
+        }
+    }
+}

--- a/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
@@ -107,6 +107,34 @@ class WorldDataSaverTest {
         }
     }
 
+    @Test
+    void closedSessionCannotOverwriteARestoredFile() throws Exception {
+        TestSaver saver = new TestSaver();
+        Path target = Files.createDirectory(temporary.resolve("map.dat"));
+        Path blocker = Files.write(target.resolve("keep"), new byte[] { 1 });
+        saver.saveData(target.toFile(), tag("old-session"), false, false);
+        saver.closeSession();
+        Files.delete(blocker);
+        Files.delete(target);
+        WorldDataSaver.writeData(target.toFile(), tag("restored"), false, false);
+        saver.saveData(temporary.resolve("other-world.dat").toFile(), tag("new-session"), false, false);
+        saver.flush();
+        assertEquals("restored", CompressedStreamTools.read(target.toFile()).getString("value"));
+    }
+
+    @Test
+    void flushDrainsPendingWritesAndReportsFailures() throws Exception {
+        TestSaver saver = new TestSaver();
+        File saved = temporary.resolve("saved.dat").toFile();
+        saver.saveData(saved, tag("saved"), false, false);
+        saver.flush();
+        assertEquals("saved", CompressedStreamTools.read(saved).getString("value"));
+        Path blocked = Files.createDirectory(temporary.resolve("blocked"));
+        Files.write(blocked.resolve("keep"), new byte[] { 1 });
+        saver.saveData(blocked.toFile(), tag("failed"), false, false);
+        assertThrows(IOException.class, saver::flush);
+    }
+
     private static NBTTagCompound tag(String value) {
         NBTTagCompound tag = new NBTTagCompound();
         tag.setString("value", value);
@@ -120,6 +148,14 @@ class WorldDataSaverTest {
         @Override
         protected void queueIO(IThreadedFileIO task) {
             if (!tasks.contains(task)) tasks.add(task);
+        }
+
+        @Override
+        protected void awaitIO() {
+            for (IThreadedFileIO task : new ArrayList<>(tasks)) {
+                while (task.writeNextIO()) {}
+                tasks.remove(task);
+            }
         }
     }
 }

--- a/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
@@ -29,6 +29,17 @@ class WorldDataSaverTest {
     Path temporary;
 
     @Test
+    void replacementPreservesPosixPermissions() throws Exception {
+        Path target = Files.createFile(temporary.resolve("permissions.dat"));
+        org.junit.jupiter.api.Assumptions.assumeTrue(Files.getFileStore(target).supportsFileAttributeView("posix"));
+        java.util.Set<java.nio.file.attribute.PosixFilePermission> permissions = java.nio.file.attribute.PosixFilePermissions
+                .fromString("rw-rw----");
+        Files.setPosixFilePermissions(target, permissions);
+        WorldDataSaver.writeData(target.toFile(), tag("replacement"), false, false);
+        assertEquals(permissions, Files.getPosixFilePermissions(target));
+    }
+
+    @Test
     void saveQueuedDuringRemovalGetsANewDrainTask() throws Exception {
         TestSaver saver = new TestSaver();
         File file = temporary.resolve("data.dat").toFile();

--- a/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
@@ -15,10 +15,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.storage.IThreadedFileIO;
+import net.minecraft.world.storage.ThreadedFileIOBase;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,6 +52,67 @@ class WorldDataSaverTest {
         WorldDataSaver.writeData(target.toFile(), tag("read-only-owner"), false, false);
         assertEquals(readOnlyOwner, Files.getPosixFilePermissions(target));
         assertEquals("read-only-owner", CompressedStreamTools.read(target.toFile()).getString("value"));
+    }
+
+    @Test
+    void backupReplacementFailureKeepsTheTargetAndClearsTemporaries() throws Exception {
+        Path directory = Files.createDirectory(temporary.resolve("backup-failure"));
+        Path target = directory.resolve("data.dat");
+        CompressedStreamTools.write(tag("original"), target.toFile());
+        Path blocked = Files.createDirectory(directory.resolve("data.dat_old"));
+        Files.write(blocked.resolve("keep"), new byte[] { 1 });
+
+        assertThrows(
+                IOException.class,
+                () -> WorldDataSaver.writeData(target.toFile(), tag("replacement"), false, true));
+        assertEquals("original", CompressedStreamTools.read(target.toFile()).getString("value"));
+        try (java.util.stream.Stream<Path> leftovers = Files.list(directory)) {
+            assertFalse(leftovers.anyMatch(path -> path.getFileName().toString().endsWith(".tmp")));
+        }
+    }
+
+    @Test
+    void flushWaitsForQueuedWorkToFinish() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        ThreadedFileIOBase.threadedIOInstance.queueIO(new IThreadedFileIO() {
+
+            private boolean done;
+
+            @Override
+            public boolean writeNextIO() {
+                if (done) return false;
+                started.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                done = true;
+                return true;
+            }
+        });
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+
+        AtomicBoolean returned = new AtomicBoolean();
+        CountDownLatch flushing = new CountDownLatch(1);
+        Thread flusher = new Thread(() -> {
+            flushing.countDown();
+            try {
+                WorldDataSaver.INSTANCE.flush();
+                returned.set(true);
+            } catch (Exception ignored) {}
+        });
+        flusher.start();
+        try {
+            assertTrue(flushing.await(5, TimeUnit.SECONDS));
+            flusher.join(200);
+            assertTrue(flusher.isAlive(), "flush returned while work was still queued");
+        } finally {
+            release.countDown();
+        }
+        flusher.join(TimeUnit.SECONDS.toMillis(5));
+        assertTrue(returned.get());
     }
 
     @Test

--- a/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
+++ b/src/test/java/com/mitchej123/hodgepodge/util/WorldDataSaverTest.java
@@ -32,6 +32,10 @@ class WorldDataSaverTest {
     void replacementPreservesPosixPermissions() throws Exception {
         Path target = Files.createFile(temporary.resolve("permissions.dat"));
         org.junit.jupiter.api.Assumptions.assumeTrue(Files.getFileStore(target).supportsFileAttributeView("posix"));
+        Path reference = Files.createFile(temporary.resolve("ordinary-new-file"));
+        Path newTarget = temporary.resolve("new-save.dat");
+        WorldDataSaver.writeData(newTarget.toFile(), tag("new"), false, false);
+        assertEquals(Files.getPosixFilePermissions(reference), Files.getPosixFilePermissions(newTarget));
         java.util.Set<java.nio.file.attribute.PosixFilePermission> permissions = java.nio.file.attribute.PosixFilePermissions
                 .fromString("rw-rw----");
         Files.setPosixFilePermissions(target, permissions);

--- a/src/test/java/hodgepodge/ChunkWriteConcurrencyTest.java
+++ b/src/test/java/hodgepodge/ChunkWriteConcurrencyTest.java
@@ -1,0 +1,67 @@
+package hodgepodge;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.junit.jupiter.api.Test;
+
+import com.mitchej123.hodgepodge.mixins.early.minecraft.MixinAnvilChunkLoader_FastChunkWrite;
+
+class ChunkWriteConcurrencyTest {
+
+    @Test
+    void concurrentWritesPreserveNbtAcrossBufferResizes() throws Exception {
+        Object writer = new MixinAnvilChunkLoader_FastChunkWrite();
+        Method write = writer.getClass()
+                .getDeclaredMethod("hodgepodge$batchedNBTWrite", NBTTagCompound.class, DataOutput.class);
+        write.setAccessible(true);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            Future<?>[] workers = new Future<?>[2];
+            for (int worker = 0; worker < workers.length; worker++) {
+                final int id = worker;
+                workers[worker] = executor.submit(() -> {
+                    NBTTagCompound small = new NBTTagCompound();
+                    small.setString("mOwnerUuid", "00000000-0000-0000-0000-00000000000" + id);
+                    NBTTagCompound large = (NBTTagCompound) small.copy();
+                    large.setByteArray("payload", new byte[65536]);
+                    byte[][] expected = new byte[2][];
+                    NBTTagCompound[] tags = { small, large };
+                    for (int i = 0; i < tags.length; i++) {
+                        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                        CompressedStreamTools.write(tags[i], new DataOutputStream(bytes));
+                        expected[i] = bytes.toByteArray();
+                    }
+                    start.await();
+                    for (int i = 0; i < 4096; i++) {
+                        int size = i % 512 == 0 ? 1 : 0;
+                        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                        write.invoke(writer, tags[size], new DataOutputStream(bytes));
+                        assertArrayEquals(expected[size], bytes.toByteArray(), "worker " + id + ", write " + i);
+                    }
+                    return null;
+                });
+            }
+            start.countDown();
+            for (Future<?> worker : workers) {
+                worker.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/test/java/hodgepodge/ChunkWriteConcurrencyTest.java
+++ b/src/test/java/hodgepodge/ChunkWriteConcurrencyTest.java
@@ -1,10 +1,12 @@
 package hodgepodge;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -64,4 +66,57 @@ class ChunkWriteConcurrencyTest {
             executor.awaitTermination(30, TimeUnit.SECONDS);
         }
     }
+
+    @Test
+    void blockedOutputDoesNotBlockSerializationOrChangeItsSnapshot() throws Exception {
+        Object writer = new MixinAnvilChunkLoader_FastChunkWrite();
+        Method write = writer.getClass()
+                .getDeclaredMethod("hodgepodge$batchedNBTWrite", NBTTagCompound.class, DataOutput.class);
+        write.setAccessible(true);
+        NBTTagCompound first = new NBTTagCompound();
+        first.setString("mOwnerUuid", "first");
+        NBTTagCompound second = new NBTTagCompound();
+        second.setString("mOwnerUuid", "second");
+        ByteArrayOutputStream expected = new ByteArrayOutputStream();
+        CompressedStreamTools.write(first, new DataOutputStream(expected));
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        CountDownLatch outputStarted = new CountDownLatch(1);
+        CountDownLatch releaseOutput = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> firstWrite = executor.submit(() -> {
+                write.invoke(writer, first, new DataOutputStream(actual) {
+
+                    @Override
+                    public void write(byte[] bytes) throws IOException {
+                        outputStarted.countDown();
+                        try {
+                            if (!releaseOutput.await(30, TimeUnit.SECONDS)) {
+                                throw new IOException("Timed out waiting to release output");
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IOException(e);
+                        }
+                        super.write(bytes);
+                    }
+                });
+                return null;
+            });
+            assertTrue(outputStarted.await(10, TimeUnit.SECONDS));
+            Future<?> secondWrite = executor.submit(() -> {
+                write.invoke(writer, second, new DataOutputStream(new ByteArrayOutputStream()));
+                return null;
+            });
+            secondWrite.get(10, TimeUnit.SECONDS);
+            releaseOutput.countDown();
+            firstWrite.get(10, TimeUnit.SECONDS);
+            assertArrayEquals(expected.toByteArray(), actual.toByteArray());
+        } finally {
+            releaseOutput.countDown();
+            executor.shutdownNow();
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+
 }

--- a/src/test/java/hodgepodge/LoginSessionLifecycleTest.java
+++ b/src/test/java/hodgepodge/LoginSessionLifecycleTest.java
@@ -277,7 +277,7 @@ class LoginSessionLifecycleTest {
                         net.minecraft.nbt.CompressedStreamTools.read(blocked.toFile()).getString("value"));
             } finally {
                 saver.closeSession();
-                java.nio.file.Files.deleteIfExists(blocker);
+                if (java.nio.file.Files.isDirectory(blocked)) java.nio.file.Files.deleteIfExists(blocker);
                 java.nio.file.Files.deleteIfExists(blocked);
                 java.nio.file.Files.deleteIfExists(file);
                 java.nio.file.Files.delete(root);

--- a/src/test/java/hodgepodge/LoginSessionLifecycleTest.java
+++ b/src/test/java/hodgepodge/LoginSessionLifecycleTest.java
@@ -126,6 +126,7 @@ class LoginSessionLifecycleTest {
         MixinBootstrap.init();
         MixinExtrasBootstrap.init();
         Mixins.addConfiguration("mixins.hodgepodge.login-test.json");
+        Mixins.addConfiguration("mixins.hodgepodge.world-save-test.json");
         Method phase = MixinEnvironment.class.getDeclaredMethod("gotoPhase", MixinEnvironment.Phase.class);
         phase.setAccessible(true);
         phase.invoke(null, MixinEnvironment.Phase.DEFAULT);
@@ -235,6 +236,52 @@ class LoginSessionLifecycleTest {
             if (serverLookup != null) serverLookup.close();
             if (fmlLookup != null) fmlLookup.close();
             if (loaderLookup != null) loaderLookup.close();
+        }
+
+        public void testWorldDataFlushAndCrashShutdown() throws Exception {
+            java.nio.file.Path root = java.nio.file.Files.createTempDirectory("hodgepodge-world-save-");
+            java.nio.file.Path file = root.resolve("data.dat");
+            java.nio.file.Path blocked = root.resolve("map.dat");
+            java.nio.file.Path blocker = blocked.resolve("keep");
+            com.mitchej123.hodgepodge.util.WorldDataSaver saver = com.mitchej123.hodgepodge.util.WorldDataSaver.INSTANCE;
+            net.minecraft.nbt.NBTTagCompound data = new net.minecraft.nbt.NBTTagCompound();
+            data.setString("value", "saved");
+            server.worldServers = new WorldServer[] { world };
+            try {
+                saver.saveData(file.toFile(), data, false, false);
+                new net.minecraft.command.server.CommandSaveAll()
+                        .processCommand(mock(net.minecraft.command.ICommandSender.class), new String[] { "flush" });
+                assertEquals("saved", net.minecraft.nbt.CompressedStreamTools.read(file.toFile()).getString("value"));
+
+                java.nio.file.Files.createDirectory(blocked);
+                java.nio.file.Files.write(blocker, new byte[] { 1 });
+                saver.saveData(blocked.toFile(), data, false, false);
+                assertThrows(
+                        net.minecraft.command.CommandException.class,
+                        () -> new net.minecraft.command.server.CommandSaveAll().processCommand(
+                                mock(net.minecraft.command.ICommandSender.class),
+                                new String[] { "flush" }));
+                org.mockito.Mockito.doThrow(new IllegalStateException("injected shutdown failure")).when(server)
+                        .stopServer();
+                doCallRealMethod().when(server).run();
+                server.run();
+                java.nio.file.Files.delete(blocker);
+                java.nio.file.Files.delete(blocked);
+                net.minecraft.nbt.NBTTagCompound restored = new net.minecraft.nbt.NBTTagCompound();
+                restored.setString("value", "restored");
+                net.minecraft.nbt.CompressedStreamTools.write(restored, blocked.toFile());
+                saver.saveData(file.toFile(), data, false, false);
+                saver.flush();
+                assertEquals(
+                        "restored",
+                        net.minecraft.nbt.CompressedStreamTools.read(blocked.toFile()).getString("value"));
+            } finally {
+                saver.closeSession();
+                java.nio.file.Files.deleteIfExists(blocker);
+                java.nio.file.Files.deleteIfExists(blocked);
+                java.nio.file.Files.deleteIfExists(file);
+                java.nio.file.Files.delete(root);
+            }
         }
 
         @SubscribeEvent

--- a/src/test/resources/mixins.hodgepodge.world-save-test.json
+++ b/src/test/resources/mixins.hodgepodge.world-save-test.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8.3-GTNH",
+  "package": "com.mitchej123.hodgepodge.mixins.early.minecraft",
+  "target": "@env(DEFAULT)",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MixinMinecraftServer_WorldDataSave",
+    "MixinCommandSaveAll_WorldDataSave"
+  ]
+}


### PR DESCRIPTION
## Summary
Fixes GTNewHorizons/GT-New-Horizons-Modpack/issues/25520

Fixes a race between background chunk saving and /save-all that could corrupt world data.
Second commit attempt to keep the fix while keeping the compression part out of the synchronized to try to minimize locks.

Adds some (AI generated) regression tests to try to avoid hitting this again since saving and backups is quite sensitive.

## External backup scripts

Plain `/save-all` still requests a save without guaranteeing that pending writes have completed. External backup scripts must use `/save-all flush` and wait for successful command completion before copying, in the sequence `/save-off` → `/save-all flush` → copy → `/save-on`. Restore saving even if the copy fails, and do not start copying if the flush reports a failure.

This PR fixes the concurrent serialization race and makes the explicit flush also drain Hodgepodge's asynchronous world-data saves. It does not turn plain `/save-all` into a flush, or guarantee that every mod's files remain frozen throughout an external copy. A broader external-backup coordination mechanism is separate work.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)

