### PR TITLE
Mark the Bibliocraft Armor Stand as dirty when the inventory changes

### DIFF
--- a/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
+++ b/src/main/java/com/mitchej123/hodgepodge/config/FixesConfig.java
@@ -619,6 +619,12 @@ public class FixesConfig {
     @Config.DefaultBoolean(true)
     public static boolean fixBibliocraftArmorStandBreak;
 
+    @Config.Comment("""
+            Mark the Bibliocraft Armor Stand to save when its inventory is modified without going through its GUI (hoppers or shift-right-clicking),
+            preventing the items on the armor stand from rolling back on save (and potentially duplicating / voiding.)""")
+    @Config.DefaultBoolean(true)
+    public static boolean bibliocraftArmorStandMarkDirty;
+
     @Config.Comment("Fix Bibliocraft path sanitization")
     @Config.DefaultBoolean(true)
     public static boolean fixBibliocraftPathSanitization;

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/Mixins.java
@@ -2014,6 +2014,11 @@ public enum Mixins implements IMixins {
             .setApplyIf(() -> FixesConfig.fixBibliocraftArmorStandBreak)
             .addRequiredMod(TargetedMod.BIBLIOCRAFT)
             .setPhase(Phase.LATE)),
+    BIBLIOCRAFT_ARMOR_STAND_MARK_DIRTY(new MixinBuilder("Mark the Bibliocraft Armor Stand to save when its inventory is modified")
+            .addCommonMixins("bibliocraft.MixinTileEntityArmorStand_MarkDirty")
+            .setApplyIf(() -> FixesConfig.bibliocraftArmorStandMarkDirty)
+            .addRequiredMod(TargetedMod.BIBLIOCRAFT)
+            .setPhase(Phase.LATE)),
     BIBLIOCRAFT_PATH_SANITIZATION_FIX(new MixinBuilder("Path sanitization fix")
             .addCommonMixins("bibliocraft.MixinPathSanitization")
             .setApplyIf(() -> FixesConfig.fixBibliocraftPathSanitization)

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinTileEntityArmorStand_MarkDirty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinTileEntityArmorStand_MarkDirty.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import jds.bibliocraft.tileentities.TileEntityArmorStand;
 
@@ -15,6 +16,11 @@ public class MixinTileEntityArmorStand_MarkDirty extends TileEntity {
 
     @Inject(method = "setInventorySlotContents", at = @At("TAIL"))
     private void triggerMarkDirty(int slot, ItemStack stack, CallbackInfo ci) {
+        this.markDirty();
+    }
+
+    @Inject(method = "decrStackSize", at = @At("TAIL"))
+    private void triggerMarkDirty2(int slot, int amount, CallbackInfoReturnable<ItemStack> cir) {
         this.markDirty();
     }
 }

--- a/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinTileEntityArmorStand_MarkDirty.java
+++ b/src/main/java/com/mitchej123/hodgepodge/mixins/late/bibliocraft/MixinTileEntityArmorStand_MarkDirty.java
@@ -1,0 +1,20 @@
+package com.mitchej123.hodgepodge.mixins.late.bibliocraft;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import jds.bibliocraft.tileentities.TileEntityArmorStand;
+
+@Mixin(TileEntityArmorStand.class)
+public class MixinTileEntityArmorStand_MarkDirty extends TileEntity {
+
+    @Inject(method = "setInventorySlotContents", at = @At("TAIL"))
+    private void triggerMarkDirty(int slot, ItemStack stack, CallbackInfo ci) {
+        this.markDirty();
+    }
+}


### PR DESCRIPTION
## Summary
Bug fix - closes GTNewHorizons/Dupes-Exploits-GTNH#133. See issue for replication instructions.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack - irrelevant, Bibliocraft Armor Stands are unobtainable in full pack.
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
