### PR TITLE
Add option to limit received packet processing by time

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -297,6 +297,15 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean remove2MBChunkLimit;
 
+    @Config.Comment("Change the way received packet processing is limited from a count limit to a time limit")
+    @Config.DefaultBoolean(true)
+    public static boolean changeReceivedPacketCountLimitToTimeLimit;
+
+    @Config.Comment("Max time spent processing received packets in nanoseconds (1ms = 1_000_000ns)")
+    @Config.RangeInt(min = 1_000, max = 50_000_000)
+    @Config.DefaultInt(5_000_000)
+    public static int receivedPacketTimeLimit;
+
     @Config.Comment("Disable the creative search tab since it can be very laggy in large modpacks")
     @Config.DefaultBoolean(true)
     public static boolean removeCreativeSearchTab;

--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -297,7 +297,7 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean remove2MBChunkLimit;
 
-    @Config.Comment("Change the way received packet processing is limited from a count limit to a time limit")
+    @Config.Comment("Change incoming packet processing from a fixed 1001 packet limit to a time limit allowing for potentially more packets to be processed")
     @Config.DefaultBoolean(true)
     public static boolean changeReceivedPacketCountLimitToTimeLimit;
 

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -1218,6 +1218,10 @@ public enum Mixins implements IMixins {
             .addClientMixins("debug.MixinNetworkManager_TrackIncomingPackets")
             .setApplyIf(() -> DebugConfig.trackIncomingPackets)
             .setPhase(Phase.EARLY)),
+    CHANGE_RECEIVED_PACKET_COUNT_LIMIT_TO_TIME_LIMIT(new MixinBuilder("Change received packet count limit to time limit")
+            .addClientMixins("minecraft.packets.MixinNetworkManager_ReceivedProcessingLimit")
+            .setApplyIf(() -> FixesConfig.changeReceivedPacketCountLimitToTimeLimit)
+            .setPhase(Phase.EARLY)),
     // endregion
 
     // region Ic2 adjustments

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinNetworkManager_ReceivedProcessingLimit.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/early/minecraft/packets/MixinNetworkManager_ReceivedProcessingLimit.java
@@ -1,0 +1,47 @@
+package com.mitchej123.hodgepodge.mixins.early.minecraft.packets;
+
+import net.minecraft.network.NetworkManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalLongRef;
+import com.mitchej123.hodgepodge.config.FixesConfig;
+
+@Mixin(NetworkManager.class)
+public class MixinNetworkManager_ReceivedProcessingLimit {
+
+    @Unique
+    private static final int HODGEPODGE$TIME_CHECK_INTERVAL = 50;
+
+    @Definition(id = "i", local = @Local(type = int.class))
+    @Expression("i = @(1000)")
+    @ModifyExpressionValue(method = "processReceivedPackets", at = @At("MIXINEXTRAS:EXPRESSION"))
+    public int modifyLoopInit(int constant, @Share("startTime") LocalLongRef startTime) {
+        startTime.set(System.nanoTime());
+        return 0;
+    }
+
+    @Definition(id = "i", local = @Local(type = int.class))
+    @Expression("i >= 0")
+    @ModifyExpressionValue(method = "processReceivedPackets", at = @At("MIXINEXTRAS:EXPRESSION"))
+    public boolean redirectLoopCondition(boolean original, @Local(type = int.class) int i,
+            @Share("startTime") LocalLongRef startTime) {
+        if (i % HODGEPODGE$TIME_CHECK_INTERVAL != 0) return true;
+        long now = System.nanoTime();
+        return now - startTime.get() < FixesConfig.receivedPacketTimeLimit;
+    }
+
+    @Definition(id = "i", local = @Local(type = int.class))
+    @Expression("i = @(i + -1)")
+    @ModifyExpressionValue(method = "processReceivedPackets", at = @At("MIXINEXTRAS:EXPRESSION"))
+    public int switchLoopCounterDirection(int original) {
+        return original + 2;
+    }
+}


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Adds a config to change the hardcoded limit of 1001 received packets processed per tick to a max time spent limit.
The vanilla count limit is easily hit in cases of for example a lot of entities cramming. Processing those packets is very cheap, so a limit that low doesn't make sense, and the only thing it does is make the received packet queue grow, which for the user seems like an ever growing ping, even though mspt could be very low.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
