### PR TITLE
Add a packetstats command

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
+++ b/src/main/java/com/mitchej123/hodgepodge/client/HodgepodgeClient.java
@@ -14,6 +14,7 @@ import com.mitchej123.hodgepodge.client.handlers.ClientKeyListener;
 import com.mitchej123.hodgepodge.client.handlers.ReloadSoundsGui;
 import com.mitchej123.hodgepodge.commands.AllocationsCommand;
 import com.mitchej123.hodgepodge.commands.DumpTextureAtlasCommand;
+import com.mitchej123.hodgepodge.commands.PacketStatsCommand;
 import com.mitchej123.hodgepodge.config.DebugConfig;
 import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.SoundConfig;
@@ -68,6 +69,7 @@ public class HodgepodgeClient {
 
         ClientCommandHandler.instance.registerCommand(new AllocationsCommand());
         ClientCommandHandler.instance.registerCommand(new DumpTextureAtlasCommand());
+        ClientCommandHandler.instance.registerCommand(new PacketStatsCommand());
 
         FMLCommonHandler.instance().bus().register(new ClientKeyListener());
 

--- a/src/main/java/com/mitchej123/hodgepodge/commands/PacketStatsCommand.java
+++ b/src/main/java/com/mitchej123/hodgepodge/commands/PacketStatsCommand.java
@@ -1,0 +1,239 @@
+package com.mitchej123.hodgepodge.commands;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+
+import com.mitchej123.hodgepodge.Common;
+import com.mitchej123.hodgepodge.config.DebugConfig;
+import com.mitchej123.hodgepodge.core.HodgepodgeCore;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.common.network.internal.FMLProxyPacket;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+
+public final class PacketStatsCommand extends CommandBase {
+
+    private static final int DEFAULT_TICKS = 200;
+    private static final int MAX_TICKS = 12000;
+    private static final int TOP_COUNT = 10;
+
+    private static volatile boolean trackingIncoming;
+    private static final LongAdder incomingTotal = new LongAdder();
+    private static final ConcurrentHashMap<String, LongAdder> incomingByType = new ConcurrentHashMap<>();
+
+    private static final Comparator<Object2LongMap.Entry<String>> PACKET_ORDER = Collections
+            .reverseOrder(Comparator.comparingLong(Object2LongMap.Entry::getLongValue));
+
+    private boolean measuring;
+    private int ticksRemaining;
+    private int measuredTicks;
+
+    private static Field RECEIVED_PACKETS_QUEUE_FIELD;
+
+    static {
+        try {
+            String fieldName = HodgepodgeCore.isObf() ? "field_150748_i" : "receivedPacketsQueue";
+            RECEIVED_PACKETS_QUEUE_FIELD = NetworkManager.class.getDeclaredField(fieldName);
+            RECEIVED_PACKETS_QUEUE_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            Common.log.error("Failed to get NetworkManager receivedPacketsQueue field", e);
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return "packetstats";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/packetstats <queue|incoming [ticks]>";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length < 1) throw new WrongUsageException(getCommandUsage(sender));
+
+        int ticks = switch (args[0]) {
+            case "queue" -> {
+                if (args.length != 1) throw new WrongUsageException(getCommandUsage(sender));
+                yield 0;
+            }
+            case "incoming" -> {
+                if (!DebugConfig.trackIncomingPackets) {
+                    throw new CommandException(
+                            "[PacketStats] Tracking incoming packets requires "
+                                    + "\"trackIncomingPackets\" to be enabled in the config.");
+                }
+                yield switch (args.length) {
+                    case 1 -> DEFAULT_TICKS;
+                    case 2 -> parseIntBounded(sender, args[1], 1, MAX_TICKS);
+                    default -> throw new WrongUsageException(getCommandUsage(sender));
+                };
+            }
+            default -> throw new WrongUsageException(getCommandUsage(sender));
+        };
+
+        Queue<Packet> queue = getReceiveQueue();
+        if (queue == null) throw new CommandException("[PacketStats] No active client connection");
+
+        // rerunning the command just restarts the measurement
+        if (!measuring) {
+            FMLCommonHandler.instance().bus().register(this);
+            measuring = true;
+        }
+
+        measuredTicks = ticks;
+        ticksRemaining = ticks;
+
+        if (measuredTicks != 0) {
+            trackingIncoming = false;
+            incomingTotal.reset();
+            incomingByType.clear();
+            trackingIncoming = true;
+
+            printChatMessage("[PacketStats] Analyzing incoming packets for " + ticks + " ticks.");
+        } else {
+            printChatMessage("[PacketStats] Analyzing queued packets");
+        }
+    }
+
+    public static void recordIncoming(Packet packet) {
+        if (!trackingIncoming) return;
+
+        incomingTotal.increment();
+        incomingByType.computeIfAbsent(packetName(packet), ignored -> new LongAdder()).increment();
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || !measuring) return;
+        if (--ticksRemaining > 0) return;
+
+        measuring = false;
+        trackingIncoming = false;
+
+        FMLCommonHandler.instance().bus().unregister(this);
+
+        Queue<Packet> queue = getReceiveQueue();
+        if (queue == null) {
+            printChatMessage(EnumChatFormatting.RED + "[PacketStats] Received packets queue closed.");
+            return;
+        }
+
+        if (measuredTicks != 0) {
+            printChatMessage(EnumChatFormatting.GOLD + "[PacketStats] Incoming packets - " + measuredTicks + " ticks");
+        } else {
+            printChatMessage(EnumChatFormatting.GOLD + "[PacketStats] Queued packets");
+        }
+
+        printChatMessage("Queue size: " + queue.size());
+
+        long entryCount;
+        List<Object2LongMap.Entry<String>> topEntries;
+        if (measuredTicks != 0) {
+            long total = incomingTotal.sum();
+            double avg = total / (double) measuredTicks;
+
+            printChatMessage("Incoming: " + format(avg) + "/t (" + total + " total)");
+
+            entryCount = total;
+            topEntries = incomingByType.entrySet().stream()
+                    .map(e -> Object2LongMap.entry(e.getKey(), e.getValue().sum())).sorted(PACKET_ORDER)
+                    .limit(TOP_COUNT).collect(Collectors.toList());
+        } else {
+            Object2LongMap<String> countsSnapshot = queue.stream().collect(
+                    Collectors.toMap(
+                            PacketStatsCommand::packetName,
+                            _packet -> 1L,
+                            Long::sum,
+                            Object2LongOpenHashMap::new));
+
+            entryCount = countsSnapshot.object2LongEntrySet().stream().mapToLong(Object2LongMap.Entry::getLongValue)
+                    .sum();
+            topEntries = countsSnapshot.object2LongEntrySet().stream().sorted(PACKET_ORDER).limit(TOP_COUNT)
+                    .collect(Collectors.toList());
+        }
+
+        printChatMessage(EnumChatFormatting.YELLOW + "Top packets:");
+
+        StringBuilder builder = new StringBuilder();
+        for (Object2LongMap.Entry<String> entry : topEntries) {
+            builder.setLength(0);
+
+            long count = entry.getLongValue();
+            double percentage = entryCount == 0 ? 0.0 : count * 100.0 / entryCount;
+
+            String perTick = measuredTicks != 0 ? "(" + format(count / (double) measuredTicks) + "/t)" : "";
+
+            builder.append(EnumChatFormatting.GRAY);
+            builder.append(String.format(Locale.ROOT, "%8d %10s %6.1f%%  ", count, perTick, percentage));
+            builder.append(EnumChatFormatting.WHITE).append(entry.getKey());
+
+            printChatMessage(builder.toString());
+        }
+
+        if (entryCount == 0) {
+            printChatMessage(EnumChatFormatting.GRAY + "  none");
+        }
+    }
+
+    private static String packetName(Packet packet) {
+        if (packet instanceof FMLProxyPacket fmlProxyPacket) {
+            String channel = fmlProxyPacket.channel();
+            return "FMLProxyPacket[" + (channel == null ? "???" : channel) + "]";
+        }
+
+        return packet.getClass().getSimpleName();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Queue<Packet> getReceiveQueue() {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.getNetHandler() == null) return null;
+        if (RECEIVED_PACKETS_QUEUE_FIELD == null) return null;
+
+        try {
+            NetworkManager manager = mc.getNetHandler().getNetworkManager();
+            return (Queue<Packet>) RECEIVED_PACKETS_QUEUE_FIELD.get(manager);
+        } catch (ReflectiveOperationException e) {
+            Common.log.error("Failed to access NetworkManager received packet queue", e);
+            return null;
+        }
+    }
+
+    private static String format(double value) {
+        return String.format(Locale.ROOT, "%.1f", value);
+    }
+
+    private static void printChatMessage(String message) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.ingameGUI == null) return;
+        mc.ingameGUI.getChatGUI().printChatMessage(new ChatComponentText(message));
+    }
+}

--- a/src/main/java/com/mitchej123/hodgepodge/config/DebugConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/DebugConfig.java
@@ -26,4 +26,9 @@ public class DebugConfig {
     @Config.DefaultBoolean(false)
     public static boolean showChunkGenDebug;
 
+    @Config.Comment({ "Track incoming client packets for /packetstats.",
+            "When disabled, /packetstats can still inspect the existing receive queue." })
+    @Config.RequiresMcRestart
+    @Config.DefaultBoolean(true)
+    public static boolean trackIncomingPackets;
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1214,6 +1214,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("minecraft.MixinAbstractResourcePack")
             .setApplyIf(() -> SpeedupsConfig.optimizeResourcePackPath)
             .setPhase(Phase.EARLY)),
+    TRACK_INCOMING_PACKETS(new MixinBuilder("Track incoming packets for /packetstats")
+            .addClientMixins("debug.MixinNetworkManager_TrackIncomingPackets")
+            .setApplyIf(() -> DebugConfig.trackIncomingPackets)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/debug/MixinNetworkManager_TrackIncomingPackets.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/debug/MixinNetworkManager_TrackIncomingPackets.java
@@ -1,0 +1,32 @@
+package com.mitchej123.hodgepodge.mixins.early.debug;
+
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.Packet;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mitchej123.hodgepodge.commands.PacketStatsCommand;
+
+import io.netty.channel.ChannelHandlerContext;
+
+@Mixin(NetworkManager.class)
+public class MixinNetworkManager_TrackIncomingPackets {
+
+    @Final
+    @Shadow
+    private boolean isClientSide;
+
+    @Inject(
+            method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/Packet;)V",
+            at = @At("HEAD"))
+    private void hodgepodge$trackIncomingPacket(ChannelHandlerContext ctx, Packet packet, CallbackInfo ci) {
+        if (isClientSide) {
+            PacketStatsCommand.recordIncoming(packet);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Adds /packetstats, a client side debug command to analyze queued/incoming packets.
Images:
<img width="653" height="256" alt="image" src="https://github.com/user-attachments/assets/53f6cea6-a333-4976-b853-c6f196a5a79e" />
<img width="649" height="273" alt="image" src="https://github.com/user-attachments/assets/38c84895-8cf0-4a94-ae9f-a410d9fca8ce" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
